### PR TITLE
Ignore mark as fuzzy and only track one action per user per translation

### DIFF
--- a/includes/class-wporg-gp-translation-events-stats-calculator.php
+++ b/includes/class-wporg-gp-translation-events-stats-calculator.php
@@ -65,7 +65,7 @@ class WPORG_GP_Translation_Events_Stats_Calculator {
 		$query = $wpdb->prepare( "
 				select locale,
 					   sum(if(action = 'create', 1, 0)) AS created,
-					   sum(if(action in ('approve', 'reject', 'request_changes', 'mark_fuzzy'), 1, 0)) AS reviewed,
+					   sum(if(action in ('approve', 'reject', 'request_changes'), 1, 0)) AS reviewed,
 					   count(distinct user_id) as users
 				from $this->ACTIONS_TABLE_NAME
 				where event_id = %d

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -6,7 +6,6 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	const ACTION_APPROVE = 'approve';
 	const ACTION_REJECT = 'reject';
 	const ACTION_REQUEST_CHANGES = 'request_changes';
-	const ACTION_MARK_FUZZY = 'mark_fuzzy';
 
 	public function start(): void {
 		add_action(
@@ -39,9 +38,6 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 						break;
 					case 'changesrequested':
 						$action = self::ACTION_REQUEST_CHANGES;
-						break;
-					case 'fuzzy':
-						$action = self::ACTION_MARK_FUZZY;
 						break;
 				}
 

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -60,8 +60,8 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		global $wpdb;
 
 		foreach ( $events as $event ) {
-			// A given user can only do one action of a given type on a specific translation.
-			// So we replace instead of insert, which will enforce the primary key.
+			// A given user can only do one action on a specific translation.
+			// So we replace instead of insert, which will keep only the last action.
 			$wpdb->replace(
 				self::ACTIONS_TABLE_NAME,
 				[
@@ -69,8 +69,8 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 					'event_id'       => $event->ID,
 					'user_id'        => $user_id,
 					'translation_id' => $translation->id,
-					'action'         => $action,
 					// end primary key
+					'action'         => $action,
 					'locale'         => $translation_set->locale,
 					'happened_at'    => $happened_at->format( 'Y-m-d H:i:s' ),
 				]

--- a/schema.sql
+++ b/schema.sql
@@ -9,7 +9,7 @@ create or replace table wp_wporg_gp_translation_events_actions
     action         varchar(16) not null comment 'The action that the user made (create, reject, etc)',
     locale         varchar(10) not null comment 'Locale of the translation',
     happened_at    datetime    not null comment 'When the action happened, in UTC',
-    # Make sure that for a given event and translation, the user cannot do multiple actions of the same type.
-    primary key (event_id, translation_id, user_id, action)
+    # Make sure that for a given event and translation, the user cannot do multiple actions.
+    primary key (event_id, translation_id, user_id)
 )
     comment 'Tracks translation actions that happened during a translation event';


### PR DESCRIPTION
Fix #29 #32 