### PR TITLE
Add missing closing div

### DIFF
--- a/templates/event.php
+++ b/templates/event.php
@@ -78,7 +78,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<summary>View stats summary in text </summary>
 		<p class="event-stats-text"><?php echo esc_html( sprintf( 'At the %s event, %d people contributed in %d languages (%s), translated %d strings and reviewed %d strings.', esc_html( $event_title ), esc_html( $event_stats->totals()->users ), count( $event_stats->rows() ), esc_html( implode( ',', array_keys( $event_stats->rows() ) ) ), esc_html( $event_stats->totals()->created ), esc_html( $event_stats->totals()->reviewed ) ) ); ?></p>
 	</details>
-<?php endif ?>
+	<?php endif ?>
 	</div>
 	<div class="event-details-right">
 		<div class="event-details-date">
@@ -108,5 +108,6 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		</div>
 		<?php endif; ?>
 	</div>
+</div>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -83,5 +83,6 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<?php endif; ?>
 	</div>
 </form>
+</div>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -178,5 +178,6 @@ endif;
 		?>
 	</div>
 <?php endif; ?>
+</div>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -114,5 +114,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	else :
 		echo 'No events found.';
 	endif;
-	gp_tmpl_footer();
 	?>
+</div>
+<?php
+	gp_tmpl_footer();
+?>


### PR DESCRIPTION
Make footer full-width by adding the missing closing `</div>`

**Before**
<img width="1676" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/6bc850d0-25e5-486e-8077-d28bb9147ec4">


**After**
<img width="1674" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/cb354027-6a37-4295-95a9-c5cd4103141f">
