### PR TITLE
Add header to other pages

### DIFF
--- a/templates/event.php
+++ b/templates/event.php
@@ -2,6 +2,8 @@
 /* translators: %s: Event title. */
 gp_title( sprintf( __( 'Translation Events - %s' ), esc_html( $event_title ) ) );
 gp_tmpl_header();
+gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
+
 ?>
 
 <div class="event-details-page">

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -1,6 +1,7 @@
 <?php
 gp_title( __( 'Translation Events - Edit Event' ) );
 gp_tmpl_header();
+gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 
 ?>
 


### PR DESCRIPTION
The header which contains the links to `My Events` and `Create Event`  pages are added to other templates.

**Screesnshots**
<img width="1674" alt="Screenshot 2024-02-09 at 09 52 21" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/07ee8475-d726-456f-a5d9-81df2cf5a108">

<img width="1668" alt="Screenshot 2024-02-09 at 09 53 40" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/652ee041-4879-4a5e-908c-466ab5a2a8ab">

