### PR TITLE
Enable the event creation, update and delete only to administrators

### DIFF
--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -1,13 +1,24 @@
 <?php
 namespace Wporg\TranslationEvents;
 
+use GP;
 ?>
 
 <div class="event-list-top-bar">
 	<ul class="event-list-nav">
 		<?php if ( is_user_logged_in() ) : ?>
 			<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
-			<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+			<?php
+			/**
+			 * Filter the ability to create, edit, or delete an event.
+			 *
+			 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
+			 */
+			$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
+			if ( $can_crud_event ) :
+				?>
+				<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+			<?php endif; ?>
 		<?php endif; ?>
 	</ul>
 </div>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -24,7 +24,6 @@ use Exception;
 use GP;
 use WP_Post;
 use WP_Query;
-use function Symfony\Component\VarDumper\Dumper\esc;
 
 /**
  * Check if a slug is being used by another post type.


### PR DESCRIPTION
This PR:
- Enables the event creation, update and delete only to administrators.
- Adds a hook to overwrite it.
- Updates some validations and strings, to be able to translate them.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/136.