### PR TITLE
Add the past events in the main template

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -76,8 +76,8 @@
 span.event-list-date {
 	display: block;
 	color: #939393;
-	font-size: .9em;
-	font-weight: bold;
+	font-size: .8em;
+	font-weight: normal;
 }
 span.event-list-date.events-i-am-attending {
 	font-size: .8em;

--- a/includes/route.php
+++ b/includes/route.php
@@ -66,7 +66,6 @@ class Route extends GP_Route {
 		$current_events_args  = array(
 			'post_type'            => 'event',
 			'posts_per_page'       => 10,
-			'current_events_paged' => $_current_events_paged,
 			'paged'                => $_current_events_paged,
 			'post_status'          => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -92,7 +91,6 @@ class Route extends GP_Route {
 		$upcoming_events_args  = array(
 			'post_type'             => 'event',
 			'posts_per_page'        => 10,
-			'upcoming_events_paged' => $_upcoming_events_paged,
 			'paged'                 => $_upcoming_events_paged,
 			'post_status'           => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -112,7 +110,6 @@ class Route extends GP_Route {
 		$past_events_args  = array(
 			'post_type'         => 'event',
 			'posts_per_page'    => 10,
-			'past_events_paged' => $_past_events_paged,
 			'paged'             => $_past_events_paged,
 			'post_status'       => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -134,7 +131,6 @@ class Route extends GP_Route {
 			'post_type'                   => 'event',
 			'post__in'                    => array_keys( $user_attending_events ),
 			'posts_per_page'              => 10,
-			'user_attending_events_paged' => $_user_attending_events_paged,
 			'paged'                       => $_user_attending_events_paged,
 			'post_status'                 => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -152,6 +148,7 @@ class Route extends GP_Route {
 			'order'                       => 'ASC',
 		);
 		$user_attending_events_query = new WP_Query( $user_attending_events_args );
+
 		$this->tmpl( 'events-list', get_defined_vars() );
 	}
 

--- a/includes/route.php
+++ b/includes/route.php
@@ -33,6 +33,7 @@ class Route extends GP_Route {
 
 		$_current_events_paged        = 1;
 		$_upcoming_events_paged       = 1;
+		$_past_events_paged           = 1;
 		$_user_attending_events_paged = 1;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
@@ -46,6 +47,12 @@ class Route extends GP_Route {
 			$value = sanitize_text_field( wp_unslash( $_GET['upcoming_events_paged'] ) );
 			if ( is_numeric( $value ) ) {
 				$_upcoming_events_paged = (int) $value;
+			}
+		}
+		if ( isset( $_GET['past_events_paged'] ) ) {
+			$value = sanitize_text_field( wp_unslash( $_GET['past_events_paged'] ) );
+			if ( is_numeric( $value ) ) {
+				$_past_events_paged = (int) $value;
 			}
 		}
 		if ( isset( $_GET['user_attending_events_paged'] ) ) {
@@ -101,6 +108,26 @@ class Route extends GP_Route {
 			'order'                 => 'ASC',
 		);
 		$upcoming_events_query = new WP_Query( $upcoming_events_args );
+
+		$past_events_args  = array(
+			'post_type'         => 'event',
+			'posts_per_page'    => 10,
+			'past_events_paged' => $_past_events_paged,
+			'paged'             => $_past_events_paged,
+			'post_status'       => 'publish',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'        => array(
+				array(
+					'key'     => '_event_end',
+					'value'   => $current_datetime_utc,
+					'compare' => '<',
+					'type'    => 'DATETIME',
+				),
+			),
+			'orderby'           => 'meta_value',
+			'order'             => 'ASC',
+		);
+		$past_events_query = new WP_Query( $past_events_args );
 
 		$user_attending_events      = get_user_meta( get_current_user_id(), self::USER_META_KEY_ATTENDING, true ) ?: array();
 		$user_attending_events_args = array(

--- a/includes/route.php
+++ b/includes/route.php
@@ -64,12 +64,12 @@ class Route extends GP_Route {
 		// phpcs:enable
 
 		$current_events_args  = array(
-			'post_type'            => 'event',
-			'posts_per_page'       => 10,
-			'paged'                => $_current_events_paged,
-			'post_status'          => 'publish',
+			'post_type'      => 'event',
+			'posts_per_page' => 10,
+			'paged'          => $_current_events_paged,
+			'post_status'    => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'           => array(
+			'meta_query'     => array(
 				array(
 					'key'     => '_event_start',
 					'value'   => $current_datetime_utc,
@@ -83,18 +83,18 @@ class Route extends GP_Route {
 					'type'    => 'DATETIME',
 				),
 			),
-			'orderby'              => 'meta_value',
-			'order'                => 'ASC',
+			'orderby'        => 'meta_value',
+			'order'          => 'ASC',
 		);
 		$current_events_query = new WP_Query( $current_events_args );
 
 		$upcoming_events_args  = array(
-			'post_type'             => 'event',
-			'posts_per_page'        => 10,
-			'paged'                 => $_upcoming_events_paged,
-			'post_status'           => 'publish',
+			'post_type'      => 'event',
+			'posts_per_page' => 10,
+			'paged'          => $_upcoming_events_paged,
+			'post_status'    => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'            => array(
+			'meta_query'     => array(
 				array(
 					'key'     => '_event_start',
 					'value'   => $current_datetime_utc,
@@ -102,18 +102,18 @@ class Route extends GP_Route {
 					'type'    => 'DATETIME',
 				),
 			),
-			'orderby'               => 'meta_value',
-			'order'                 => 'ASC',
+			'orderby'        => 'meta_value',
+			'order'          => 'ASC',
 		);
 		$upcoming_events_query = new WP_Query( $upcoming_events_args );
 
 		$past_events_args  = array(
-			'post_type'         => 'event',
-			'posts_per_page'    => 10,
-			'paged'             => $_past_events_paged,
-			'post_status'       => 'publish',
+			'post_type'      => 'event',
+			'posts_per_page' => 10,
+			'paged'          => $_past_events_paged,
+			'post_status'    => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'        => array(
+			'meta_query'     => array(
 				array(
 					'key'     => '_event_end',
 					'value'   => $current_datetime_utc,
@@ -121,20 +121,20 @@ class Route extends GP_Route {
 					'type'    => 'DATETIME',
 				),
 			),
-			'orderby'           => 'meta_value',
-			'order'             => 'ASC',
+			'orderby'        => 'meta_value',
+			'order'          => 'ASC',
 		);
 		$past_events_query = new WP_Query( $past_events_args );
 
 		$user_attending_events      = get_user_meta( get_current_user_id(), self::USER_META_KEY_ATTENDING, true ) ?: array();
 		$user_attending_events_args = array(
-			'post_type'                   => 'event',
-			'post__in'                    => array_keys( $user_attending_events ),
-			'posts_per_page'              => 10,
-			'paged'                       => $_user_attending_events_paged,
-			'post_status'                 => 'publish',
+			'post_type'      => 'event',
+			'post__in'       => array_keys( $user_attending_events ),
+			'posts_per_page' => 10,
+			'paged'          => $_user_attending_events_paged,
+			'post_status'    => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'                  => array(
+			'meta_query'     => array(
 				array(
 					'key'     => '_event_end',
 					'value'   => $current_datetime_utc,
@@ -143,9 +143,9 @@ class Route extends GP_Route {
 				),
 			),
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-			'meta_key'                    => '_event_start',
-			'orderby'                     => 'meta_value',
-			'order'                       => 'ASC',
+			'meta_key'       => '_event_start',
+			'orderby'        => 'meta_value',
+			'order'          => 'ASC',
 		);
 		$user_attending_events_query = new WP_Query( $user_attending_events_args );
 

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -10,19 +10,20 @@ use WP_Query;
 
 /** @var WP_Query $current_events_query */
 /** @var WP_Query $upcoming_events_query */
+/** @var WP_Query $past_events_query */
 
-gp_title( __( 'Translation Events' ) );
+gp_title( esc_html__( 'Translation Events', 'gp-translation-events' ) );
 gp_tmpl_header();
 gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 ?>
 
 <div class="event-page-wrapper">
-	<h2 class="event_page_title">Translation Events</h2>
+	<h1 class="event_page_title"><?php esc_html_e( 'Translation Events', 'gp-translation-events' ); ?></h1>
 <div class="event-left-col">
 <?php
 if ( $current_events_query->have_posts() ) :
 	?>
-	<h3>Current events</h3>
+	<h2><?php esc_html_e( 'Current events', 'gp-translation-events' ); ?></h2>
 	<ul class="event-list">
 		<?php
 		while ( $current_events_query->have_posts() ) :
@@ -57,7 +58,7 @@ if ( $current_events_query->have_posts() ) :
 endif;
 if ( $upcoming_events_query->have_posts() ) :
 	?>
-	<h3>Upcoming events</h3>
+	<h2><?php esc_html_e( 'Upcoming events', 'gp-translation-events' ); ?></h2>
 	<ul class="event-list">
 		<?php
 		while ( $upcoming_events_query->have_posts() ) :
@@ -89,9 +90,48 @@ if ( $upcoming_events_query->have_posts() ) :
 
 	wp_reset_postdata();
 endif;
+if ( $past_events_query->have_posts() ) :
+	?>
+	<h2><?php esc_html_e( 'Past events', 'gp-translation-events' ); ?></h2>
+	<ul class="event-list">
+		<?php
+		while ( $past_events_query->have_posts() ) :
+			$past_events_query->the_post();
+			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
+			$event_end   = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+			?>
+			<li class="event-list-item">
+				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
+				<?php if ( $event_start === $event_end ) : ?>
+					<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
+				<?php else : ?>
+					<span class="event-list-date"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
+				<?php endif; ?>
+				<?php the_excerpt(); ?>
+			</li>
+			<?php
+		endwhile;
+		?>
+	</ul>
 
-if ( 0 === $current_events_query->post_count && 0 === $upcoming_events_query->post_count ) :
-	echo 'No events found.';
+	<?php
+	echo wp_kses_post(
+		paginate_links(
+			array(
+				'total'     => $past_events_query->max_num_pages,
+				'current'   => max( 1, $past_events_query->query_vars['past_events_paged'] ),
+				'format'    => '?past_events_paged=%#%',
+				'prev_text' => '&laquo; Previous',
+				'next_text' => 'Next &raquo;',
+			)
+		) ?? ''
+	);
+
+	wp_reset_postdata();
+endif;
+
+if ( 0 === $current_events_query->post_count && 0 === $upcoming_events_query->post_count && 0 === $past_events_query->post_count ) :
+	esc_html_e( 'No events found.', 'gp-translation-events' );
 endif;
 ?>
 </div>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -46,7 +46,7 @@ if ( $current_events_query->have_posts() ) :
 		paginate_links(
 			array(
 				'total'     => $current_events_query->max_num_pages,
-				'current'   => max( 1, $current_events_query->query_vars['current_events_paged'] ),
+				'current'   => max( 1, $current_events_query->query_vars['paged'] ),
 				'format'    => '?current_events_paged=%#%',
 				'prev_text' => '&laquo; Previous',
 				'next_text' => 'Next &raquo;',
@@ -80,7 +80,7 @@ if ( $upcoming_events_query->have_posts() ) :
 		paginate_links(
 			array(
 				'total'     => $upcoming_events_query->max_num_pages,
-				'current'   => max( 1, $upcoming_events_query->query_vars['upcoming_events_paged'] ),
+				'current'   => max( 1, $upcoming_events_query->query_vars['paged'] ),
 				'format'    => '?upcoming_events_paged=%#%',
 				'prev_text' => '&laquo; Previous',
 				'next_text' => 'Next &raquo;',
@@ -119,7 +119,7 @@ if ( $past_events_query->have_posts() ) :
 		paginate_links(
 			array(
 				'total'     => $past_events_query->max_num_pages,
-				'current'   => max( 1, $past_events_query->query_vars['past_events_paged'] ),
+				'current'   => max( 1, $past_events_query->query_vars['paged'] ),
 				'format'    => '?past_events_paged=%#%',
 				'prev_text' => '&laquo; Previous',
 				'next_text' => 'Next &raquo;',
@@ -165,7 +165,7 @@ endif;
 					paginate_links(
 						array(
 							'total'     => $user_attending_events_query->max_num_pages,
-							'current'   => max( 1, $user_attending_events_query->query_vars['user_attending_events_paged'] ),
+							'current'   => max( 1, $user_attending_events_query->query_vars['paged'] ),
 							'format'    => '?user_attending_events_paged=%#%',
 							'prev_text' => '&laquo; Previous',
 							'next_text' => 'Next &raquo;',


### PR DESCRIPTION
This PR adds the "Past events" in the main template

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/83b579f3-423a-4ee0-b8c1-ed1f28a46be1)

It adds pagination (the next screenshot was taken with a pagination of 3 items per page).

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/71143a9e-71ca-475a-ab16-ce5c88f7279c)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/119.