### PR TITLE
Update the slug update logic and add a message for the published events to update their slug

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -64,6 +64,7 @@
 							$( '#event-id' ).val( response.data.eventId );
 							if ( eventStatus === 'publish' ) {
 								$( 'button[data-event-status="draft"]' ).hide();
+								$( '#published-update-text' ).show();
 								$( 'button[data-event-status="publish"]' ).text( 'Update Event' );
 							}
 							if ( eventStatus === 'draft' ) {

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -82,6 +82,31 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<button id="delete-button" class="button is-destructive delete-event" type="submit" name="submit" value="Delete" style="display: <?php echo esc_attr( $visibility_delete_button ); ?>">Delete Event</button>
 	<?php endif; ?>
 	</div>
+	<div class="clear"></div>
+	<div class="published-update-text">
+		<?php
+		$visibility_published_button = 'none';
+		if ( isset( $event_status ) && 'publish' === $event_status ) {
+			$visibility_published_button = 'block';
+		}
+		?>
+		<span id="published-update-text" style="display: <?php echo esc_attr( $visibility_published_button ); ?>">
+		<?php
+		$polyglots_slack_channel = 'https://wordpress.slack.com/archives/C02RP50LK';
+		echo wp_kses(
+		// translators: %s: Polyglots Slack channel URL.
+			sprintf( __( 'If you need to update the event slug, please, contact with an admin in the <a href="%s" target="_blank">Polyglots</a> channel in Slack.', 'gp-translation-events' ), $polyglots_slack_channel ),
+			array(
+				'a' => array(
+					'href'   => array(),
+					'target' => array(),
+				),
+
+			)
+		);
+		?>
+		</span>
+	</div>
 </form>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -384,8 +384,10 @@ function generate_event_slug( array $data, array $postarr ): array {
 		if ( 'publish' === $data['post_status'] ) {
 			if ( is_numeric( $postarr['ID'] ) && 0 !== $postarr['ID'] ) {
 				$post = get_post( $postarr['ID'] );
-				if ( 'draft' === $post->post_status ) {
-					$data['post_name'] = sanitize_title( $data['post_title'] );
+				if ( $post instanceof WP_Post ) {
+					if ( 'draft' === $post->post_status ) {
+						$data['post_name'] = sanitize_title( $data['post_title'] );
+					}
 				}
 			}
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -382,7 +382,7 @@ function generate_event_slug( array $data, array $postarr ): array {
 			$data['post_name'] = sanitize_title( $data['post_title'] );
 		}
 		if ( 'publish' === $data['post_status'] ) {
-			if ( is_numeric( $postarr['ID'] ) ) {
+			if ( is_numeric( $postarr['ID'] ) && 0 !== $postarr['ID'] ) {
 				$post = get_post( $postarr['ID'] );
 				if ( 'draft' === $post->post_status ) {
 					$data['post_name'] = sanitize_title( $data['post_title'] );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -366,24 +366,35 @@ function gp_event_nav_menu_items( array $items, string $location ): array {
 add_filter( 'gp_nav_menu_items', 'Wporg\TranslationEvents\gp_event_nav_menu_items', 10, 2 );
 
 /**
- * Generate a slug for the event post type when we save a draft event.
+ * Generate a slug for the event post type when we save a draft event or when we publish an event.
  *
- * Generate a slug based on the event title if it's not provided.
+ * Generate a slug based on the event title if:
+ * - The event is a draft.
+ * - The event is published and it was a draft just before.
  *
- * @param array $data An array of slashed post data.
+ * @param array $data    An array of slashed post data.
+ * @param array $postarr An array of sanitized, but otherwise unmodified post data.
  * @return array The modified post data.
  */
-function generate_event_slug( array $data ): array {
-	if ( 'event' === $data['post_type'] && 'draft' === $data['post_status'] ) {
-		if ( empty( $data['post_name'] ) ) {
+function generate_event_slug( array $data, array $postarr ): array {
+	if ( 'event' === $data['post_type'] ) {
+		if ( 'draft' === $data['post_status'] ) {
 			$data['post_name'] = sanitize_title( $data['post_title'] );
+		}
+		if ( 'publish' === $data['post_status'] ) {
+			if ( is_numeric( $postarr['ID'] ) ) {
+				$post = get_post( $postarr['ID'] );
+				if ( 'draft' === $post->post_status ) {
+					$data['post_name'] = sanitize_title( $data['post_title'] );
+				}
+			}
 		}
 	}
 
 	return $data;
 }
 
-add_filter( 'wp_insert_post_data', 'Wporg\TranslationEvents\generate_event_slug', 10, 1 );
+add_filter( 'wp_insert_post_data', 'Wporg\TranslationEvents\generate_event_slug', 10, 2 );
 
 add_action(
 	'gp_init',


### PR DESCRIPTION
This PR:

- Updates the slug generation, updating it with the title content only when:
  - The event status is `draft`.
  - The event status is `published` and it comes from a previous status of `draft`.
- Adds a message, only showed if the event status is `published` or just when its status changes from `draft`to `published`.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/b0cbcd95-b63f-4f2c-9b53-ef3a143ed027)

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/97.