### PR TITLE
Show a bar with the events to which the user contributes

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -150,10 +150,14 @@ span.event-label-draft, span.event-details-join-expired, span.active-events-befo
 	border-radius: 1em;
 	text-transform: capitalize;
 }
+span.active-events-before-translation-table a {
+	color: var( --gp-color-bubble-inactive-project-text );
+	text-decoration: none;
+}
 .active-events-before-translation-table {
 	width: 100%;
-	border: 1px solid var( --gp-color-btn-active-border );
-	background: var( --gp-color-attention-emphasis );
+	border: 1px solid var( --gp-color-border-default );
+	background: var( --gp-color-status-waiting-subtle );
 	margin: 1rem 0;
 	padding: 0.3rem 0.8rem;
 }

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -121,10 +121,10 @@ h2.event_page_title {
 a.event-link-draft {
 	color:#80807f;
 }
-span.event-label-draft {
+span.event-label-draft, span.active-events-before-translation-table {
 	font-weight: 500;
-	color:#c05621;
-	border: 1px solid #c05621;
+	color: var( --gp-color-bubble-inactive-project-text );
+	border: 1px solid var( --gp-color-bubble-inactive-project-text );
 	font-size: .7em;
 	margin-right: 0.3em;
 	width: 6em;
@@ -132,4 +132,11 @@ span.event-label-draft {
 	padding: 0.2em 0.5em;
 	border-radius: 1em;
 	text-transform: capitalize;
+}
+.active-events-before-translation-table {
+	width: 100%;
+	border: 1px solid var( --gp-color-btn-active-border );
+	background: var( --gp-color-attention-emphasis );
+	margin: 1rem 0;
+	padding: 0.3rem 0.8rem;
 }

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -425,7 +425,8 @@ function add_active_events_current_user(): void {
 		}
 
 		$remaining_events = $number_of_events - 2;
- 		$content         .= '<span class="remaining-events">' . sprintf(esc_html__(' and %d more events.', 'gp-translation-events'), $remaining_events) . '</span>';
+		/* translators: %d: Number of remaining events */
+		$content .= '<span class="remaining-events">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</span>';
 
 	} else {
 		while ( $user_attending_events_query->have_posts() ) {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -452,18 +452,21 @@ function add_active_events_current_user(): void {
 		$counter = 0;
 		while ( $user_attending_events_query->have_posts() && $counter < 2 ) {
 			$user_attending_events_query->the_post();
-			$content .= '<span class="active-events-before-translation-table">' . get_the_title() . '</span>';
+			$url      = esc_url( gp_url( '/events/' . get_post_field( 'post_name', get_post() ) ) );
+			$content .= '<span class="active-events-before-translation-table"><a href="' . $url . '" target="_blank">' . get_the_title() . '</a></span>';
 			++$counter;
 		}
 
 		$remaining_events = $number_of_events - 2;
+		$url              = esc_url( gp_url( '/events/' ) );
 		/* translators: %d: Number of remaining events */
-		$content .= '<span class="remaining-events">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</span>';
+		$content .= '<span class="remaining-events"><a href="' . $url . '" target="_blank">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</a></span>';
 
 	} else {
 		while ( $user_attending_events_query->have_posts() ) {
 			$user_attending_events_query->the_post();
-			$content .= '<span class="active-events-before-translation-table">' . get_the_title() . '</span>';
+			$url      = esc_url( gp_url( '/events/' . get_post_field( 'post_name', get_post() ) ) );
+			$content .= '<span class="active-events-before-translation-table"><a href="' . $url . '" target="_blank">' . get_the_title() . '</a></span>';
 		}
 	}
 	$content .= '</div>';
@@ -477,6 +480,10 @@ function add_active_events_current_user(): void {
 			),
 			'span' => array(
 				'class' => array(),
+			),
+			'a'    => array(
+				'href'   => array(),
+				'target' => array(),
 			),
 		)
 	);


### PR DESCRIPTION
This PR adds a bar with the events to which the user contributes.

If the user contributes to up to 3 events, it displays all of them. If she contributes to more, it shows 2 and a text with the number of the other events to which he/she contributes.

### User who does not attend any event

![Translations   Galician   Akismet Anti-Spam   GlotPress 2024-02-20 11-21-07](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/03173a35-292d-4981-8e5d-4b0335fb57e8)

### User attending 1 event

![Translations   Galician   Akismet Anti-Spam   GlotPress 2024-02-20 11-17-24](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/de52e638-3503-4c4e-9ff3-cd0272ae1284)

### User attending 2 events

![Translations   Galician   Akismet Anti-Spam   GlotPress 2024-02-20 11-16-46](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f434862e-5ee5-45b0-b515-0246ef46c7b3)

### User attending 3 events

![Translations   Galician   Akismet Anti-Spam   GlotPress 2024-02-20 11-19-05](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/e54f22ed-d60f-4b7c-86ab-1c47c1b1db73)

### User attending more than 3 events

![Translations   Galician   Akismet Anti-Spam   GlotPress 2024-02-20 11-20-02](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/b84da5be-9b43-4b28-845a-fdc6a6100666)
 
This PR needs [this PR](https://github.com/GlotPress/GlotPress/pull/1792) to be approved.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/98.