### PR TITLE
Show time format based on locale

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -39,7 +39,7 @@
 .event-details-right {
 	width: 22%;
 	float: right;
-	padding: 1em;
+	padding-top: 1em;
 }
 .event-details-stats {
 	clear: both;
@@ -181,7 +181,7 @@ input[type="submit"].attending-btn {
 .event-details-date {
 	background: #f4f4f4;
 	color: #606161;
-	padding: 1em;
+	padding: .5em;
 	font-size: .9em;
 	line-height: 1.8em;
 	font-weight: 500;

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -144,7 +144,7 @@
 					const userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
 					const userLocalDateTime    = new Date( eventDateObj.getTime() - userTimezoneOffsetMs );
 
-					const options = {
+					const options      = {
 						weekday: 'short',
 						year: 'numeric',
 						month: 'short',

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -151,11 +151,9 @@
 						day: 'numeric',
 						hour: 'numeric',
 						minute: 'numeric',
-						hour12: true,
 						timeZoneName: 'short'
 					};
-
-					timeEl.textContent = userLocalDateTime.toLocaleString( 'en-US', options );
+					timeEl.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
 				}
 			);
 		}


### PR DESCRIPTION
Some locale use the 12-hour format while some use the 24-hour time format. In this PR, the time format is determined by the locale and not hardcoded.

**Before**
<img width="1424" alt="Screenshot 2024-02-21 at 14 36 35" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/878e9283-35c9-4e8a-ab18-783173c1ad5c">

**After** (de-De locale)
<img width="1434" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/2c9d90f7-f0a1-4742-b3b2-747794af27d0">
