### PR TITLE
Add the current events in the event list

### DIFF
--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -26,14 +26,42 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		if ( ! is_user_logged_in() ) {
 			$this->die_with_404();
 		}
-		$current_datetime_utc = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
-		$_paged               = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-		$args                 = array(
-			'post_type'      => 'event',
-			'posts_per_page' => 10,
-			'paged'          => $_paged,
-			'post_status'    => 'publish',
-			'meta_query'     => array(
+		$current_datetime_utc   = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
+		$_current_events_paged  = isset( $_GET[ 'current_events_paged' ] ) && is_numeric( $_GET[ 'current_events_paged' ] ) ? $_GET[ 'current_events_paged' ] : 1;
+		$_upcoming_events_paged = isset( $_GET[ 'upcoming_events_paged' ] ) && is_numeric( $_GET[ 'upcoming_events_paged' ] ) ? $_GET[ 'upcoming_events_paged' ] : 1;
+
+		$current_events_args  = array(
+			'post_type'            => 'event',
+			'posts_per_page'       => 10,
+			'current_events_paged' => $_current_events_paged,
+			'paged'                => $_current_events_paged,
+			'post_status'          => 'publish',
+			'meta_query'           => array(
+				array(
+					'key'     => '_event_start',
+					'value'   => $current_datetime_utc,
+					'compare' => '<=',
+					'type'    => 'DATETIME',
+				),
+				array(
+					'key'     => '_event_end',
+					'value'   => $current_datetime_utc,
+					'compare' => '>=',
+					'type'    => 'DATETIME',
+				),
+			),
+			'orderby'              => 'meta_value',
+			'order'                => 'ASC',
+		);
+		$current_events_query = new WP_Query( $current_events_args );
+
+		$upcoming_events_args = array(
+			'post_type'             => 'event',
+			'posts_per_page'        => 10,
+			'upcoming_events_paged' => $_upcoming_events_paged,
+			'paged'                 => $_upcoming_events_paged,
+			'post_status'           => 'publish',
+			'meta_query'            => array(
 				array(
 					'key'     => '_event_start',
 					'value'   => $current_datetime_utc,
@@ -41,10 +69,10 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 					'type'    => 'DATETIME',
 				),
 			),
-			'orderby'        => 'meta_value',
-			'order'          => 'ASC',
+			'orderby'               => 'meta_value',
+			'order'                 => 'ASC',
 		);
-		$query                = new WP_Query( $args );
+		$upcoming_events_query = new WP_Query( $upcoming_events_args );
 		$this->tmpl( 'events-list', get_defined_vars() );
 	}
 

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -20,7 +20,7 @@ if ( $current_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 		<?php
@@ -52,7 +52,7 @@ if ( $upcoming_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 		<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -20,7 +20,7 @@ if ( $current_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 		<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -52,7 +52,7 @@ if ( $upcoming_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 		<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -6,41 +6,75 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 
 
 
-<h2 class="event_page_title">Upcoming Translation Events</h2>
+<h2 class="event_page_title">Translation Events</h2>
 <div class="event-left-col">
 <?php
-if ( $query->have_posts() ) :
+if ( $current_events_query->have_posts() ) :
 	?>
+	<h3>Current events</h3>
 	<ul>
 		<?php
-		while ( $query->have_posts() ) :
-			$query->the_post();
-			$event_start = get_post_meta( get_the_ID(), '_event_start', true );
+		while ( $current_events_query->have_posts() ) :
+			$current_events_query->the_post();
+			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format('l, F j, Y');
 			?>
 			<li class="event-list-item">
-				<span class="event-list-date"><time class="event-utc-time" datetime="<?php echo esc_attr( $event_start ); ?>"></span>
-				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ) ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
+				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
-			<?php
+		<?php
 		endwhile;
 		?>
 	</ul>
 
 	<?php
-	echo esc_html(
-		paginate_links(
-			array(
-				'total'     => $query->max_num_pages,
-				'current'   => max( 1, get_query_var( 'paged' ) ),
-				'prev_text' => '&laquo; Previous',
-				'next_text' => 'Next &raquo;',
-			)
+	echo paginate_links(
+		array(
+			'total'     => $current_events_query->max_num_pages,
+			'current'   => max( 1, $current_events_query->query_vars['current_events_paged'] ),
+			'format'	=> '?current_events_paged=%#%',
+			'prev_text' => '&laquo; Previous',
+			'next_text' => 'Next &raquo;',
 		)
 	);
 
 	wp_reset_postdata();
-else :
+endif;
+if ( $upcoming_events_query->have_posts() ) :
+	?>
+	<h3>Upcoming events</h3>
+	<ul>
+		<?php
+		while ( $upcoming_events_query->have_posts() ) :
+			$upcoming_events_query->the_post();
+			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format('l, F j, Y');
+			?>
+			<li class="event-list-item">
+				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
+				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<p><?php the_excerpt(); ?></p>
+			</li>
+		<?php
+		endwhile;
+		?>
+	</ul>
+
+	<?php
+	echo paginate_links(
+		array(
+			'total'     => $upcoming_events_query->max_num_pages,
+			'current'   => max( 1, $upcoming_events_query->query_vars['upcoming_events_paged'] ),
+			'format'	=> '?upcoming_events_paged=%#%',
+			'prev_text' => '&laquo; Previous',
+			'next_text' => 'Next &raquo;',
+		)
+	);
+
+	wp_reset_postdata();
+endif;
+
+if ( 0 === $current_events_query->post_count && 0 === $upcoming_events_query->post_count ) :
 	echo 'No events found.';
 endif;
 ?>


### PR DESCRIPTION
Currently, the event list only supports the upcoming events, not the current events:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/6a23f5bd-b875-454b-a106-d5f92c9ddacb)

This PR adds the events that are happening right now: that have started in the past and end in the future. 

This PR does not cache requests.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/08e13230-f6cf-4d6d-b8a7-c31b6448b31e)

It adds pagination for current and upcoming events (in the next screenshot, I have changed the number of items per page from 10 to 1 to take the screenshot).

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1a4abcd5-3476-4e67-a86f-749cf503b3a4)

I put the current events first before the upcoming events because I think it is more important to visualize the current ones than the future ones.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/46.