### PR TITLE
Modify how date is displayed on the event list

### DIFF
--- a/includes/event.php
+++ b/includes/event.php
@@ -52,4 +52,26 @@ class Event {
 	public function timezone(): DateTimeZone {
 		return $this->timezone;
 	}
+
+	/**
+	 * Generate text for the end date.
+	 *
+	 * @param string $event_end The end date.
+	 *
+	 * @return string The end date text.
+	 */
+	public static function get_end_date_text( string $event_end ): string {
+		$end_date_time     = new DateTimeImmutable( $event_end );
+		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		$interval       = $end_date_time->diff( $current_date_time );
+		$hours_left     = ( $interval->d * 24 ) + $interval->h;
+		$hours_in_a_day = 24;
+
+		if ( $hours_left <= $hours_in_a_day ) {
+			return 'ends in ' . $hours_left . ' hours';
+		} else {
+			return 'until ' . $end_date_time->format( 'M j, Y' );
+		}
+	}
 }

--- a/includes/event.php
+++ b/includes/event.php
@@ -68,10 +68,13 @@ class Event {
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
 		$hours_in_a_day = 24;
 
-		if ( $hours_left <= $hours_in_a_day ) {
-			return 'ends in ' . $hours_left . ' hours';
-		} else {
-			return 'until ' . $end_date_time->format( 'M j, Y' );
+		if ( 0 === $hours_left ) {
+			/* translators: %s: Number of minutes left. */
+			return sprintf( _n( 'ends in %s minute', 'ends in %s minutes', $interval->i ), $interval->i );
+		} elseif ( $hours_left <= $hours_in_a_day ) {
+			/* translators: %s: Number of hours left. */
+			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
 		}
+		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
 	}
 }

--- a/includes/route.php
+++ b/includes/route.php
@@ -316,26 +316,4 @@ class Route extends GP_Route {
 	public static function convertToTimezone( string $date_time, string $time_zone ): string {
 		return ( new DateTime( $date_time, new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $time_zone ) )->format( 'Y-m-d H:i:s' );
 	}
-
-	/**
-	 * Generate text for the end date.
-	 *
-	 * @param string $event_end The end date.
-	 *
-	 * @return string The end date text.
-	 */
-	public static function get_end_date_text( string $event_end ): string {
-		$end_date_time     = new DateTime( $event_end );
-		$current_date_time = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-
-		$interval       = $end_date_time->diff( $current_date_time );
-		$hours_left     = ( $interval->d * 24 ) + $interval->h;
-		$hours_in_a_day = 24;
-
-		if ( $hours_left <= $hours_in_a_day ) {
-			return 'ends in ' . $hours_left . ' hours';
-		} else {
-			return 'until ' . $end_date_time->format( 'M j, Y' );
-		}
-	}
 }

--- a/includes/route.php
+++ b/includes/route.php
@@ -316,4 +316,26 @@ class Route extends GP_Route {
 	public static function convertToTimezone( string $date_time, string $time_zone ): string {
 		return ( new DateTime( $date_time, new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $time_zone ) )->format( 'Y-m-d H:i:s' );
 	}
+
+	/**
+	 * Generate text for the end date.
+	 *
+	 * @param string $event_end The end date.
+	 *
+	 * @return string The end date text.
+	 */
+	public static function get_end_date_text( string $event_end ): string {
+		$end_date_time     = new DateTime( $event_end );
+		$current_date_time = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+		$interval       = $end_date_time->diff( $current_date_time );
+		$hours_left     = ( $interval->d * 24 ) + $interval->h;
+		$hours_in_a_day = 24;
+
+		if ( $hours_left <= $hours_in_a_day ) {
+			return 'ends in ' . $hours_left . ' hours';
+		} else {
+			return 'until ' . $end_date_time->format( 'M j, Y' );
+		}
+	}
 }

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -27,13 +27,13 @@ if ( $current_events_query->have_posts() ) :
 		<?php
 		while ( $current_events_query->have_posts() ) :
 			$current_events_query->the_post();
-			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'l, F j, Y' );
-			$event_url   = gp_url( wp_make_link_relative( get_the_permalink() ) );
+			$event_end = Route::get_end_date_text( get_post_meta( get_the_ID(), '_event_end', true ) );
+			$event_url = gp_url( wp_make_link_relative( get_the_permalink() ) );
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<p><?php the_excerpt(); ?></p>
+				<span class="event-list-date"><?php echo esc_html( $event_end ); ?></span>
+				<?php the_excerpt(); ?>
 			</li>
 			<?php
 		endwhile;
@@ -67,7 +67,7 @@ if ( $upcoming_events_query->have_posts() ) :
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<p><?php the_excerpt(); ?></p>
+				<?php the_excerpt(); ?>
 			</li>
 			<?php
 		endwhile;

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -27,7 +27,7 @@ if ( $current_events_query->have_posts() ) :
 		<?php
 		while ( $current_events_query->have_posts() ) :
 			$current_events_query->the_post();
-			$event_end = Route::get_end_date_text( get_post_meta( get_the_ID(), '_event_end', true ) );
+			$event_end = Event::get_end_date_text( get_post_meta( get_the_ID(), '_event_end', true ) );
 			$event_url = gp_url( wp_make_link_relative( get_the_permalink() ) );
 			?>
 			<li class="event-list-item">

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -32,7 +32,7 @@ if ( $current_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 			<?php
@@ -66,7 +66,7 @@ if ( $upcoming_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a> by <span><?php the_author(); ?></span>
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 			<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -31,8 +31,8 @@ if ( $current_events_query->have_posts() ) :
 			$event_url   = gp_url( wp_make_link_relative( get_the_permalink() ) );
 			?>
 			<li class="event-list-item">
-				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
 				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
+				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 			<?php
@@ -65,8 +65,8 @@ if ( $upcoming_events_query->have_posts() ) :
 			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'l, F j, Y' );
 			?>
 			<li class="event-list-item">
-				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
+				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
 				<p><?php the_excerpt(); ?></p>
 			</li>
 			<?php


### PR DESCRIPTION
Fixes #84 

**Before**
<img width="1401" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/6489cb13-f810-47bd-ab8e-896a0fe72723">


**After**
<img width="1433" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/c7d22818-67a6-4b69-9c3d-6f67962d1d3c">
