### PR TITLE
Prevent the usage of event titles that can conflict with event URLs

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -69,9 +69,11 @@
 							$gp.notices.success( response.data.message );
 						}
 					},
-					error: function ( error ) {
-						$gp.notices.error( response.data.message );
-					}
+					error: function ( xhr, msg ) {
+						/* translators: %s: Error message. */
+						msg = xhr.responseJSON.data ? wp.i18n.sprintf( wp.i18n.__( 'Error: %s', 'gp-translation-events' ), xhr.responseJSON.data ) : wp.i18n.__( 'Error saving the event!', 'gp-translation-events' );
+						$gp.notices.error( msg );
+					},
 				}
 			);
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -160,7 +160,12 @@ function submit_event_ajax() {
 		}
 	}
 	if ( ! $is_nonce_valid ) {
-		wp_send_json_error( 'Nonce verification failed' );
+		wp_send_json_error( 'Nonce verification failed', 403 );
+	}
+	// This is a list of slugs that are not allowed, as they conflict with the event URLs.
+	$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
+	if ( isset( $_POST['event_title'] ) && in_array( sanitize_title( wp_unslash( $_POST['event_title'] ) ), $invalid_slugs, true ) ) {
+		wp_send_json_error( 'Invalid slug', 403 );
 	}
 
 	$title          = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
@@ -336,10 +341,10 @@ add_filter( 'gp_nav_menu_items', 'Wporg\TranslationEvents\gp_event_nav_menu_item
  *
  * Generate a slug based on the event title if it's not provided.
  *
- * @param array $data    An array of slashed post data.
+ * @param array $data An array of slashed post data.
  * @return array The modified post data.
  */
-function generate_event_slug( $data ) {
+function generate_event_slug( array $data ): array {
 	if ( 'event' === $data['post_type'] && 'draft' === $data['post_status'] ) {
 		if ( empty( $data['post_name'] ) ) {
 			$data['post_name'] = sanitize_title( $data['post_title'] );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -163,16 +163,15 @@ function submit_event_ajax() {
 		wp_send_json_error( 'Nonce verification failed', 403 );
 	}
 	// This is a list of slugs that are not allowed, as they conflict with the event URLs.
-	$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
-	if ( isset( $_POST['event_title'] ) && in_array( sanitize_title( wp_unslash( $_POST['event_title'] ) ), $invalid_slugs, true ) ) {
-		wp_send_json_error( 'Invalid slug', 403 );
-	}
-
+	$invalid_slugs  = array( 'new', 'edit', 'attend', 'my-events' );
 	$title          = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
 	$description    = isset( $_POST['event_description'] ) ? sanitize_text_field( wp_unslash( $_POST['event_description'] ) ) : '';
 	$event_start    = isset( $_POST['event_start'] ) ? sanitize_text_field( wp_unslash( $_POST['event_start'] ) ) : '';
 	$event_end      = isset( $_POST['event_end'] ) ? sanitize_text_field( wp_unslash( $_POST['event_end'] ) ) : '';
 	$event_timezone = isset( $_POST['event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['event_timezone'] ) ) : '';
+	if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
+		wp_send_json_error( 'Invalid slug', 403 );
+	}
 
 	$is_valid_event_date = false;
 	try {


### PR DESCRIPTION
Currently, we can create events with some problematic URLs, used in the routes:
- new
- edit
- attend
- my-events

This PR adds a check to avoid the creation of events with these titles:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/60151668-0ee1-4f87-aca3-9b6b3a25f97e)


Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/89.