### PR TITLE
Remove the "Event link" in the top right menu

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -320,12 +320,15 @@ add_action( 'save_post', 'Wporg\TranslationEvents\save_event_meta_boxes' );
  * @param array $items The menu items.
  * @return array The modified menu items.
  */
-function gp_event_nav_menu_items( array $items ): array {
+function gp_event_nav_menu_items( array $items, string $location ): array {
+	if ( 'main' !== $location ) {
+		return $items;
+	}
 	$new[ esc_url( gp_url( '/events/' ) ) ] = esc_html__( 'Events', 'gp-translation-events' );
 	return array_merge( $items, $new );
 }
 // Add the events link to the GlotPress main menu.
-add_filter( 'gp_nav_menu_items', 'Wporg\TranslationEvents\gp_event_nav_menu_items' );
+add_filter( 'gp_nav_menu_items', 'Wporg\TranslationEvents\gp_event_nav_menu_items', 10, 2 );
 
 /**
  * Generate a slug for the event post type when we save a draft event.

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -317,7 +317,8 @@ add_action( 'save_post', 'Wporg\TranslationEvents\save_event_meta_boxes' );
 /**
  * Add the events link to the GlotPress main menu.
  *
- * @param array $items The menu items.
+ * @param array  $items    The menu items.
+ * @param string $location The menu location.
  * @return array The modified menu items.
  */
 function gp_event_nav_menu_items( array $items, string $location ): array {


### PR DESCRIPTION
The "Event" link is duplicated in the top menu. We need to remove it from the right sidebar. 

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1fb8acde-7f45-469b-beb2-d63118658276)

This PR removes the "Event link" in the top right menu.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/7bd482e4-182a-4c1e-a631-7531cbc5a461)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/106.