### PR TITLE
Add the date to "My events" and update the date order

### DIFF
--- a/includes/class-wporg-gp-translation-events-route.php
+++ b/includes/class-wporg-gp-translation-events-route.php
@@ -296,10 +296,11 @@ class WPORG_GP_Translation_Events_Route extends GP_Route {
 			'posts_per_page' => 10,
 			'post_status'    => array( 'publish', 'draft' ),
 			'paged'          => $_paged,
-			'orderby'        => 'date',
-			'order'          => 'DESC',
 			'author'         => $user_id,
-
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_key'       => '_event_start',
+			'orderby'        => 'meta_value',
+			'order'          => 'DESC',
 		);
 		$query = new WP_Query( $args );
 		$this->tmpl( 'events-user-created', get_defined_vars() );

--- a/templates/events-user-created.php
+++ b/templates/events-user-created.php
@@ -24,12 +24,19 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
 		$event_edit_url                = gp_url( 'events/edit/' . $event_id );
 		$event_status                  = get_post_status( $event_id );
+		$event_start                   = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
+		$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
 		?>
 		<li class="event-list-item">
 			<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
 			<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 			<?php if ( 'draft' === $event_status ) : ?>
 				<span class="event-label-<?php echo esc_attr( $event_status ); ?>"><?php echo esc_html( $event_status ); ?></span>
+			<?php endif; ?>
+			<?php if ( $event_start === $event_end ) : ?>
+				<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?></span>
+			<?php else : ?>
+				<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
 			<?php endif; ?>
 			<p><?php the_excerpt(); ?></p>
 		</li>

--- a/templates/events-user-created.php
+++ b/templates/events-user-created.php
@@ -60,5 +60,6 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 else :
 	echo 'No events found.';
 endif;
+gp_tmpl_footer();
 ?>
 </div>


### PR DESCRIPTION
Currently, "My events" doesn't have the date of each event and the order is not working properly.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/de8183f3-12a8-4b19-86f9-876aef1ee355)

This PR add the date of each event and order them descending, so the old events will appear in the last places of the list. It adds the footer to the template.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/5fdf8d39-cf51-43b0-b112-6a10c57dc962)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/92.