### PR TITLE
Remove the "Attend Event" if the event has passed

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -121,7 +121,7 @@ h2.event_page_title {
 a.event-link-draft {
 	color:#80807f;
 }
-span.event-label-draft {
+span.event-label-draft, span.event-details-join-expired {
 	font-weight: 500;
 	color:#c05621;
 	border: 1px solid #c05621;

--- a/templates/event.php
+++ b/templates/event.php
@@ -43,13 +43,22 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
-			<form class="event-details-attend" method="post" action="<?php echo esc_url( gp_url( "/events/attend/$event_id" ) ); ?>">
-				<?php if ( ! $user_is_attending ) : ?>
-					<input type="submit" class="button is-primary" value="Attend Event"/>
-				<?php else : ?>
-					<input type="submit" class="button is-secondary" value="You're attending"/>
+			<?php
+			$current_time = gmdate( 'Y-m-d H:i:s' );
+			if ( strtotime( $current_time ) > strtotime( $event_end ) ) :
+				?>
+				<?php if ( $user_is_attending ) : ?>
+					<span class="event-details-join-expired"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></span>
 				<?php endif ?>
-			</form>
+			<?php else : ?>
+				<form class="event-details-attend" method="post" action="<?php echo esc_url( gp_url( "/events/attend/$event_id" ) ); ?>">
+					<?php if ( ! $user_is_attending ) : ?>
+						<input type="submit" class="button is-primary" value="Attend Event"/>
+					<?php else : ?>
+						<input type="submit" class="button is-secondary" value="You're attending"/>
+					<?php endif ?>
+				</form>
+			<?php endif ?>
 		</div>
 		<?php endif; ?>
 	</div>


### PR DESCRIPTION
Currently, it is possible to attend or to stop attending to a past event.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/66e5294d-6fd1-492c-a755-35a5e8a26768)

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/1135bc04-32a8-4504-91d3-d8b69904cca8)

This PR removes the "Attend Event" and the "You're attending" buttons if the event has passed. It adds a bubble if the user has assisted in a past event.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/59836b38-1564-43ff-8c41-1925946bac8c)

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/982c0c5f-33a7-4494-8cfe-1167efd641b7)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/53.