### PR TITLE
Fix PHP Notice:  Undefined variable: attending_event_ids

### DIFF
--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -154,6 +154,8 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	 * @param WPORG_GP_Translation_Events_Event[] $events Events.
 	 * @return WPORG_GP_Translation_Events_Event[]
 	 */
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
 		$attending_events = get_user_meta( $user_id, 'translation-events-attending', true );
 		return array_filter(

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -154,13 +154,12 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	 * @param WPORG_GP_Translation_Events_Event[] $events Events.
 	 * @return WPORG_GP_Translation_Events_Event[]
 	 */
-	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
+		$attending_events = get_user_meta( $user_id, 'translation-events-attending', true );
 		return array_filter(
 			$events,
-			function ( $event ) use ( $attending_event_ids ) {
-				return isset( $attending_event_ids[ $event->ID ] );
+			function ( $event ) use ( $attending_events ) {
+				return isset( $attending_events[ $event->id() ] );
 			}
 		);
 	}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -157,11 +157,11 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_events_ids = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
+		$attending_event_ids = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
 		return array_filter(
 			$events,
-			function ( $event ) use ( $attending_events_ids ) {
-				return isset( $attending_events_ids[ $event->id() ] );
+			function ( $event ) use ( $attending_event_ids ) {
+				return isset( $attending_event_ids[ $event->id() ] );
 			}
 		);
 	}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -157,7 +157,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_events = get_user_meta( $user_id, 'translation-events-attending', true );
+		$attending_events = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
 		return array_filter(
 			$events,
 			function ( $event ) use ( $attending_events ) {

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -157,11 +157,11 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_events = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
+		$attending_events_ids = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
 		return array_filter(
 			$events,
-			function ( $event ) use ( $attending_events ) {
-				return isset( $attending_events[ $event->id() ] );
+			function ( $event ) use ( $attending_events_ids ) {
+				return isset( $attending_events_ids[ $event->id() ] );
 			}
 		);
 	}

--- a/includes/class-wporg-gp-translation-events-translation-listener.php
+++ b/includes/class-wporg-gp-translation-events-translation-listener.php
@@ -160,7 +160,7 @@ class WPORG_GP_Translation_Events_Translation_Listener {
 		$attending_event_ids = get_user_meta( $user_id, WPORG_GP_Translation_Events_Route::USER_META_KEY_ATTENDING, true );
 		return array_filter(
 			$events,
-			function ( $event ) use ( $attending_event_ids ) {
+			function ( WPORG_GP_Translation_Events_Event $event ) use ( $attending_event_ids ) {
 				return isset( $attending_event_ids[ $event->id() ] );
 			}
 		);


### PR DESCRIPTION
Stats for new events were not showing and the stats for old events were not updated after making a translation and PHP threw this notice;
`PHP Notice:  Undefined variable: attending_event_ids`. In this PR, the missing `$attending_event_ids` variable is added.