### PR TITLE
Fix broken route loading

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -257,10 +257,10 @@ add_action(
 	'gp_init',
 	function() {
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
-		GP::$router->prepend( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ), 'get' );
-		GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
-		GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
-		GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
+		GP::$router->add( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
+		GP::$router->add( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
+		GP::$router->add( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
+		GP::$router->add( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ), 'get' );
 
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-translation-listener.php';
 		$wporg_gp_translation_events_listener = new WPORG_GP_Translation_Events_Translation_Listener();

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -257,10 +257,10 @@ add_action(
 	'gp_init',
 	function() {
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-route.php';
+		GP::$router->prepend( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ), 'get' );
 		GP::$router->prepend( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
 		GP::$router->prepend( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
 		GP::$router->prepend( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
-		GP::$router->prepend( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ), 'get' );
 
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-translation-listener.php';
 		$wporg_gp_translation_events_listener = new WPORG_GP_Translation_Events_Translation_Listener();


### PR DESCRIPTION
All the events route stopped return a 404, this has been fixed in this PR by reordering the routes registration.