### PR TITLE
Check if the start and end dates have been filled in

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -37,6 +37,14 @@
 		 * @param isDraft	  Whether the current event status is a draft or not
 		 */
 		function handleSubmit( eventStatus, isDraft ) {
+			if ( '' === $( '#event-start' ).val() ) {
+				$gp.notices.error( 'Event start date and time must be set.' );
+				return;
+			}
+			if ( '' === $( '#event-end' ).val() ) {
+				$gp.notices.error( 'Event end date and time must be set.' );
+				return;
+			}
 			if ( $( '#event-end' ).val() <= $( '#event-start' ).val() ) {
 				$gp.notices.error( 'Event end date and time must be later than event start date and time.' );
 				return;


### PR DESCRIPTION
Creating a new event, if you are using Chrome or another Chromium browser, when you select the start and end date, the hour is selected by default to the current one.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/e86aac92-0eea-478c-9060-3a1a622fe789)

If you use Firefox, these hours are not set by default.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/4c9ab239-5ed7-4129-a504-704b02d1d92a)

If you try to create an event without start or end time, you will get the "Event end date and time must be later than event start date and time." error.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/3a974306-dffa-4b3e-bc0e-9b3938d62ffd)

This PR checks if both dates are completed, returning and error if one of them are not set. 

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/140. 