### PR TITLE
Show some resources to not logged in users

### DIFF
--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -23,9 +23,6 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 	 * @return void
 	 */
 	public function events_list() {
-		if ( ! is_user_logged_in() ) {
-			$this->die_with_404();
-		}
 		$current_datetime_utc = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
 		$_paged               = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 		$args                 = array(
@@ -55,7 +52,7 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 	 */
 	public function events_create() {
 		if ( ! is_user_logged_in() ) {
-			$this->die_with_404();
+			$this->die_with_error( 'You must be logged in to create an event', 403 );
 		}
 		$event_form_title  = 'Create Event';
 		$event_form_name   = 'create_event';
@@ -79,11 +76,11 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 	 */
 	public function events_edit( $event_id ) {
 		if ( ! is_user_logged_in() ) {
-			$this->die_with_404();
+			$this->die_with_error( 'You must be logged in to edit an event' );
 		}
 		$event = get_post( $event_id );
 		if ( ! $event || 'event' !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-			$this->die_with_404();
+			$this->die_with_error( 'Event does not exist, or you do not have permission to edit it.' );
 		}
 
 		include ABSPATH . 'wp-admin/includes/post.php';
@@ -109,9 +106,6 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 	 * @return void
 	 */
 	public function events_details( $event_slug ) {
-		if ( ! is_user_logged_in() ) {
-			$this->die_with_404();
-		}
 		$event = get_page_by_path( $event_slug, OBJECT, 'event' );
 		if ( ! $event ) {
 			$this->die_with_404();

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -76,11 +76,11 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 	 */
 	public function events_edit( $event_id ) {
 		if ( ! is_user_logged_in() ) {
-			$this->die_with_error( 'You must be logged in to edit an event' );
+			$this->die_with_error( 'You must be logged in to edit an event', 403 );
 		}
 		$event = get_post( $event_id );
 		if ( ! $event || 'event' !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-			$this->die_with_error( 'Event does not exist, or you do not have permission to edit it.' );
+			$this->die_with_error( 'Event does not exist, or you do not have permission to edit it.', 403 );
 		}
 
 		include ABSPATH . 'wp-admin/includes/post.php';

--- a/templates/event.php
+++ b/templates/event.php
@@ -27,9 +27,11 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 		<div class="event-details-date">
 			<p><span class="dashicons dashicons-clock"></span> <time class="event-utc-time" datetime="<?php echo esc_attr( $event_start ); ?>"></time> - <time class="event-utc-time" datetime="<?php echo esc_attr( $event_end ); ?>"></time></p>
 		</div>
+		<?php  if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
 			<button class="button is-primary" id="join-event">Attend Event</button>
 		</div>
+		<?php endif; ?>
 	</div>
 <?php if ( ! empty( $event_stats->rows() ) ):?>
 	<div class="event-details-stats">

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -1,6 +1,8 @@
 <div class="event-list-top-bar">
 	<ul class="event-list-nav">
-		<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
-		<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+		<?php if ( is_user_logged_in() ) : ?>
+			<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
+			<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+		<?php endif; ?>
 	</ul>
 </div>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -45,20 +45,22 @@ else :
 endif;
 ?>
 </div>
-<div class="event-right-col">
-	<h3 class="">Events I'm Attending</h3>
-	<?php
-		// TODO: Add the list of events the user is attending.
-	?>
-	<ul class="event-attending-list">
-		<li>
-			<a href="#">Spanish Translation Day</a>
-		</li>
-		<li>
-			<a href="#">Let's Translate 2024</a>
-		</li>
-		<li>
-			<a href="#">Basics of Translation Workshop</a>
-		</li>
-	</ul>
-</div>
+<?php if ( is_user_logged_in() ) : ?>
+	<div class="event-right-col">
+		<h3 class="">Events I'm Attending</h3>
+		<?php
+			// TODO: Add the list of events the user is attending.
+		?>
+		<ul class="event-attending-list">
+			<li>
+				<a href="#">Spanish Translation Day</a>
+			</li>
+			<li>
+				<a href="#">Let's Translate 2024</a>
+			</li>
+			<li>
+				<a href="#">Basics of Translation Workshop</a>
+			</li>
+		</ul>
+	</div>
+<?php endif; ?>


### PR DESCRIPTION
If a not logged-in user tries to access the events, she gets a 404 error. 

This PR improves some situations:

## List

https://glotpress.test/glotpress/events/

Before this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1db656ce-3985-4ea2-ae0f-b642ea5dba16)

With this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/9ae840d0-c001-47e7-9e89-fed37eb5a649)

## Show

https://glotpress.test/glotpress/events/upcoming-event/

Before this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1db656ce-3985-4ea2-ae0f-b642ea5dba16)

With this PR (not logged user):

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/4b8e0c23-714c-4dcc-852b-85c2caf2a9d3)

With this PR (Logged user):
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/05f11734-86cc-4761-9215-abc0fe4eab1f)

## Edit

https://glotpress.test/glotpress/events/edit/167

Before this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1db656ce-3985-4ea2-ae0f-b642ea5dba16)

With this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/8dc3bd80-d7da-4e8e-9549-0070df913b43)

## Create

https://glotpress.test/glotpress/events/new

Before this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1db656ce-3985-4ea2-ae0f-b642ea5dba16)

With this PR:
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f168f540-df35-401a-9fc6-9f053a5adead)


Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/47.