### PR TITLE
Track all actions that are relevant (reject, approve, etc)

### DIFF
--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -17,12 +17,16 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		add_action(
 			'gp_translation_saved',
 			function ( $translation, $translation_before ) {
-				$user_id       = $translation->user_id_last_modified;
-				$status        = $translation->status;
-				$status_before = $translation_before->status;
-				$happened_at   = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, new DateTimeZone( 'UTC' ) );
+				$user_id     = $translation->user_id_last_modified;
+				$status      = $translation->status;
+				$happened_at = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, new DateTimeZone( 'UTC' ) );
 
-				if ( 'current' === $status && 'current' !== $status_before ) {
+				if ( $translation_before->status === $status ) {
+					// Translation hasn't changed status, so there's nothing for us to track.
+					return;
+				}
+
+				if ( 'current' === $status ) {
 					$this->handle_action( $translation, $user_id, self::ACTION_APPROVE, $happened_at );
 				}
 			},

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -2,13 +2,13 @@
 
 class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTIONS_TABLE_NAME = 'wp_wporg_gp_translation_events_actions';
-	const ACTION_CREATED = 'created';
+	const ACTION_CREATE = 'create';
 
 	public function start(): void {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$this->handle_action( $translation, self::ACTION_CREATED );
+				$this->handle_action( $translation, self::ACTION_CREATE );
 			},
 		);
 	}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -92,14 +92,14 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				'post_status' => 'publish',
 				'meta_query'  => [
 					[
-						'key'     => '_event_start_date',
-						'value'   => $at->format( 'Y-m-d' ),
+						'key'     => '_event_start',
+						'value'   => $at->format( 'Y-m-d H:i:s' ),
 						'compare' => '<=',
 						'type'    => 'DATETIME',
 					],
 					[
-						'key'     => '_event_end_date',
-						'value'   => $at->format( 'Y-m-d' ),
+						'key'     => '_event_end',
+						'value'   => $at->format( 'Y-m-d H:i:s' ),
 						'compare' => '>=',
 						'type'    => 'DATETIME',
 					],

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -26,8 +26,15 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 					return;
 				}
 
-				if ( 'current' === $status ) {
-					$this->handle_action( $translation, $user_id, self::ACTION_APPROVE, $happened_at );
+				$action = null;
+				switch ( $status ) {
+					case 'current':
+						$action = self::ACTION_APPROVE;
+						break;
+				}
+
+				if ( $action ) {
+					$this->handle_action( $translation, $user_id, $action, $happened_at );
 				}
 			},
 			10,

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -4,6 +4,8 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTIONS_TABLE_NAME = 'wp_wporg_gp_translation_events_actions';
 	const ACTION_CREATE = 'create';
 	const ACTION_APPROVE = 'approve';
+	const ACTION_REJECT = 'reject';
+	const ACTION_MARK_FUZZY = 'mark_fuzzy';
 
 	public function start(): void {
 		add_action(
@@ -30,6 +32,12 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				switch ( $status ) {
 					case 'current':
 						$action = self::ACTION_APPROVE;
+						break;
+					case 'rejected':
+						$action = self::ACTION_REJECT;
+						break;
+					case 'fuzzy':
+						$action = self::ACTION_MARK_FUZZY;
 						break;
 				}
 

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -36,12 +36,11 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$active_events = $this->get_active_events( $happened_at );
 		$events        = $this->select_events_user_is_registered_for( $active_events, $user_id );
 
+		/** @var GP_Translation_Set $translation_set */
+		$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
+		global $wpdb;
+
 		foreach ( $events as $event ) {
-			/** @var GP_Translation_Set $translation_set */
-			$translation_set = ( new GP_Translation_Set )->find_one( [ 'id' => $translation->translation_set_id ] );
-
-			global $wpdb;
-
 			// A given user can only do one action of a given type on a specific translation.
 			// So we replace instead of insert, which will enforce the primary key.
 			$wpdb->replace(

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -3,6 +3,7 @@
 class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTIONS_TABLE_NAME = 'wp_wporg_gp_translation_events_actions';
 	const ACTION_CREATE = 'create';
+	const ACTION_APPROVE = 'approve';
 
 	public function start(): void {
 		add_action(
@@ -10,6 +11,20 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 			function ( $translation ) {
 				$this->handle_action( $translation, self::ACTION_CREATE );
 			},
+		);
+
+		add_action(
+			'gp_translation_saved',
+			function ( $translation, $translation_before ) {
+				$status = $translation->status;
+				$status_before = $translation_before->status;
+
+				if ($status === 'current' && $status_before !== 'current') {
+					$this->handle_action( $translation, self::ACTION_APPROVE );
+				}
+			},
+			10,
+			2,
 		);
 	}
 

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -11,7 +11,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$happened_at = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_addedd, new DateTimeZone( 'UTC' ) );
+				$happened_at = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_added, new DateTimeZone( 'UTC' ) );
 				$this->handle_action( $translation, $translation->user_id, self::ACTION_CREATE, $happened_at );
 			},
 		);

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -9,7 +9,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		add_action(
 			'gp_translation_created',
 			function ( $translation ) {
-				$happened_at = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_created, DateTimeZone::UTC );
+				$happened_at = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_addedd, new DateTimeZone( 'UTC' ) );
 				$this->handle_action( $translation, $translation->user_id, self::ACTION_CREATE, $happened_at );
 			},
 		);
@@ -20,7 +20,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 				$user_id       = $translation->user_id_last_modified;
 				$status        = $translation->status;
 				$status_before = $translation_before->status;
-				$happened_at   = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, DateTimeZone::UTC );
+				$happened_at   = DateTime::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, new DateTimeZone( 'UTC' ) );
 
 				if ( 'current' === $status && 'current' !== $status_before ) {
 					$this->handle_action( $translation, $user_id, self::ACTION_APPROVE, $happened_at );

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -16,11 +16,11 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		add_action(
 			'gp_translation_saved',
 			function ( $translation, $translation_before ) {
-				$user_id = $translation->user_id_last_modified;
-				$status = $translation->status;
+				$user_id       = $translation->user_id_last_modified;
+				$status        = $translation->status;
 				$status_before = $translation_before->status;
 
-				if ($status === 'current' && $status_before !== 'current') {
+				if ( 'current' === $status && 'current' !== $status_before ) {
 					$this->handle_action( $translation, $user_id, self::ACTION_APPROVE );
 				}
 			},

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -5,6 +5,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTION_CREATE = 'create';
 	const ACTION_APPROVE = 'approve';
 	const ACTION_REJECT = 'reject';
+	const ACTION_REQUEST_CHANGES = 'request_changes';
 	const ACTION_MARK_FUZZY = 'mark_fuzzy';
 
 	public function start(): void {
@@ -35,6 +36,9 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 						break;
 					case 'rejected':
 						$action = self::ACTION_REJECT;
+						break;
+					case 'changesrequested':
+						$action = self::ACTION_REQUEST_CHANGES;
 						break;
 					case 'fuzzy':
 						$action = self::ACTION_MARK_FUZZY;

--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',
     user_id        int(10)     not null comment 'ID of the user who made the action',
-    action         varchar(16) not null comment 'The action that the user made (create, reject, etc)',
+    action         varchar(10) not null comment 'The action that the user made (create, reject, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
     # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.

--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',
     user_id        int(10)     not null comment 'ID of the user who made the action',
-    action         varchar(16) not null comment 'The action that the user made (created, rejected, etc)',
+    action         varchar(16) not null comment 'The action that the user made (create, reject, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
     # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.

--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',
     user_id        int(10)     not null comment 'ID of the user who made the action',
-    action         varchar(10) not null comment 'The action that the user made (create, reject, etc)',
+    action         varchar(16) not null comment 'The action that the user made (create, reject, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
     # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.


### PR DESCRIPTION
Fixes #16 

We're now tracking the following actions

- `create`: Create a translation
- `approve`: Approve a translation
- `reject`: Reject a translation
- `mark_fuzzy`: Mark a translation as fuzzy
- `request_changes`: Changes were requested on a translation
