### PR TITLE
Convert event time to user's local time

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function($) {
         selectUserTimezone();
     }
     validateEventDates();
+    convertToUserLocalTime();
 
     $('.submit-event').on('click', function(e) {
         e.preventDefault();
@@ -64,6 +65,23 @@ jQuery(document).ready(function($) {
         document.querySelector(`#event-timezone option[value="${Intl.DateTimeFormat().resolvedOptions().timeZone}"]`).selected = true 
     }
 
+    function convertToUserLocalTime() {
+        var timeElements = document.querySelectorAll('time.event-utc-time');
+        if ( timeElements.length === 0 ) {
+            return;
+        }
+        timeElements.forEach(function(timeEl) {
+            var eventDateObj = new Date( timeEl.getAttribute('datetime') );
+            var userTimezoneOffset = new Date().getTimezoneOffset();
+            var userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
+            var userLocalDateTime = new Date(eventDateObj.getTime() - userTimezoneOffsetMs);
+
+            var options = { weekday: 'short', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', hour12: true, timeZoneName: 'short' };
+    
+            timeEl.textContent = userLocalDateTime.toLocaleString('en-US', options);
+        });
+    }
+    
 });
 }( jQuery, $gp )
 );

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -53,7 +53,10 @@ jQuery(document).ready(function($) {
     function validateEventDates() {
         var startDateTimeInput = $('#event-start');
         var endDateTimeInput = $('#event-end');
-    
+        if ( ! startDateTimeInput.length || ! endDateTimeInput.length ) {
+            return;
+        }
+
         startDateTimeInput.add(endDateTimeInput).on('input', function () {
             endDateTimeInput.prop('min', startDateTimeInput.val());
             if (endDateTimeInput.val() < startDateTimeInput.val()) {

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -1,7 +1,7 @@
 ( function( $, $gp ) {
 jQuery(document).ready(function($) {
     $gp.notices.init();
-    if ( ! $('#event-timezone').val() ) {
+    if ( $('#event-timezone').length && ! $('#event-timezone').val() ) {
         selectUserTimezone();
     }
     validateEventDates();

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -119,8 +119,8 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 
 		$event_title       = $event->post_title;
 		$event_description = $event->post_content;
-		$event_start        = get_post_meta( $event->ID, '_event_start', true ) ?? '';
-		$event_end          = get_post_meta( $event->ID, '_event_end', true ) ?? '';
+		$event_start       = get_post_meta( $event->ID, '_event_start', true ) ?? '';
+		$event_end         = get_post_meta( $event->ID, '_event_end', true ) ?? '';
 
 		$stats_calculator = new WPORG_GP_Translation_Events_Stats_Calculator();
 		try {

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -119,8 +119,8 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 
 		$event_title       = $event->post_title;
 		$event_description = $event->post_content;
-		$event_start_date  = get_post_meta( $event->ID, '_event_start_date', true ) ?? '';
-		$event_end_date    = get_post_meta( $event->ID, '_event_end_date', true ) ?? '';
+		$event_start        = get_post_meta( $event->ID, '_event_start', true ) ?? '';
+		$event_end          = get_post_meta( $event->ID, '_event_end', true ) ?? '';
 
 		$stats_calculator = new WPORG_GP_Translation_Events_Stats_Calculator();
 		try {

--- a/templates/event.php
+++ b/templates/event.php
@@ -25,8 +25,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 	</div>
 	<div class="event-details-right">
 		<div class="event-details-date">
-			<p><span class="dashicons dashicons-calendar"></span> <?php echo esc_html( ( new DateTime( $event_start_date ) )->format( 'l, F j, Y' ) ); ?></p>
-			<p><span class="dashicons dashicons-clock"></span> 13:00 - 15:00</p>
+			<p><span class="dashicons dashicons-clock"></span> <time class="event-utc-time" datetime="<?php echo esc_attr( $event_start ); ?>"></time> - <time class="event-utc-time" datetime="<?php echo esc_attr( $event_end ); ?>"></time></p>
 		</div>
 		<div class="event-details-join">
 			<button class="button is-primary" id="join-event">Attend Event</button>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -27,14 +27,14 @@ if ( $query->have_posts() ) :
 	</ul>
 
 	<?php
-	echo paginate_links(
+	echo esc_html( paginate_links(
 		array(
 			'total'     => $query->max_num_pages,
 			'current'   => max( 1, get_query_var( 'paged' ) ),
 			'prev_text' => '&laquo; Previous',
 			'next_text' => 'Next &raquo;',
 		)
-	);
+	) );
 
 	wp_reset_postdata();
 else :

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -3,12 +3,7 @@ gp_title( __( 'Translation Events' ) );
 gp_tmpl_header();
 gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 ?>
-<div class="event-list-top-bar">
-	<ul class="event-list-nav">
-		<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
-		<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
-	</ul>
-</div>
+
 
 
 <h2 class="event_page_title">Upcoming Translation Events</h2>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -3,6 +3,12 @@ gp_title( __( 'Translation Events' ) );
 gp_tmpl_header();
 gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 ?>
+<div class="event-list-top-bar">
+	<ul class="event-list-nav">
+		<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
+		<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+	</ul>
+</div>
 
 
 <h2 class="event_page_title">Upcoming Translation Events</h2>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -15,10 +15,10 @@ if ( $query->have_posts() ) :
 		<?php
 		while ( $query->have_posts() ) :
 			$query->the_post();
-			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format('l, F j, Y');
+			$event_start = get_post_meta( get_the_ID(), '_event_start', true );
 			?>
 			<li class="event-list-item">
-				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
+				<span class="event-list-date"><time class="event-utc-time" datetime="<?php echo esc_attr( $event_start ); ?>"></span>
 				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -28,14 +28,16 @@ if ( $query->have_posts() ) :
 	</ul>
 
 	<?php
-	echo esc_html( paginate_links(
-		array(
-			'total'     => $query->max_num_pages,
-			'current'   => max( 1, get_query_var( 'paged' ) ),
-			'prev_text' => '&laquo; Previous',
-			'next_text' => 'Next &raquo;',
+	echo esc_html(
+		paginate_links(
+			array(
+				'total'     => $query->max_num_pages,
+				'current'   => max( 1, get_query_var( 'paged' ) ),
+				'prev_text' => '&laquo; Previous',
+				'next_text' => 'Next &raquo;',
+			)
 		)
-	) );
+	);
 
 	wp_reset_postdata();
 else :


### PR DESCRIPTION
Events datetime are stored in UTC. In this PR, we ensure that event date and time are displayed in readable format and in the user's local time zone.
<img width="1084" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/a4667b83-f2d5-4533-a740-793f9939101a">

<img width="1118" alt="Screenshot 2024-02-12 at 10 40 09" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/d03ae7a4-b0e9-45e5-80c0-dac04d96ffbb">

