### PR TITLE
Add the events link to the GlotPress main menu

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -243,6 +243,21 @@ add_action( 'init', 'register_event_post_type' );
 add_action( 'add_meta_boxes', 'event_meta_boxes' );
 add_action( 'save_post', 'save_event_meta_boxes' );
 
+/**
+ * Add the events link to the GlotPress main menu.
+ *
+ * @param array  $items    The menu items.
+ * @param string $location The menu location.
+ *
+ * @return array           The modified menu items.
+ */
+function gp_event_nav_menu_items( $items, $location ) {
+	$new[ esc_url( gp_url( '/events/' ) ) ] = esc_html__('Events', 'gp-translation-events' );
+	return array_merge( $items, $new );
+}
+// Add the events link to the GlotPress main menu.
+add_filter( 'gp_nav_menu_items', 'gp_event_nav_menu_items', 10, 2);
+
 add_action(
 	'gp_init',
 	function() {


### PR DESCRIPTION
Before this PR, we don't have a link to the Events list in the main menu.
![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/eb0f1426-0d64-45e8-b337-4fd0f0ccbf60)


This PR adds a link to the Events list in the main menu.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/c454930d-b55a-46a4-9a45-e7a0250c7465)
