### PR TITLE
Remove the unsupported replace element

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,7 +1,7 @@
 # This file is only used in development environments, and to serve as documentation.
 # It is not used in production in any way.
 
-create or replace table wp_wporg_gp_translation_events_actions
+create table IF NOT EXISTS wp_wporg_gp_translation_events_actions
 (
     event_id       int(10)     not null comment 'ID of the event',
     translation_id int(10)     not null comment 'ID of the translation',


### PR DESCRIPTION
Using MySQL

```
mysql -V
mysql  Ver 8.3.0 for macos14.2 on arm64 (Homebrew)
```

I got this error when I tried to create the new table:

```
$ wp db query < schema.sql
ERROR 1064 (42000) at line 4: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'table wp_wporg_gp_translation_events_actions
(
    event_id       int(10)     no' at line 1
```

I tested it from a MySQL GUI and I got the same error:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/47ebbe74-6830-4b47-8911-a032c88509af)

[MySQL doesn't support](https://dev.mysql.com/doc/refman/8.0/en/create-table.html) the `create or replace table` statement, as [it does MariaDB](https://mariadb.com/kb/en/create-table/). This PR updates the SQL query, to create the table if it doesn't exist, and to be compatible with both SQL engines.