### PR TITLE
Keep a log of actions users performed on translations during a translation event

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
   "core": "WordPress/WordPress#master",
-  "plugins": [ "GlotPress/GlotPress#local", "." ]
+  "plugins": [ "GlotPress/GlotPress#local", "." ],
+  "config": {
+    "SAVEQUERIES": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -9,4 +9,10 @@ Then you can run a local WordPress instance with the plugin installed:
 composer dev:start
 ```
 
+Once the environment is running, you must create the database tables needed by this plugin:
+
+```shell
+composer dev:db:schema
+```
+
 WordPress is now running at http://localhost:8888, user: `admin`, password: `password`.

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-2.0-only",
     "require": {},
     "scripts":{
-        "dev:start": "wp-env start && wp-env run cli wp rewrite structure '/%postname%/'"
+        "dev:start": "wp-env start && wp-env run cli wp rewrite structure '/%postname%/'",
+        "dev:db:schema": "wp-env run cli sh -c 'wp db query < /var/www/html/wp-content/plugins/wporg-gp-translation-events/schema.sql'"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {},
     "scripts":{
         "dev:start": "wp-env start && wp-env run cli wp rewrite structure '/%postname%/'",
+        "dev:debug": "wp-env start --xdebug",
         "dev:db:schema": "wp-env run cli sh -c 'wp db query < /var/www/html/wp-content/plugins/wporg-gp-translation-events/schema.sql'"
     }
 }

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -2,17 +2,18 @@
 
 class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTIONS_TABLE_NAME = 'wp_wporg_gp_translation_events_actions';
+	const ACTION_CREATED = 'created';
 
 	public function start(): void {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$this->handle_action( $translation );
+				$this->handle_action( $translation, self::ACTION_CREATED );
 			},
 		);
 	}
 
-	private function handle_action( GP_Translation $translation ): void {
+	private function handle_action( GP_Translation $translation, string $action ): void {
 		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
 		// Get events that are active now, for which the user is registered for.
@@ -20,14 +21,15 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$events        = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
 
 		foreach ( $events as $event ) {
-			$this->persist( $event, $translation, $now );
+			$this->persist( $event, $translation, $now, $action );
 		}
 	}
 
 	private function persist(
 		WP_Post $event,
 		GP_Translation $translation,
-		DateTime $happened_at
+		DateTime $happened_at,
+		string $action
 	): void {
 		/** @var GP_Translation_Set $translation_set */
 		$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
@@ -40,6 +42,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				'user_id'        => $translation->user_id,
 				'translation_id' => $translation->id,
 				'happened_at'    => $happened_at->format( 'Y-m-d H:i:s' ),
+				'action'         => $action,
 				'locale'         => $translation_set->locale,
 			]
 		);

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -3,16 +3,16 @@
 class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTION_TYPE_CREATED = 'created';
 
-	function start(): void {
+	public function start(): void {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$this->persist( $translation, self::ACTION_TYPE_CREATED );
+				$this->handle_action( $translation, self::ACTION_TYPE_CREATED );
 			},
 		);
 	}
 
-	private function persist( GP_Translation $translation, string $action_type ): void {
+	private function handle_action( GP_Translation $translation, string $action_type ): void {
 		// TODO.
 	}
 }

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -27,10 +27,10 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	private function persist(
 		WP_Post $event,
 		GP_Translation $translation,
-		DateTime $occurred_at
+		DateTime $created_at
 	): void {
 		/** @var GP_Translation_Set $translation_set */
-		$translation_set = (new GP_Translation_Set)->find_one( [ 'id' => $translation->translation_set_id ] );
+		$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
 
 		global $wpdb;
 		$wpdb->insert(
@@ -39,7 +39,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				'event_id'       => $event->ID,
 				'user_id'        => $translation->user_id,
 				'translation_id' => $translation->id,
-				'occurred_at'    => $occurred_at->format('Y-m-d H:i:s'),
+				'created_at'     => $created_at->format( 'Y-m-d H:i:s' ),
 				'locale'         => $translation_set->locale,
 			]
 		);

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -35,15 +35,20 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
 
 		global $wpdb;
-		$wpdb->insert(
+
+		// A given user can only do one action of a given type on a specific translation.
+		// So we replace instead of insert, which will enforce the primary key.
+		$wpdb->replace(
 			self::ACTIONS_TABLE_NAME,
 			[
+				// start primary key
 				'event_id'       => $event->ID,
 				'user_id'        => $translation->user_id,
 				'translation_id' => $translation->id,
-				'happened_at'    => $happened_at->format( 'Y-m-d H:i:s' ),
 				'action'         => $action,
+				// end primary key
 				'locale'         => $translation_set->locale,
+				'happened_at'    => $happened_at->format( 'Y-m-d H:i:s' ),
 			]
 		);
 	}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -27,7 +27,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	private function persist(
 		WP_Post $event,
 		GP_Translation $translation,
-		DateTime $created_at
+		DateTime $happened_at
 	): void {
 		/** @var GP_Translation_Set $translation_set */
 		$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
@@ -39,7 +39,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				'event_id'       => $event->ID,
 				'user_id'        => $translation->user_id,
 				'translation_id' => $translation->id,
-				'created_at'     => $created_at->format( 'Y-m-d H:i:s' ),
+				'happened_at'    => $happened_at->format( 'Y-m-d H:i:s' ),
 				'locale'         => $translation_set->locale,
 			]
 		);

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -15,7 +15,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	private function handle_action( GP_Translation $translation, string $action_type ): void {
 		// Get events that are active now, for which the user is registered for.
 		$active_events = $this->get_active_events( new DateTime() );
-		$events = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
+		$events        = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
 
 		foreach ( $events as $event ) {
 			$this->persist( $translation, $event );
@@ -30,8 +30,26 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	 * @return WP_Post[]
 	 */
 	private function get_active_events( DateTime $at ): array {
-		// TODO.
-		return [];
+		return get_posts(
+			[
+				'post_type'   => 'event',
+				'post_status' => 'publish',
+				'meta_query'  => [
+					[
+						'key'     => '_event_start_date',
+						'value'   => $at->format( 'Y-m-d' ),
+						'compare' => '<=',
+						'type'    => 'DATETIME',
+					],
+					[
+						'key'     => '_event_end_date',
+						'value'   => $at->format( 'Y-m-d' ),
+						'compare' => '>=',
+						'type'    => 'DATETIME',
+					],
+				],
+			],
+		);
 	}
 
 	/**

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -2,18 +2,17 @@
 
 class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTIONS_TABLE_NAME = 'wp_wporg_gp_translation_events_actions';
-	const ACTION_TYPE_CREATED = 'created';
 
 	public function start(): void {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$this->handle_action( $translation, self::ACTION_TYPE_CREATED );
+				$this->handle_action( $translation );
 			},
 		);
 	}
 
-	private function handle_action( GP_Translation $translation, string $action_type ): void {
+	private function handle_action( GP_Translation $translation ): void {
 		$now = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
 		// Get events that are active now, for which the user is registered for.
@@ -21,15 +20,14 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$events        = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
 
 		foreach ( $events as $event ) {
-			$this->persist( $event, $translation, $now, $action_type );
+			$this->persist( $event, $translation, $now );
 		}
 	}
 
 	private function persist(
 		WP_Post $event,
 		GP_Translation $translation,
-		DateTime $occurred_at,
-		string $action_type
+		DateTime $occurred_at
 	): void {
 		/** @var GP_Translation_Set $translation_set */
 		$translation_set = (new GP_Translation_Set)->find_one( [ 'id' => $translation->translation_set_id ] );
@@ -42,7 +40,6 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				'user_id'        => $translation->user_id,
 				'translation_id' => $translation->id,
 				'occurred_at'    => $occurred_at->format('Y-m-d H:i:s'),
-				'action_type'    => $action_type,
 				'locale'         => $translation_set->locale,
 			]
 		);

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -18,11 +18,11 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$events        = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
 
 		foreach ( $events as $event ) {
-			$this->persist( $translation, $event );
+			$this->persist( $translation, $event, $action_type );
 		}
 	}
 
-	private function persist( GP_Translation $translation, WP_Post $event ): void {
+	private function persist( GP_Translation $translation, WP_Post $event, string $action_type ): void {
 		// TODO.
 	}
 

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -1,0 +1,7 @@
+<?php
+
+class WPORG_GP_Translation_Events_Translation_Listener {
+	function start(): void {
+		// TODO
+	}
+}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -1,7 +1,18 @@
 <?php
 
 class WPORG_GP_Translation_Events_Translation_Listener {
+	const ACTION_TYPE_CREATED = 'created';
+
 	function start(): void {
-		// TODO
+		add_action(
+			'gp_translation_created',
+			function ( $translation ) {
+				$this->persist( $translation, self::ACTION_TYPE_CREATED );
+			},
+		);
+	}
+
+	private function persist( GP_Translation $translation, string $action_type ): void {
+		// TODO.
 	}
 }

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -13,6 +13,39 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	}
 
 	private function handle_action( GP_Translation $translation, string $action_type ): void {
+		// Get events that are active now, for which the user is registered for.
+		$active_events = $this->get_active_events( new DateTime() );
+		$events = $this->select_events_user_is_registered_for( $active_events, $translation->user_id );
+
+		foreach ( $events as $event ) {
+			$this->persist( $translation, $event );
+		}
+	}
+
+	private function persist( GP_Translation $translation, WP_Post $event ): void {
 		// TODO.
+	}
+
+	/**
+	 * @return WP_Post[]
+	 */
+	private function get_active_events( DateTime $at ): array {
+		// TODO.
+		return [];
+	}
+
+	/**
+	 * @param WP_Post[] $events
+	 *
+	 * @return WP_Post[]
+	 */
+	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
+		return array_filter(
+			$events,
+			function ( $event ) {
+				// TODO.
+				return true;
+			}
+		);
 	}
 }

--- a/schema.sql
+++ b/schema.sql
@@ -13,12 +13,3 @@ create or replace table wp_wporg_gp_translation_events_actions
     primary key (event_id, translation_id, user_id, action)
 )
     comment 'Tracks translation actions that happened during a translation event';
-
-create index wp_wporg_gp_translation_events_actions_event_id_index
-    on wp_wporg_gp_translation_events_actions (event_id);
-
-create index wp_wporg_gp_translation_events_actions_happened_at_index
-    on wp_wporg_gp_translation_events_actions (happened_at);
-
-create index wp_wporg_gp_translation_events_actions_user_id_index
-    on wp_wporg_gp_translation_events_actions (user_id);

--- a/schema.sql
+++ b/schema.sql
@@ -4,6 +4,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     user_id        int(10)     not null comment 'ID of the user who authored the translation',
     translation_id int(10)     not null comment 'ID of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
+    action         varchar(16) not null comment 'The action that happened (created, rejected, etc)',
     locale         varchar(10) not null comment 'Locale of the translation'
 )
     comment 'Tracks translations that were created during a translation event';

--- a/schema.sql
+++ b/schema.sql
@@ -9,10 +9,10 @@ create or replace table wp_wporg_gp_translation_events_actions
     comment 'Tracks translations that were created during a translation event';
 
 create index wp_wporg_gp_translation_events_actions_event_id_index
-    on wordpress.wp_wporg_gp_translation_events_actions (event_id);
+    on wp_wporg_gp_translation_events_actions (event_id);
 
 create index wp_wporg_gp_translation_events_actions_created_at_index
-    on wordpress.wp_wporg_gp_translation_events_actions (created_at);
+    on wp_wporg_gp_translation_events_actions (created_at);
 
 create index wp_wporg_gp_translation_events_actions_user_id_index
-    on wordpress.wp_wporg_gp_translation_events_actions (user_id);
+    on wp_wporg_gp_translation_events_actions (user_id);

--- a/schema.sql
+++ b/schema.sql
@@ -6,9 +6,9 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',
     user_id        int(10)     not null comment 'ID of the user who authored the translation',
-    happened_at    datetime    not null comment 'When the action happened, in UTC',
     action         varchar(16) not null comment 'The action that happened (created, rejected, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
+    happened_at    datetime    not null comment 'When the action happened, in UTC',
     # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.
     primary key (event_id, translation_id, user_id, action)
 )

--- a/schema.sql
+++ b/schema.sql
@@ -1,19 +1,18 @@
 create or replace table wp_wporg_gp_translation_events_actions
 (
     event_id       int(10)     not null comment 'ID of the event',
-    user_id        int(10)     not null comment 'ID of the user who authored/modified/deleted the translation',
+    user_id        int(10)     not null comment 'ID of the user who authored the translation',
     translation_id int(10)     not null comment 'ID of the translation',
     occurred_at    datetime    not null comment 'When the action occurred, in UTC',
-    action_type    varchar(16) not null comment 'The action that happened on the translation (created, modified, deleted, etc)',
     locale         varchar(10) not null comment 'Locale of the translation'
 )
-    comment 'Tracks actions (created, modified, deleted, etc) that happened during a translation event';
+    comment 'Tracks translations that were created during a translation event';
 
 create index wp_wporg_gp_translation_events_actions_event_id_index
-    on wp_wporg_gp_translation_events_actions (event_id);
-
-create index wp_wporg_gp_translation_events_actions_user_id_index
-    on wp_wporg_gp_translation_events_actions (user_id);
+    on wordpress.wp_wporg_gp_translation_events_actions (event_id);
 
 create index wp_wporg_gp_translation_events_actions_occurred_at_index
-    on wp_wporg_gp_translation_events_actions (occurred_at);
+    on wordpress.wp_wporg_gp_translation_events_actions (occurred_at);
+
+create index wp_wporg_gp_translation_events_actions_user_id_index
+    on wordpress.wp_wporg_gp_translation_events_actions (user_id);

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,19 @@
+create or replace table wp_wporg_gp_translation_events_actions
+(
+    event_id       int(10)     not null comment 'ID of the event',
+    user_id        int(10)     not null comment 'ID of the user who authored/modified/deleted the translation',
+    translation_id int(10)     not null comment 'ID of the translation',
+    occurred_at    datetime    not null comment 'When the action occurred, in UTC',
+    action_type    varchar(16) not null comment 'The action that happened on the translation (created, modified, deleted, etc)',
+    locale         varchar(10) not null comment 'Locale of the translation'
+)
+    comment 'Tracks actions (created, modified, deleted, etc) that happened during a translation event';
+
+create index wp_wporg_gp_translation_events_actions_event_id_index
+    on wp_wporg_gp_translation_events_actions (event_id);
+
+create index wp_wporg_gp_translation_events_actions_user_id_index
+    on wp_wporg_gp_translation_events_actions (user_id);
+
+create index wp_wporg_gp_translation_events_actions_occurred_at_index
+    on wp_wporg_gp_translation_events_actions (occurred_at);

--- a/schema.sql
+++ b/schema.sql
@@ -1,13 +1,18 @@
+# This file is only used in development environments, and to serve as documentation.
+# It is not used in production in any way.
+
 create or replace table wp_wporg_gp_translation_events_actions
 (
     event_id       int(10)     not null comment 'ID of the event',
-    user_id        int(10)     not null comment 'ID of the user who authored the translation',
     translation_id int(10)     not null comment 'ID of the translation',
+    user_id        int(10)     not null comment 'ID of the user who authored the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
     action         varchar(16) not null comment 'The action that happened (created, rejected, etc)',
-    locale         varchar(10) not null comment 'Locale of the translation'
+    locale         varchar(10) not null comment 'Locale of the translation',
+    # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.
+    primary key (event_id, translation_id, user_id, action)
 )
-    comment 'Tracks translations that were created during a translation event';
+    comment 'Tracks translation actions that happened during a translation event';
 
 create index wp_wporg_gp_translation_events_actions_event_id_index
     on wp_wporg_gp_translation_events_actions (event_id);

--- a/schema.sql
+++ b/schema.sql
@@ -3,7 +3,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     user_id        int(10)     not null comment 'ID of the user who authored the translation',
     translation_id int(10)     not null comment 'ID of the translation',
-    occurred_at    datetime    not null comment 'When the action occurred, in UTC',
+    created_at     datetime    not null comment 'When the translation was created, in UTC',
     locale         varchar(10) not null comment 'Locale of the translation'
 )
     comment 'Tracks translations that were created during a translation event';
@@ -11,8 +11,8 @@ create or replace table wp_wporg_gp_translation_events_actions
 create index wp_wporg_gp_translation_events_actions_event_id_index
     on wordpress.wp_wporg_gp_translation_events_actions (event_id);
 
-create index wp_wporg_gp_translation_events_actions_occurred_at_index
-    on wordpress.wp_wporg_gp_translation_events_actions (occurred_at);
+create index wp_wporg_gp_translation_events_actions_created_at_index
+    on wordpress.wp_wporg_gp_translation_events_actions (created_at);
 
 create index wp_wporg_gp_translation_events_actions_user_id_index
     on wordpress.wp_wporg_gp_translation_events_actions (user_id);

--- a/schema.sql
+++ b/schema.sql
@@ -5,8 +5,8 @@ create or replace table wp_wporg_gp_translation_events_actions
 (
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',
-    user_id        int(10)     not null comment 'ID of the user who authored the translation',
-    action         varchar(16) not null comment 'The action that happened (created, rejected, etc)',
+    user_id        int(10)     not null comment 'ID of the user who made the action',
+    action         varchar(16) not null comment 'The action that the user made (created, rejected, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
     # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.

--- a/schema.sql
+++ b/schema.sql
@@ -3,7 +3,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     user_id        int(10)     not null comment 'ID of the user who authored the translation',
     translation_id int(10)     not null comment 'ID of the translation',
-    created_at     datetime    not null comment 'When the translation was created, in UTC',
+    happened_at    datetime    not null comment 'When the action happened, in UTC',
     locale         varchar(10) not null comment 'Locale of the translation'
 )
     comment 'Tracks translations that were created during a translation event';
@@ -11,8 +11,8 @@ create or replace table wp_wporg_gp_translation_events_actions
 create index wp_wporg_gp_translation_events_actions_event_id_index
     on wp_wporg_gp_translation_events_actions (event_id);
 
-create index wp_wporg_gp_translation_events_actions_created_at_index
-    on wp_wporg_gp_translation_events_actions (created_at);
+create index wp_wporg_gp_translation_events_actions_happened_at_index
+    on wp_wporg_gp_translation_events_actions (happened_at);
 
 create index wp_wporg_gp_translation_events_actions_user_id_index
     on wp_wporg_gp_translation_events_actions (user_id);

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -188,7 +188,7 @@ add_action( 'init', 'register_event_post_type' );
 add_action( 'add_meta_boxes', 'event_meta_boxes' );
 add_action( 'save_post', 'save_event_meta_boxes' );
 
-if ( class_exists( GP::class ) ) {
+add_action( 'gp_init', function() {
 	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
 	GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
 	GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
@@ -197,4 +197,4 @@ if ( class_exists( GP::class ) ) {
 	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-translation-listener.php';
 	$wporg_gp_translation_events_listener = new WPORG_GP_Translation_Events_Translation_Listener();
 	$wporg_gp_translation_events_listener->start();
-}
+});

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -12,19 +12,6 @@
  * @package Translation Events
  */
 
-if ( class_exists( GP_Route::class ) ) {
-	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
-}
-
-function register_routes() {
-	if ( class_exists( GP_Route::class ) ) {
-		GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
-		GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
-		GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
-	}
-}
-
-
 /**
  * Register the event post type.
  */
@@ -200,4 +187,17 @@ add_action( 'wp_enqueue_scripts', 'register_translation_event_js' );
 add_action( 'init', 'register_event_post_type' );
 add_action( 'add_meta_boxes', 'event_meta_boxes' );
 add_action( 'save_post', 'save_event_meta_boxes' );
+
+if ( class_exists( GP_Route::class ) ) {
+	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
+}
+
+function register_routes() {
+	if ( class_exists( GP_Route::class ) ) {
+		GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
+		GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
+		GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
+	}
+}
+
 register_routes();

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -192,12 +192,8 @@ if ( class_exists( GP_Route::class ) ) {
 	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
 }
 
-function register_routes() {
-	if ( class_exists( GP_Route::class ) ) {
-		GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
-		GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
-		GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
-	}
+if ( class_exists( GP_Route::class ) ) {
+	GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
+	GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
+	GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
 }
-
-register_routes();

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -188,9 +188,13 @@ add_action( 'init', 'register_event_post_type' );
 add_action( 'add_meta_boxes', 'event_meta_boxes' );
 add_action( 'save_post', 'save_event_meta_boxes' );
 
-if ( class_exists( GP_Route::class ) ) {
+if ( class_exists( GP::class ) ) {
 	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
 	GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
 	GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
 	GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
+
+	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-translation-listener.php';
+	$wporg_gp_translation_events_listener = new WPORG_GP_Translation_Events_Translation_Listener();
+	$wporg_gp_translation_events_listener->start();
 }

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -190,9 +190,6 @@ add_action( 'save_post', 'save_event_meta_boxes' );
 
 if ( class_exists( GP_Route::class ) ) {
 	require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
-}
-
-if ( class_exists( GP_Route::class ) ) {
 	GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
 	GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
 	GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );


### PR DESCRIPTION
Fixes #7 

This PR adds a `wp_wporg_gp_translation_events_actions` table to the database, add adds entries to said table when new actions on translations happen in GlotPress (`created`, `rejected`, etc).

## Summary of changes

- Define database schema in `schema.sql`.
    - If you're using `wp-env`, you can apply the schema with `composer dev:db:schema`.
    - In production, the schema will need to be applied manually, the plugin does not apply it automatically.
- Create a translation _listener_, which "listens" to newly-created translations in GlotPress, and persists them into the `wp_wporg_gp_translation_events_actions` table.
    - An entry is created for each currently-ongoing event for which the user is registered for.

## TODO

- [x] What should happen to stored stats when the start or end datetimes of an event are edited?
- [x] Rename `created_at` to `happened_at`, so that it's not confusing because there will be different types of actions, and one of them is `created`
- [x] Add an `action` column
- [x] Add primary key for `event_id`, `translation_id`, `user_id`, `action`
- [x] Remove indexes (can be added back when/if needed)
- [x] Make sure that for a given event and translation, the user cannot do multiple actions of the same type

## Next steps

- https://github.com/WordPress/wporg-gp-translation-events/issues/16

## Screen captures
<img width="892" alt="Screenshot 2024-01-24 at 13 08 16" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/3878b373-9f41-4f80-a88d-b19c72b24bf8">

<img width="1031" alt="Screenshot 2024-01-24 at 13 07 35" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/22c08ae8-6909-4f74-94dc-fb3f34bd1c6d">
