### PR TITLE
Add a prompt if the event is in draft status and the user publishes it

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -15,7 +15,8 @@
 					function ( e ) {
 						e.preventDefault();
 						let eventStatus = $( this ).data( 'event-status' );
-						handleSubmit( eventStatus );
+						let isDraft     = $( 'button.save-draft[data-event-status="draft"]:visible' ).length > 0;
+						handleSubmit( eventStatus, isDraft );
 					}
 				);
 
@@ -29,12 +30,18 @@
 			}
 		);
 
-		function handleSubmit( eventStatus ) {
+		/**
+		 * Handles the form submission
+		 *
+		 * @param eventStatus The new status of the event
+		 * @param isDraft	  Whether the current event status is a draft or not
+		 */
+		function handleSubmit( eventStatus, isDraft ) {
 			if ( $( '#event-end' ).val() <= $( '#event-start' ).val() ) {
 				$gp.notices.error( 'Event end date and time must be later than event start date and time.' );
 				return;
 			}
-			if ( eventStatus === 'publish' && '' === $( '#event-id' ).val() ) {
+			if ( eventStatus === 'publish' && isDraft ) {
 				const submitPrompt = 'Are you sure you want to publish this event?';
 				if ( ! confirm( submitPrompt ) ) {
 					return;


### PR DESCRIPTION
If the event is in draft status and the user publishes it, she doesn't get a prompt.

This PR adds this prompt. To test it, you can test two different situations:

- Test 1:
  - Create a new event.
  - Click on the "Publish Event" button. You will get a prompt with the "Are you sure you want to publish this event?" text.
  - Update the content and click on the "Update Event" button.

- Test 2:
  - Create a new event.
  - Click on the "Save Draft" button. 
  - Update the content and click on the "Update Draft" button.
  - Click on the "Publish Event" button. You will get a prompt with the "Are you sure you want to publish this event?" text.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/81. 