### PR TITLE
Don't add link to Events breadcrumb base if no extra items

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -515,7 +515,9 @@ add_action( 'gp_before_translation_table', 'Wporg\TranslationEvents\add_active_e
  * @return string   HTML of the breadcrumb.
  */
 function gp_breadcrumb_translation_events( $extra_items = array() ) {
-	$breadcrumb = array( gp_link_get( gp_url( '/events' ), __( 'Events' ) ) );
+	$breadcrumb = array(
+		empty( $extra_items ) ? __( 'Events', 'gp-translation-events' ) : gp_link_get( gp_url( '/events' ), __( 'Events', 'gp-translation-events' ) ),
+	);
 	if ( ! empty( $extra_items ) ) {
 		$breadcrumb = array_merge( $breadcrumb, $extra_items );
 	}


### PR DESCRIPTION
Remove breadcrumb "Events" base link when no extra items added.

![imagem](https://github.com/WordPress/wporg-gp-translation-events/assets/7371591/aeba0685-497e-49c6-bd61-263ebbde322f)
![imagem](https://github.com/WordPress/wporg-gp-translation-events/assets/7371591/f4dab45b-f2a6-465e-911a-cc22f368f499)
![imagem](https://github.com/WordPress/wporg-gp-translation-events/assets/7371591/e94e158a-93ac-4b49-8c12-ca64de66c4e0)

Fixes #141 