### PR TITLE
Show a bubble when the event is in draft status

### DIFF
--- a/templates/event.php
+++ b/templates/event.php
@@ -15,7 +15,12 @@ gp_tmpl_load( 'events-header', get_defined_vars(), dirname( __FILE__ ) );
 
 <div class="event-details-page">
 	<div class="event-details-head">
-		<h1><?php echo esc_html( $event_title ); ?></h1>
+		<h1>
+			<?php echo esc_html( $event_title ); ?>
+			<?php if ( 'draft' === $event->post_status ): ?>
+				<span class="event-label-draft"><?php echo esc_html( $event->post_status ); ?></span>
+			<?php endif; ?>
+		</h1>
 		<p>Host: <a href="<?php echo esc_attr( get_author_posts_url( $event->post_author ) ); ?>"><?php echo esc_html( get_the_author_meta( 'display_name', $event->post_author ) ); ?></a></p>
 	</div>
 	<div class="event-details-left">

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -299,22 +299,23 @@ add_filter( 'gp_nav_menu_items', 'gp_event_nav_menu_items' );
 /**
  * Generate a slug for the event post type when we save a draft event.
  *
+ * Generate a slug based on the event title if it's not provided.
+ *
  * @param array $data    An array of slashed post data.
  * @param array $postarr An array of sanitized, but otherwise unmodified post data.
  * @return array The modified post data.
  */
 function generate_event_slug( $data, $postarr ) {
-	if ( $data[ 'post_type' ] === 'event' && $data[ 'post_status' ] === 'draft' ) {
-		// Generate a slug based on the event title if it's not provided
-		if ( empty( $data[ 'post_name' ] ) ) {
-			$data[ 'post_name' ] = sanitize_title( $data[ 'post_title' ] );
+	if ( 'event' === $data['post_type'] && 'draft' === $data['post_status'] ) {
+		if ( empty( $data['post_name'] ) ) {
+			$data['post_name'] = sanitize_title( $data['post_title'] );
 		}
 	}
 
 	return $data;
 }
 
-add_filter('wp_insert_post_data', 'generate_event_slug', 10, 2);
+add_filter( 'wp_insert_post_data', 'generate_event_slug', 10, 2 );
 
 add_action(
 	'gp_init',

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -302,10 +302,9 @@ add_filter( 'gp_nav_menu_items', 'gp_event_nav_menu_items' );
  * Generate a slug based on the event title if it's not provided.
  *
  * @param array $data    An array of slashed post data.
- * @param array $postarr An array of sanitized, but otherwise unmodified post data.
  * @return array The modified post data.
  */
-function generate_event_slug( $data, $postarr ) {
+function generate_event_slug( $data ) {
 	if ( 'event' === $data['post_type'] && 'draft' === $data['post_status'] ) {
 		if ( empty( $data['post_name'] ) ) {
 			$data['post_name'] = sanitize_title( $data['post_title'] );
@@ -315,7 +314,7 @@ function generate_event_slug( $data, $postarr ) {
 	return $data;
 }
 
-add_filter( 'wp_insert_post_data', 'generate_event_slug', 10, 2 );
+add_filter( 'wp_insert_post_data', 'generate_event_slug', 10, 1 );
 
 add_action(
 	'gp_init',

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -296,6 +296,26 @@ function gp_event_nav_menu_items( array $items ): array {
 // Add the events link to the GlotPress main menu.
 add_filter( 'gp_nav_menu_items', 'gp_event_nav_menu_items' );
 
+/**
+ * Generate a slug for the event post type when we save a draft event.
+ *
+ * @param array $data    An array of slashed post data.
+ * @param array $postarr An array of sanitized, but otherwise unmodified post data.
+ * @return array The modified post data.
+ */
+function generate_event_slug( $data, $postarr ) {
+	if ( $data[ 'post_type' ] === 'event' && $data[ 'post_status' ] === 'draft' ) {
+		// Generate a slug based on the event title if it's not provided
+		if ( empty( $data[ 'post_name' ] ) ) {
+			$data[ 'post_name' ] = sanitize_title( $data[ 'post_title' ] );
+		}
+	}
+
+	return $data;
+}
+
+add_filter('wp_insert_post_data', 'generate_event_slug', 10, 2);
+
 add_action(
 	'gp_init',
 	function () {


### PR DESCRIPTION
This PR adds a filter to generate the event slug when it is stored as draft and a bubble when the user sees it, to indicate that is a draft.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/37830be8-fdad-436b-a093-aeae85695712)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/75.