### PR TITLE
Add the footer in some templates

### DIFF
--- a/templates/event.php
+++ b/templates/event.php
@@ -106,4 +106,5 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		</div>
 		<?php endif; ?>
 	</div>
-</div>
+<div class="clear"></div>
+<?php gp_tmpl_footer(); ?>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -83,5 +83,5 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<?php endif; ?>
 	</div>
 </form>
-
-</div>
+<div class="clear"></div>
+<?php gp_tmpl_footer(); ?>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -138,6 +138,5 @@ endif;
 		?>
 	</div>
 <?php endif; ?>
-</div>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -139,3 +139,5 @@ endif;
 	</div>
 <?php endif; ?>
 </div>
+<div class="clear"></div>
+<?php gp_tmpl_footer(); ?>

--- a/templates/events-user-created.php
+++ b/templates/events-user-created.php
@@ -67,4 +67,3 @@ else :
 endif;
 gp_tmpl_footer();
 ?>
-</div>


### PR DESCRIPTION
Some templates don't have a footer. This PR adds some footers in these templates.

## Event list

### Before

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/27a0d0f3-7140-4bc9-bce3-e77b40471e0f)

### After

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/9c52a491-d75f-471b-a269-406c5709b0de)

## My events

This template had a footer, but I have to remove a `</div>`, because the `gp_tmpl_footer()` function adds an extra `</div>` just at the beginning.

### Before

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/8967b593-0ea1-403c-9327-b7fb9c8d5dc4)

### After

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/eaf3999d-9ae5-4f1e-9d92-a2a713ce0d55)

## Show an event

### Before

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/3f01f208-c093-4369-abd0-26c635250f76)

### After

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/44d0be10-45fb-4ce4-b7d2-a67ba4197329)

## Create an event

### Before

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/8f962257-6188-4a51-978a-0bd78945f09e)

### After

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/78f12af0-0716-4bc8-b67b-8ddc9f84f137)

## Edit an event

### Before

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/a74da8c2-8112-4723-a0aa-4578a2d7fb4f)

### After

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/d2221b9a-c669-4e8a-9ce1-5f307d447e54)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/91.