### PR TITLE
Align the labels in the creation form

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -59,9 +59,6 @@ button#join-event {
 .hide-event-url {
     display: none;
 }
-.translation-event-form .submit-btn-group {
-    margin-left: 10%;
-}
 .translation-event-form button.save-draft {
     background: #fff;
     color: var(--gp-color-btn-primary-bg);

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -1,8 +1,9 @@
 .translation-event-form label {
-    width: 10%;
+    display: inline-block;
+    width: 140px;
     vertical-align: top;
 }
-.translation-event-form #event-title, 
+.translation-event-form #event-title,
 .translation-event-form #event-description {
     width: 30%;
 }

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -16,10 +16,10 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 		<label for="event-title">Event Title</label>
 		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event_title ); ?>" required>
 	</div>
-	<p id="event-url" class="<?php echo esc_attr( $css_show_url ); ?>">
-		<span>Event URL</span>
-		 <a class="event-permalink" href="<?php echo esc_url( $permalink ); ?>"><?php echo esc_url( $permalink ); ?></a>
-	</p>
+	<div id="event-url" class="<?php echo esc_attr( $css_show_url ); ?>">
+		<label for="event-permalink">Event URL</label>
+		<a id="event-permalink" class="event-permalink" href="<?php echo esc_url( gp_url( wp_make_link_relative( $permalink ) ) ) ?>" target="_blank"><?php echo esc_url( get_site_url() . gp_url( wp_make_link_relative( $permalink ) ) ) ?></a>
+	</div>
 	<div>
 		<label for="event-description">Event Description</label>
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -50,6 +50,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 		</select>
 	</div>
 	<div class="submit-btn-group">
+		<label for="event-status"></label>
 	<?php if ( $event_id ) : ?>
 		<?php if ( isset( $event_status ) && 'draft' === $event_status ) : ?>
 			<button class="button is-primary save-draft submit-event" type="submit" data-event-status="draft">Update Draft</button>


### PR DESCRIPTION
The form for the event creation and update has the labels unaligned.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/18d480c9-7a72-49a4-aad8-91dede063a1b)


This PR vertically align them and fixes the "Event URL" link.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/dc905a6c-99d2-41ae-81e0-7e0d797d66c5)

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/67019287-4b7f-49b9-bb6b-51fe609e0e1d)

