### PR TITLE
Update the title in the view according to the action

### DIFF
--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -1,5 +1,5 @@
 <?php
-gp_title( __( 'Translation Events - Edit Event' ) );
+gp_title( __( 'Translation Events - ' ) . esc_html( $event_form_title ) );
 gp_tmpl_header();
 
 ?>


### PR DESCRIPTION
Currently, if the user is creating a new event, the page title is `Translation Events - Edit Event`. This PR updates it, setting the form title according to the action: `Translation Events - Create Event` or `Translation Events - Edit Event`.