### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/node_modules


### PR DESCRIPTION
Add the `node_modules` folder to .gitignore so that it is not tracked by git.