### PR TITLE
Update the link for each upcoming event

### DIFF
--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -39,7 +39,7 @@ if ( $query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 			<?php


### PR DESCRIPTION
In the event list, if you click in the event link:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f7177d06-3560-4735-b612-781d6f765e4f)

The user goes to the default post for the 'event' CPT:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/fb17c9ad-a7e0-4634-9cd5-5fcb09daf2c0)

With this PR, the link changes and the user goes to the event page:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/e672e093-8780-443c-aea4-53d52fc794fa)

