### PR TITLE
Use datetime-local and store time zone

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -1,7 +1,9 @@
 ( function( $, $gp ) {
 jQuery(document).ready(function($) {
     $gp.notices.init();
-    selectUserTimezone();
+    if ( $('#create-event-form').length ) {
+        selectUserTimezone();
+    }
     validateEventDates();
     $('#submit-event, #edit-translation-event').on('click', function(e) {
         if ( $('#event-end').val() <= $('#event-start').val() ) {

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -4,7 +4,7 @@ jQuery(document).ready(function($) {
     selectUserTimezone();
     validateEventDates();
     $('#submit-event, #edit-translation-event').on('click', function(e) {
-        if ( $('#event-end-date').val() <= $('#event-start-date').val() ) {
+        if ( $('#event-end').val() <= $('#event-start').val() ) {
             $gp.notices.error( 'Event end date and time must be later than event start date and time.' );
             return;
         }
@@ -25,8 +25,8 @@ jQuery(document).ready(function($) {
     });
 
     function validateEventDates() {
-        var startDateTimeInput = $('#event-start-date');
-        var endDateTimeInput = $('#event-end-date');
+        var startDateTimeInput = $('#event-start');
+        var endDateTimeInput = $('#event-end');
     
         startDateTimeInput.add(endDateTimeInput).on('input', function () {
             endDateTimeInput.prop('min', startDateTimeInput.val());

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -1,6 +1,7 @@
 ( function( $, $gp ) {
 jQuery(document).ready(function($) {
     $gp.notices.init();
+    selectUserTimezone();
     validateEventDates();
     $('#submit-event, #edit-translation-event').on('click', function(e) {
         if ( $('#event-end-date').val() <= $('#event-start-date').val() ) {
@@ -33,6 +34,9 @@ jQuery(document).ready(function($) {
                 endDateTimeInput.val(startDateTimeInput.val());
             }
         });
+    }
+    function selectUserTimezone() {
+        document.querySelector(`#event-timezone option[value="${Intl.DateTimeFormat().resolvedOptions().timeZone}"]`).selected = true 
     }
 
 });

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -1,7 +1,13 @@
 ( function( $, $gp ) {
 jQuery(document).ready(function($) {
-    $gp.notices.init(),
+    $gp.notices.init();
+    validateEventDates();
     $('#submit-event, #edit-translation-event').on('click', function(e) {
+        if ( $('#event-end-date').val() <= $('#event-start-date').val() ) {
+            $gp.notices.error( 'Event end date and time must be later than event start date and time.' );
+            return;
+        }
+
         e.preventDefault();
         var $form = $('.translation-event-form');
         $.ajax({
@@ -16,6 +22,18 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+    function validateEventDates() {
+        var startDateTimeInput = $('#event-start-date');
+        var endDateTimeInput = $('#event-end-date');
+    
+        startDateTimeInput.add(endDateTimeInput).on('input', function () {
+            endDateTimeInput.prop('min', startDateTimeInput.val());
+            if (endDateTimeInput.val() < startDateTimeInput.val()) {
+                endDateTimeInput.val(startDateTimeInput.val());
+            }
+        });
+    }
 
 });
 }( jQuery, $gp )

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -57,8 +57,8 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 
 		$event_title        = $event->post_title;
 		$event_description  = $event->post_content;
-		$event_start_date   = get_post_meta( $event_id, '_event_start_date', true ) ?? '';
-		$event_end_date     = get_post_meta( $event_id, '_event_end_date', true ) ?? '';
+		$event_start        = get_post_meta( $event_id, '_event_start', true ) ?? '';
+		$event_end          = get_post_meta( $event_id, '_event_end', true ) ?? '';
 		$event_locale       = get_post_meta( $event_id, '_event_locale', true ) ?? '';
 		$event_project_name = get_post_meta( $event_id, '_event_project_name', true ) ?? '';
 		$event_timezone     = get_post_meta( $event_id, '_event_timezone', true ) ?? '';

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -61,6 +61,7 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		$event_end_date     = get_post_meta( $event_id, '_event_end_date', true ) ?? '';
 		$event_locale       = get_post_meta( $event_id, '_event_locale', true ) ?? '';
 		$event_project_name = get_post_meta( $event_id, '_event_project_name', true ) ?? '';
+		$event_timezone     = get_post_meta( $event_id, '_event_timezone', true ) ?? '';
 		$this->tmpl( 'events-edit', get_defined_vars() );
 	}
 

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -57,11 +57,11 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 
 		$event_title        = $event->post_title;
 		$event_description  = $event->post_content;
-		$event_start        = get_post_meta( $event_id, '_event_start', true ) ?? '';
-		$event_end          = get_post_meta( $event_id, '_event_end', true ) ?? '';
+		$event_timezone     = get_post_meta( $event_id, '_event_timezone', true ) ?? '';
+		$event_start        = self::convertToTimezone( get_post_meta( $event_id, '_event_start', true ), $event_timezone ) ?? '';
+		$event_end          = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone ) ?? '';
 		$event_locale       = get_post_meta( $event_id, '_event_locale', true ) ?? '';
 		$event_project_name = get_post_meta( $event_id, '_event_project_name', true ) ?? '';
-		$event_timezone     = get_post_meta( $event_id, '_event_timezone', true ) ?? '';
 		$this->tmpl( 'events-edit', get_defined_vars() );
 	}
 
@@ -87,5 +87,17 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		$event_locale       = get_post_meta( $event->ID, '_event_locale', true ) ?? '';
 		$event_project_name = get_post_meta( $event->ID, '_event_project_name', true ) ?? '';
 		$this->tmpl( 'event', get_defined_vars() );
+	}
+
+	/**
+	 * Convert date time stored in UTC to a date time in a time zone.
+	 *
+	 * @param string $date_time The date time in UTC.
+	 * @param string $time_zone The time zone.
+	 *
+	 * @return string The date time in the time zone.
+	 */
+	public static function convertToTimezone( $date_time, $time_zone ) {
+		return ( new DateTime( $date_time, new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $time_zone ) )->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/templates/events-create.php
+++ b/templates/events-create.php
@@ -3,7 +3,6 @@ gp_title( __( 'Translation Events - Create new event' ) );
 gp_tmpl_header();
 
 ?>
-
 <h2  class="event-page-title">Create a new Translation Event</h2>
 
 <form class="translation-event-form" action="" method="post">
@@ -20,11 +19,17 @@ gp_tmpl_header();
 	</div>
 	<div>
 		<label for="event-start-date">Start Date:</label>
-		<input type="datetime-local" id="event-start_date" name="event_start_date" required>
+		<input type="datetime-local" id="event-start-date" name="event_start_date" required>
 	</div>
 	<div>
 		<label for="event-end-date">End Date:</label>
 		<input type="datetime-local" id="event-end-date" name="event_end_date" required>
+	</div>
+	<div>
+		<label for="event-timezone">Event Timezone:</label>
+		<select id="event-timezone" name="event_timezone" required>
+			<?php echo esc_html( wp_timezone_choice( 'UTC', get_user_locale() ) ); ?>
+    	</select>
 	</div>
 	<div>
 		<label for="event-locale">Locale:</label>

--- a/templates/events-create.php
+++ b/templates/events-create.php
@@ -5,7 +5,7 @@ gp_tmpl_header();
 ?>
 <h2  class="event-page-title">Create a new Translation Event</h2>
 
-<form class="translation-event-form" action="" method="post">
+<form class="translation-event-form" id="create-event-form" action="" method="post">
 	<?php wp_nonce_field( 'create_event_nonce', 'create_event_nonce' ); ?>
 	<input type="hidden" name="action" value="submit_event_ajax">
 	<input type="hidden" name="form_name" value="create_event">

--- a/templates/events-create.php
+++ b/templates/events-create.php
@@ -18,12 +18,12 @@ gp_tmpl_header();
 		<textarea id="event-description" name="event_description" rows="4" required></textarea>
 	</div>
 	<div>
-		<label for="event-start-date">Start Date:</label>
-		<input type="datetime-local" id="event-start-date" name="event_start_date" required>
+		<label for="event-start">Start Date:</label>
+		<input type="datetime-local" id="event-start" name="event_start" required>
 	</div>
 	<div>
-		<label for="event-end-date">End Date:</label>
-		<input type="datetime-local" id="event-end-date" name="event_end_date" required>
+		<label for="event-end">End Date:</label>
+		<input type="datetime-local" id="event-end" name="event_end" required>
 	</div>
 	<div>
 		<label for="event-timezone">Event Timezone:</label>

--- a/templates/events-create.php
+++ b/templates/events-create.php
@@ -28,7 +28,7 @@ gp_tmpl_header();
 	<div>
 		<label for="event-timezone">Event Timezone:</label>
 		<select id="event-timezone" name="event_timezone" required>
-			<?php echo esc_html( wp_timezone_choice( 'UTC', get_user_locale() ) ); ?>
+			<?php echo wp_kses( wp_timezone_choice( 'UTC', get_user_locale() ), array( 'optgroup' => array('label' => array()), 'option' => array('value' => array() ) ) ); ?>
     	</select>
 	</div>
 	<div>

--- a/templates/events-create.php
+++ b/templates/events-create.php
@@ -20,11 +20,11 @@ gp_tmpl_header();
 	</div>
 	<div>
 		<label for="event-start-date">Start Date:</label>
-		<input type="date" id="event-start_date" name="event_start_date" required>
+		<input type="datetime-local" id="event-start_date" name="event_start_date" required>
 	</div>
 	<div>
 		<label for="event-end-date">End Date:</label>
-		<input type="date" id="event-end-date" name="event_end_date" required>
+		<input type="datetime-local" id="event-end-date" name="event_end_date" required>
 	</div>
 	<div>
 		<label for="event-locale">Locale:</label>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -20,11 +20,11 @@ gp_tmpl_header();
 	</div>
 	<div>
 		<label for="event-start-date">Start Date:</label>
-		<input type="date" id="event-start-date" name="event_start_date" value="<?php echo esc_attr( $event_start_date ); ?>" required>
+		<input type="datetime-local" id="event-start-date" name="event_start_date" value="<?php echo esc_attr( $event_start_date ); ?>" required>
 	</div>
 	<div>
 		<label for="event-end-date">End Date:</label>
-		<input type="date" id="event-end-date" name="event_end_date" value="<?php echo esc_attr( $event_end_date ); ?>" required>
+		<input type="datetime-local" id="event-end-date" name="event_end_date" value="<?php echo esc_attr( $event_end_date ); ?>" required>
 	</div>
 	<div>
 		<label for="event-locale">Locale:</label>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -34,11 +34,11 @@ gp_tmpl_header();
 	</div>
 	<div>
 		<label for="event-locale">Locale:</label>
-		<input type="text" id="event-locale" name="event_locale" value="<?php echo esc_attr( $event_locale ); ?>" required>
+		<input type="text" id="event-locale" name="event_locale" value="<?php echo esc_attr( $event_locale ); ?>">
 	</div>
 	<div>
 		<label for="event-project-name">Project Name:</label>
-		<input type="text" id="event-project-name" name="event_project_name" value="<?php echo esc_attr( $event_project_name ); ?>" required>
+		<input type="text" id="event-project-name" name="event_project_name" value="<?php echo esc_attr( $event_project_name ); ?>">
 	</div>
 	<button class="button is-primary" type="button" id="edit-translation-event">Submit Event</button>
 </form>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -29,8 +29,8 @@ gp_tmpl_header();
     <div>
 		<label for="event-timezone">Event Timezone:</label>
 		<select id="event-timezone" name="event_timezone"  required>
-			<?php echo esc_html( wp_timezone_choice( $event_timezone, get_user_locale() ) ); ?>
-    	</select>
+			<?php echo wp_kses( wp_timezone_choice( $event_timezone, get_user_locale() ), array( 'optgroup' => array('label' => array()), 'option' => array('value' => array() ) ) ); ?>
+        </select>
 	</div>
 	<div>
 		<label for="event-locale">Locale:</label>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -19,12 +19,12 @@ gp_tmpl_header();
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
 	</div>
 	<div>
-		<label for="event-start-date">Start Date:</label>
-		<input type="datetime-local" id="event-start-date" name="event_start_date" value="<?php echo esc_attr( $event_start_date ); ?>" required>
+		<label for="event-start">Start Date:</label>
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start ); ?>" required>
 	</div>
 	<div>
-		<label for="event-end-date">End Date:</label>
-		<input type="datetime-local" id="event-end-date" name="event_end_date" value="<?php echo esc_attr( $event_end_date ); ?>" required>
+		<label for="event-end">End Date:</label>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end ); ?>" required>
 	</div>
     <div>
 		<label for="event-timezone">Event Timezone:</label>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -26,6 +26,12 @@ gp_tmpl_header();
 		<label for="event-end-date">End Date:</label>
 		<input type="datetime-local" id="event-end-date" name="event_end_date" value="<?php echo esc_attr( $event_end_date ); ?>" required>
 	</div>
+    <div>
+		<label for="event-timezone">Event Timezone:</label>
+		<select id="event-timezone" name="event_timezone"  required>
+			<?php echo esc_html( wp_timezone_choice( $event_timezone, get_user_locale() ) ); ?>
+    	</select>
+	</div>
 	<div>
 		<label for="event-locale">Locale:</label>
 		<input type="text" id="event-locale" name="event_locale" value="<?php echo esc_attr( $event_locale ); ?>" required>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -29,7 +29,7 @@ gp_tmpl_header();
     <div>
 		<label for="event-timezone">Event Timezone:</label>
 		<select id="event-timezone" name="event_timezone"  required>
-			<?php echo wp_kses( wp_timezone_choice( $event_timezone, get_user_locale() ), array( 'optgroup' => array('label' => array()), 'option' => array('value' => array() ) ) ); ?>
+			<?php echo wp_kses( wp_timezone_choice( $event_timezone, get_user_locale() ), array( 'optgroup' => array('label' => array()), 'option' => array('value' => array(), 'selected' => array() ) ) ); ?>
         </select>
 	</div>
 	<div>

--- a/templates/events-edit.php
+++ b/templates/events-edit.php
@@ -5,7 +5,7 @@ gp_tmpl_header();
 ?>
 
 <h2  class="event-page-title">Edit Translation Event</h2>
-<form class="translation-event-form" action="" method="post">
+<form class="translation-event-form" id="edit-event-form" action="" method="post">
 	<?php wp_nonce_field( 'edit_event_nonce', 'edit_event_nonce' ); ?>
 	<input type="hidden" name="action" value="submit_event_ajax">
 	<input type="hidden" name="form_name" value="edit_event">

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -202,8 +202,8 @@ function submit_event_ajax() {
 			)
 		);
 	}
-	update_post_meta( $event_id, '_event_start', $event_start );
-	update_post_meta( $event_id, '_event_end', $event_end );
+	update_post_meta( $event_id, '_event_start', convert_to_UTC( $event_start, $event_timezone ) );
+	update_post_meta( $event_id, '_event_end', convert_to_UTC( $event_end, $event_timezone ) );
 	update_post_meta( $event_id, '_event_timezone', $event_timezone );
 	if ( $locale ) {
 		update_post_meta( $event_id, '_event_locale', $locale );
@@ -218,6 +218,19 @@ function submit_event_ajax() {
 add_action( 'wp_ajax_submit_event_ajax', 'submit_event_ajax' );
 add_action( 'wp_ajax_nopriv_submit_event_ajax', 'submit_event_ajax' );
 
+/**
+ * Convert a date time in a time zone to UTC.
+ *
+ * @param  string $date_time The date time in the time zone.
+ * @param  string $time_zone The time zone.
+ *
+ * @return string            The date time in UTC.
+ */
+function convert_to_UTC( $date_time, $time_zone ) {
+	$date_time = new DateTime( $date_time, new DateTimeZone( $time_zone ) );
+	$date_time->setTimezone( new DateTimeZone( 'UTC' ) );
+	return $date_time->format( 'Y-m-d H:i:s' );
+}
 
 function register_translation_event_js() {
 	wp_register_style( 'translation-events-css', plugins_url( 'assets/css/translation-events.css', __FILE__ ), array(), filemtime( __DIR__ . '/assets/css/translation-events.css' ) );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -147,12 +147,13 @@ function submit_event_ajax() {
 		}
 	}
 
-	$title        = sanitize_text_field( $_POST['event_title'] );
-	$description  = sanitize_text_field( $_POST['event_description'] );
-	$start_date   = sanitize_text_field( $_POST['event_start_date'] );
-	$end_date     = sanitize_text_field( $_POST['event_end_date'] );
-	$locale       = sanitize_text_field( $_POST['event_locale'] );
-	$project_name = sanitize_text_field( $_POST['event_project_name'] );
+	$title          = sanitize_text_field( $_POST['event_title'] );
+	$description    = sanitize_text_field( $_POST['event_description'] );
+	$start_date     = sanitize_text_field( $_POST['event_start_date'] );
+	$end_date       = sanitize_text_field( $_POST['event_end_date'] );
+	$locale         = sanitize_text_field( $_POST['event_locale'] );
+	$project_name   = sanitize_text_field( $_POST['event_project_name'] );
+	$event_timezone = sanitize_text_field( $_POST['event_timezone'] );
 
 	if ( 'create_event' === $_POST['form_name'] ) {
 		$event_id = wp_insert_post(
@@ -180,6 +181,7 @@ function submit_event_ajax() {
 	}
 	update_post_meta( $event_id, '_event_start_date', $start_date );
 	update_post_meta( $event_id, '_event_end_date', $end_date );
+	update_post_meta( $event_id, '_event_timezone', $event_timezone );
 	if ( $locale ) {
 		update_post_meta( $event_id, '_event_locale', $locale );
 	}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -133,6 +133,24 @@ function save_event_meta_boxes( $post_id ) {
 		}
 	}
 }
+/**
+ * Validate the event dates.
+ *
+ * @param  string $event_start_date The event start date.
+ * @param  string $event_end_date   The event end date.
+ * @return bool                     Whether the event dates are valid.
+ */
+function validate_event_dates( $event_start_date, $event_end_date ) {
+	if ( ! $event_start_date || ! $event_end_date ) {
+		return false;
+	}
+	$start_date = new DateTime( $event_start_date );
+	$end_date   = new DateTime( $event_end_date );
+	if ( $start_date < $end_date ) {
+		return true;
+	}
+	return false;
+}
 
 function submit_event_ajax() {
 	$event_id;
@@ -155,6 +173,11 @@ function submit_event_ajax() {
 	$project_name   = sanitize_text_field( $_POST['event_project_name'] );
 	$event_timezone = sanitize_text_field( $_POST['event_timezone'] );
 
+	$is_valid_event_date = validate_event_dates( $start_date, $end_date );
+
+	if ( ! $is_valid_event_date ) {
+		wp_send_json_error( 'Invalid event dates' );
+	}
 	if ( 'create_event' === $_POST['form_name'] ) {
 		$event_id = wp_insert_post(
 			array(

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -81,12 +81,12 @@ function event_meta_boxes() {
  */
 function event_dates_meta_box( $post ) {
 	wp_nonce_field( 'event_dates_nonce', 'event_dates_nonce' );
-	$start_date = get_post_meta( $post->ID, '_event_start_date', true );
-	$end_date   = get_post_meta( $post->ID, '_event_end_date', true );
-	echo '<label for="event_start_date">Start Date: </label>';
-	echo '<input type="date" id="event_start_date" name="event_start_date" value="' . esc_attr( $start_date ) . '" required>';
-	echo '<label for="event_end_date">End Date: </label>';
-	echo '<input type="date" id="event_end_date" name="event_end_date" value="' . esc_attr( $end_date ) . '" required>';
+	$event_start = get_post_meta( $post->ID, '_event_start', true );
+	$event_end   = get_post_meta( $post->ID, '_event_end', true );
+	echo '<label for="event_start">Start Date: </label>';
+	echo '<input type="date" id="event_start" name="event_start" value="' . esc_attr( $event_start ) . '" required>';
+	echo '<label for="event_end">End Date: </label>';
+	echo '<input type="date" id="event_end" name="event_end" value="' . esc_attr( $event_end ) . '" required>';
 }
 
 /**
@@ -126,7 +126,7 @@ function save_event_meta_boxes( $post_id ) {
 		}
 	}
 
-	$fields = array( 'event_start_date', 'event_end_date', 'event_locale', 'event_project_name' );
+	$fields = array( 'event_start', 'event_end', 'event_locale', 'event_project_name' );
 	foreach ( $fields as $field ) {
 		if ( isset( $_POST[ $field ] ) ) {
 			update_post_meta( $post_id, '_' . $field, sanitize_text_field( $_POST[ $field ] ) );
@@ -136,17 +136,17 @@ function save_event_meta_boxes( $post_id ) {
 /**
  * Validate the event dates.
  *
- * @param  string $event_start_date The event start date.
- * @param  string $event_end_date   The event end date.
+ * @param  string $event_start The event start date.
+ * @param  string $event_end   The event end date.
  * @return bool                     Whether the event dates are valid.
  */
-function validate_event_dates( $event_start_date, $event_end_date ) {
-	if ( ! $event_start_date || ! $event_end_date ) {
+function validate_event_dates( $event_start, $event_end ) {
+	if ( ! $event_start || ! $event_end ) {
 		return false;
 	}
-	$start_date = new DateTime( $event_start_date );
-	$end_date   = new DateTime( $event_end_date );
-	if ( $start_date < $end_date ) {
+	$event_start = new DateTime( $event_start );
+	$event_end   = new DateTime( $event_end );
+	if ( $event_start < $event_end ) {
 		return true;
 	}
 	return false;
@@ -167,13 +167,13 @@ function submit_event_ajax() {
 
 	$title          = sanitize_text_field( $_POST['event_title'] );
 	$description    = sanitize_text_field( $_POST['event_description'] );
-	$start_date     = sanitize_text_field( $_POST['event_start_date'] );
-	$end_date       = sanitize_text_field( $_POST['event_end_date'] );
+	$event_start    = sanitize_text_field( $_POST['event_start'] );
+	$event_end      = sanitize_text_field( $_POST['event_end'] );
 	$locale         = sanitize_text_field( $_POST['event_locale'] );
 	$project_name   = sanitize_text_field( $_POST['event_project_name'] );
 	$event_timezone = sanitize_text_field( $_POST['event_timezone'] );
 
-	$is_valid_event_date = validate_event_dates( $start_date, $end_date );
+	$is_valid_event_date = validate_event_dates( $event_start, $event_end );
 
 	if ( ! $is_valid_event_date ) {
 		wp_send_json_error( 'Invalid event dates' );
@@ -202,8 +202,8 @@ function submit_event_ajax() {
 			)
 		);
 	}
-	update_post_meta( $event_id, '_event_start_date', $start_date );
-	update_post_meta( $event_id, '_event_end_date', $end_date );
+	update_post_meta( $event_id, '_event_start', $event_start );
+	update_post_meta( $event_id, '_event_end', $event_end );
 	update_post_meta( $event_id, '_event_timezone', $event_timezone );
 	if ( $locale ) {
 		update_post_meta( $event_id, '_event_locale', $locale );


### PR DESCRIPTION
In this PR, we change the date fields to `datetime-local`. We are also now allowing organizers set the time zone for an event  storing the timezone as a post meta.

See screenshot below;
<img width="710" alt="Screenshot 2024-01-25 at 00 44 49" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/a4bed4b8-4c96-4464-a4ba-ab25d1efe112">
