### PR TITLE
Add the list of events the user is attending

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -69,6 +69,10 @@ span.event-list-date {
     font-size: .9em;
     font-weight: bold;
 }
+span.event-list-date.events-i-am-attending {
+    font-size: .8em;
+    font-weight: normal;
+}
 .event-list-item a{
     font-weight: bold;
     font-size: 1.2em;

--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -33,8 +33,9 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 			$this->die_with_error( 'Something is wrong.' );
 		}
 
-		$_current_events_paged  = 1;
-		$_upcoming_events_paged = 1;
+		$_current_events_paged        = 1;
+		$_upcoming_events_paged       = 1;
+		$_user_attending_events_paged = 1;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['current_events_paged'] ) ) {
@@ -47,6 +48,12 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 			$value = sanitize_text_field( wp_unslash( $_GET['upcoming_events_paged'] ) );
 			if ( is_numeric( $value ) ) {
 				$_upcoming_events_paged = (int) $value;
+			}
+		}
+		if ( isset( $_GET['user_attending_events_paged'] ) ) {
+			$value = sanitize_text_field( wp_unslash( $_GET['user_attending_events_paged'] ) );
+			if ( is_numeric( $value ) ) {
+				$_user_attending_events_paged = (int) $value;
 			}
 		}
 		// phpcs:enable
@@ -96,6 +103,30 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 			'order'                 => 'ASC',
 		);
 		$upcoming_events_query = new WP_Query( $upcoming_events_args );
+
+		$user_attending_events      = get_user_meta( get_current_user_id(), self::USER_META_KEY_ATTENDING, true ) ?: array();
+		$user_attending_events_args = array(
+			'post_type'                   => 'event',
+			'post__in'                    => array_keys( $user_attending_events ),
+			'posts_per_page'              => 10,
+			'user_attending_events_paged' => $_user_attending_events_paged,
+			'paged'                       => $_user_attending_events_paged,
+			'post_status'                 => 'publish',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'                  => array(
+				array(
+					'key'     => '_event_end',
+					'value'   => $current_datetime_utc,
+					'compare' => '>',
+					'type'    => 'DATETIME',
+				),
+			),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key'                    => '_event_start',
+			'orderby'                     => 'meta_value',
+			'order'                       => 'ASC',
+		);
+		$user_attending_events_query = new WP_Query( $user_attending_events_args );
 		$this->tmpl( 'events-list', get_defined_vars() );
 	}
 
@@ -208,6 +239,7 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 		}
 
 		$event = get_post( $event_id );
+
 		if ( ! $event ) {
 			$this->die_with_404();
 		}

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -92,19 +92,43 @@ endif;
 <?php if ( is_user_logged_in() ) : ?>
 	<div class="event-right-col">
 		<h3 class="">Events I'm Attending</h3>
-		<?php
-			// TODO: Add the list of events the user is attending.
+		<?php if ( ! $user_attending_events_query->have_posts() ) : ?>
+			<p>You don't have any events to attend.</p>
+		<?php else : ?>
+			<ul class="event-attending-list">
+				<?php
+				while ( $user_attending_events_query->have_posts() ) :
+					$user_attending_events_query->the_post();
+					$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
+					$event_end   = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+					?>
+					<li class="event-list-item">
+						<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
+						<?php if ( $event_start === $event_end ) : ?>
+							<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?></span>
+						<?php else : ?>
+							<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
+						<?php endif; ?>
+					</li>
+					<?php
+				endwhile;
+				?>
+			</ul>
+			<?php
+				echo wp_kses_post(
+					paginate_links(
+						array(
+							'total'     => $user_attending_events_query->max_num_pages,
+							'current'   => max( 1, $user_attending_events_query->query_vars['user_attending_events_paged'] ),
+							'format'    => '?user_attending_events_paged=%#%',
+							'prev_text' => '&laquo; Previous',
+							'next_text' => 'Next &raquo;',
+						)
+					) ?? ''
+				);
+
+				wp_reset_postdata();
+		endif;
 		?>
-		<ul class="event-attending-list">
-			<li>
-				<a href="#">Spanish Translation Day</a>
-			</li>
-			<li>
-				<a href="#">Let's Translate 2024</a>
-			</li>
-			<li>
-				<a href="#">Basics of Translation Workshop</a>
-			</li>
-		</ul>
 	</div>
 <?php endif; ?>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -323,8 +323,8 @@ add_action(
 		GP::$router->add( '/events?', array( 'WPORG_GP_Translation_Events_Route', 'events_list' ) );
 		GP::$router->add( '/events/new', array( 'WPORG_GP_Translation_Events_Route', 'events_create' ) );
 		GP::$router->add( '/events/edit/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_edit' ) );
-		GP::$router->add( '/events/attend/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_attend' ) );
-		GP::$router->add( '/events/my-events', array( 'WPORG_GP_Translation_Events_Route', 'events_user_created' ), 'get' );
+		GP::$router->add( '/events/attend/(\d+)', array( 'WPORG_GP_Translation_Events_Route', 'events_attend' ), 'post' );
+		GP::$router->add( '/events/my-events', array( 'WPORG_GP_Translation_Events_Route', 'events_user_created' ) );
 		GP::$router->add( '/events/([a-z0-9_-]+)', array( 'WPORG_GP_Translation_Events_Route', 'events_details' ) );
 
 		require_once __DIR__ . '/includes/class-wporg-gp-translation-events-event.php';


### PR DESCRIPTION
This PR adds the list of events the user is attending. 

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f9ab51ac-d7e7-48da-913d-fd8346f2e9f3)

Only adds the current or future events.

Adds pagination (10 items per page). This screenshot was created with 3 items per page.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/10a02d19-ce9a-4bf3-8e91-d35c74a1e192)


Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/55.