### PR TITLE
Register an user to attend or un-attend to an event

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -2,7 +2,7 @@
     width: 10%;
     vertical-align: top;
 }
-.translation-event-form #event-title, 
+.translation-event-form #event-title,
 .translation-event-form #event-description {
     width: 30%;
 }
@@ -39,10 +39,6 @@
     width: 22%;
     float: left;
     padding: 1em;
-}
-button#join-event {
-    width: 100%;
-    display: block;
 }
 .event-details-stats {
     clear: both;

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -89,7 +89,7 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		$css_show_url                  = '';
 		$event_title                   = $event->post_title;
 		$event_description             = $event->post_content;
-		$event_timezone                = get_post_meta( $event_id, '_event_timezone', true ) ?? '';
+		$event_timezone                = get_post_meta( $event_id, '_event_timezone', true ) ?: '';
 		$event_start                   = self::convertToTimezone( get_post_meta( $event_id, '_event_start', true ), $event_timezone ) ?? '';
 		$event_end                     = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone ) ?? '';
 		$event_status                  = $event->post_status;
@@ -115,8 +115,8 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		$event_id = $event->ID;
 		$event_title         = $event->post_title;
 		$event_description   = $event->post_content;
-		$event_start         = get_post_meta( $event->ID, '_event_start', true ) ?? '';
-		$event_end           = get_post_meta( $event->ID, '_event_end', true ) ?? '';
+		$event_start         = get_post_meta( $event->ID, '_event_start', true ) ?: '';
+		$event_end           = get_post_meta( $event->ID, '_event_end', true ) ?: '';
 		$attending_event_ids = get_user_meta( $user->ID, self::USER_META_KEY_ATTENDING, true ) ?: array();
 		$user_is_attending   = isset( $attending_event_ids[ $event_id ] );
 

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -117,9 +117,7 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		$event_description   = $event->post_content;
 		$event_start         = get_post_meta( $event->ID, '_event_start', true ) ?? '';
 		$event_end           = get_post_meta( $event->ID, '_event_end', true ) ?? '';
-		$event_locale        = get_post_meta( $event->ID, '_event_locale', true ) ?: '';
-		$event_project_name  = get_post_meta( $event->ID, '_event_project_name', true ) ?: '';
-		$attending_event_ids = get_user_meta( $user->ID, self::USER_META_KEY_ATTENDING, true ) ?: [];
+		$attending_event_ids = get_user_meta( $user->ID, self::USER_META_KEY_ATTENDING, true ) ?: array();
 		$user_is_attending   = isset( $attending_event_ids[ $event_id ] );
 
 		$stats_calculator = new WPORG_GP_Translation_Events_Stats_Calculator();

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -151,9 +151,8 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
 		return array_filter(
 			$events,
-			function ( WPORG_GP_Translation_Events_Event $event ) {
-				// TODO.
-				return true;
+			function ( $event ) use ( $attending_event_ids ) {
+				return isset( $attending_event_ids[ $event->ID ] );
 			}
 		);
 	}

--- a/templates/event.php
+++ b/templates/event.php
@@ -29,7 +29,13 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 		</div>
 		<?php  if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
-			<button class="button is-primary" id="join-event">Attend Event</button>
+			<form class="event-details-attend" method="post" action="<?php echo esc_url( gp_url( "/events/attend/$event_id" ) )?>">
+				<?php if ( ! $user_is_attending ): ?>
+					<input type="submit" class="button is-primary" value="Attend Event"/>
+				<?php else: ?>
+					<input type="submit" class="button is-secondary" value="You're attending"/>
+				<?php endif ?>
+			</form>
 		</div>
 		<?php endif; ?>
 	</div>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -250,6 +250,7 @@ add_action(
 		GP::$router->add( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ), 'get' );
 		GP::$router->add( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ), 'get' );
 		GP::$router->add( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ), 'get' );
+		GP::$router->add( '/events/attend/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_attend' ), 'post' );
 		GP::$router->add( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ), 'get' );
 
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-event.php';


### PR DESCRIPTION
The [Attend or un-attend an event #43](https://github.com/WordPress/wporg-gp-translation-events/pull/43) PR tried to merge into the [filter-style-list](https://github.com/WordPress/wporg-gp-translation-events/tree/filter-style-list) branch, not in the trunk branch, but we merge [the PR](https://github.com/WordPress/wporg-gp-translation-events/pull/36) for this [filter-style-list](https://github.com/WordPress/wporg-gp-translation-events/tree/filter-style-list) branch before we approve the [#43](https://github.com/WordPress/wporg-gp-translation-events/pull/43) PR, so the code was not merged in the trunk branch, and now it has a lot of merge conflicts. 

This PR resolve the merging conflicts and add the same functionality than #43.