### PR TITLE
When a user creates an event, she should be attending right away

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -342,8 +342,6 @@ add_action( 'add_meta_boxes', 'Wporg\TranslationEvents\event_meta_boxes' );
 add_action( 'save_post', 'Wporg\TranslationEvents\save_event_meta_boxes' );
 add_action( 'transition_post_status', 'Wporg\TranslationEvents\event_status_transition', 10, 3 );
 
-
-
 /**
  * Add the events link to the GlotPress main menu.
  *

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -225,7 +225,6 @@ function submit_event_ajax() {
 		);
 		$response_message = 'Event updated successfully!';
 	}
-
 	if ( 'delete_event' === $action ) {
 		$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
 		$event    = get_post( $event_id );


### PR DESCRIPTION
When a user creates an event, she should be attending right away. 

To test this PR:
- Create a new event, clicking in the "Publish event" button just after filling the text fields. You should be attending to the event.
- Create a new event, clicking in the "Save Draft" button just after filling the text fields. You should not be attending to the event. Update some text field and click in the "Publish event" button. Now you should be attending to the event.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/88.