### PR TITLE
Proposal: Event repository

### DIFF
--- a/includes/active-events-cache.php
+++ b/includes/active-events-cache.php
@@ -3,6 +3,7 @@
 namespace Wporg\TranslationEvents;
 
 use Exception;
+use Wporg\TranslationEvents\Event\Event;
 
 class Active_Events_Cache {
 	public const CACHE_DURATION = 60 * 60 * 24; // 24 hours.

--- a/includes/active-events-cache.php
+++ b/includes/active-events-cache.php
@@ -6,7 +6,7 @@ use Exception;
 use Wporg\TranslationEvents\Event\Event;
 
 class Active_Events_Cache {
-	public const CACHE_DURATION = 60 * 60 * 24; // 24 hours.
+	public const CACHE_DURATION = DAY_IN_SECONDS;
 	private const KEY           = 'translation-events-active-events';
 
 	/**

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -20,8 +20,8 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->invalidate_cache();
 	}
 
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
-		$this->assert_pagination_arguments( $current_page, $page_size );
+	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$this->assert_pagination_arguments( $page, $page_size );
 
 		$cache_duration = self::CACHE_DURATION;
 		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
@@ -46,16 +46,16 @@ class Event_Repository_Cached extends Event_Repository {
 			)
 		);
 
-		if ( $current_page > 0 && $page_size > 0 ) {
+		if ( $page > 0 && $page_size > 0 ) {
 			// Convert from 1-indexed to 0-indexed.
-			--$current_page;
+			--$page;
 			$pages = array_chunk( $events, $page_size );
 		} else {
-			$current_page = 0;
-			$pages        = array( $events );
+			$page  = 0;
+			$pages = array( $events );
 		}
 
-		return new Events_Query_Result( $pages[ $current_page ], count( $pages ) );
+		return new Events_Query_Result( $pages[ $page ], count( $pages ) );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -46,7 +46,7 @@ class Event_Repository_Cached extends Event_Repository {
 
 		// TODO: paginate results.
 
-		return new Event_Query_Result( $events );
+		return new Event_Query_Result( $events, 1 );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -20,7 +20,7 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->invalidate_cache();
 	}
 
-	public function get_current_events(): Event_Query_Result {
+	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		$cache_duration = self::CACHE_DURATION;
 		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$boundary_start = $now;
@@ -43,6 +43,8 @@ class Event_Repository_Cached extends Event_Repository {
 				}
 			)
 		);
+
+		// TODO: paginate results.
 
 		return new Event_Query_Result( $events );
 	}

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -20,7 +20,7 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->invalidate_cache();
 	}
 
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 
 		$cache_duration = self::CACHE_DURATION;
@@ -55,7 +55,7 @@ class Event_Repository_Cached extends Event_Repository {
 			$pages        = array( $events );
 		}
 
-		return new Event_Query_Result( $pages[ $current_page ], count( $pages ) );
+		return new Events_Query_Result( $pages[ $current_page ], count( $pages ) );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -21,9 +21,14 @@ class Event_Repository_Cached extends Event_Repository {
 		return $event_id_or_error;
 	}
 
-	public function update_event( Event $event ): void {
-		parent::update_event( $event );
+	public function update_event( Event $event ) {
+		$event_id_or_error = parent::update_event( $event );
+		if ( $event_id_or_error instanceof WP_Error ) {
+			return $event_id_or_error;
+		}
+
 		$this->invalidate_cache();
+		return $event_id_or_error;
 	}
 
 	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -5,6 +5,9 @@ namespace Wporg\TranslationEvents\Event;
 use DateTimeImmutable;
 
 class Event_Repository_Cached implements Event_Repository_Interface {
+	private const CACHE_DURATION    = 60 * 60 * 24; // 24 hours.
+	private const ACTIVE_EVENTS_KEY = 'translation-events-active-events';
+
 	private Event_Repository $repository;
 
 	public function __construct( Event_Repository $repository ) {
@@ -12,10 +15,12 @@ class Event_Repository_Cached implements Event_Repository_Interface {
 	}
 
 	public function create_event( Event $event ): void {
+		$this->invalidate_cache();
 		$this->repository->create_event( $event );
 	}
 
 	public function update_event( Event $event ): void {
+		$this->invalidate_cache();
 		$this->repository->update_event( $event );
 	}
 
@@ -25,5 +30,9 @@ class Event_Repository_Cached implements Event_Repository_Interface {
 
 	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
 		return $this->repository->get_active_events( $boundary_start, $boundary_end );
+	}
+
+	private function invalidate_cache(): void {
+		wp_cache_delete( self::ACTIVE_EVENTS_KEY );
 	}
 }

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wporg\TranslationEvents\Event;
+
+use DateTimeImmutable;
+
+class Event_Repository_Cached implements Event_Repository_Interface {
+	private Event_Repository $repository;
+
+	public function __construct( Event_Repository $repository ) {
+		$this->repository = $repository;
+	}
+
+	public function create_event( Event $event ): void {
+		$this->repository->create_event( $event );
+	}
+
+	public function update_event( Event $event ): void {
+		$this->repository->update_event( $event );
+	}
+
+	public function get_event( int $id ): Event {
+		return $this->repository->get_event( $id );
+	}
+
+	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
+		return $this->repository->get_active_events( $boundary_start, $boundary_end );
+	}
+}

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -31,6 +31,11 @@ class Event_Repository_Cached extends Event_Repository {
 		return $event_id_or_error;
 	}
 
+	public function delete_event( Event $event ) {
+		parent::delete_event( $event );
+		$this->invalidate_cache();
+	}
+
 	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $page, $page_size );
 

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -20,7 +20,7 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->invalidate_cache();
 	}
 
-	public function get_current_events(): array {
+	public function get_current_events(): Event_Query_Result {
 		$cache_duration = self::CACHE_DURATION;
 		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$boundary_start = $now;
@@ -35,7 +35,7 @@ class Event_Repository_Cached extends Event_Repository {
 		}
 
 		// Filter out events that aren't actually active at $at.
-		return array_values(
+		$events = array_values(
 			array_filter(
 				$events,
 				function ( $event ) use ( $now ) {
@@ -43,6 +43,8 @@ class Event_Repository_Cached extends Event_Repository {
 				}
 			)
 		);
+
+		return new Event_Query_Result( $events );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -7,7 +7,7 @@ use DateTimeZone;
 use Exception;
 
 class Event_Repository_Cached extends Event_Repository {
-	private const CACHE_DURATION    = 60 * 60 * 24; // 24 hours.
+	private const CACHE_DURATION    = DAY_IN_SECONDS;
 	private const ACTIVE_EVENTS_KEY = 'translation-events-active-events';
 
 	public function create_event( Event $event ): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -28,7 +28,7 @@ class Event_Repository_Cached extends Event_Repository {
 
 		$events = wp_cache_get( self::ACTIVE_EVENTS_KEY, '', false, $found );
 		if ( ! $found ) {
-			$events = $this->get_events_between( $boundary_start, $boundary_end );
+			$events = $this->get_events_between( $boundary_start, $boundary_end )->events;
 			wp_cache_set( self::ACTIVE_EVENTS_KEY, $events, '', self::CACHE_DURATION );
 		} elseif ( ! is_array( $events ) ) {
 			throw new Exception( 'Cached events is not an array, something is wrong' );

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -30,7 +30,7 @@ class Event_Repository_Cached extends Event_Repository {
 
 		$events = wp_cache_get( self::ACTIVE_EVENTS_KEY, '', false, $found );
 		if ( ! $found ) {
-			$events = $this->get_events_between( $boundary_start, $boundary_end )->events;
+			$events = $this->get_events_active_between( $boundary_start, $boundary_end )->events;
 			wp_cache_set( self::ACTIVE_EVENTS_KEY, $events, '', self::CACHE_DURATION );
 		} elseif ( ! is_array( $events ) ) {
 			throw new Exception( 'Cached events is not an array, something is wrong' );

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -2,6 +2,10 @@
 
 namespace Wporg\TranslationEvents\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
 class Event_Repository_Cached extends Event_Repository {
 	private const CACHE_DURATION    = 60 * 60 * 24; // 24 hours.
 	private const ACTIVE_EVENTS_KEY = 'translation-events-active-events';
@@ -14,6 +18,31 @@ class Event_Repository_Cached extends Event_Repository {
 	public function update_event( Event $event ): void {
 		parent::update_event( $event );
 		$this->invalidate_cache();
+	}
+
+	public function get_active_events(): array {
+		$cache_duration = self::CACHE_DURATION;
+		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$boundary_start = $now;
+		$boundary_end   = $now->modify( "+$cache_duration seconds" );
+
+		$events = wp_cache_get( self::ACTIVE_EVENTS_KEY, '', false, $found );
+		if ( ! $found ) {
+			$events = $this->get_events_between( $boundary_start, $boundary_end );
+			wp_cache_set( self::ACTIVE_EVENTS_KEY, $events, '', self::CACHE_DURATION );
+		} elseif ( ! is_array( $events ) ) {
+			throw new Exception( 'Cached events is not an array, something is wrong' );
+		}
+
+		// Filter out events that aren't actually active at $at.
+		return array_values(
+			array_filter(
+				$events,
+				function ( $event ) use ( $now ) {
+					return $event->start() <= $now && $now <= $event->end();
+				}
+			)
+		);
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -21,6 +21,8 @@ class Event_Repository_Cached extends Event_Repository {
 	}
 
 	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+		$this->assert_pagination_arguments( $current_page, $page_size );
+
 		$cache_duration = self::CACHE_DURATION;
 		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$boundary_start = $now;

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -20,7 +20,7 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->invalidate_cache();
 	}
 
-	public function get_active_events(): array {
+	public function get_current_events(): array {
 		$cache_duration = self::CACHE_DURATION;
 		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$boundary_start = $now;

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -5,14 +5,20 @@ namespace Wporg\TranslationEvents\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
+use WP_Error;
 
 class Event_Repository_Cached extends Event_Repository {
 	private const CACHE_DURATION    = DAY_IN_SECONDS;
 	private const ACTIVE_EVENTS_KEY = 'translation-events-active-events';
 
-	public function create_event( Event $event ): void {
-		parent::create_event( $event );
+	public function insert_event( Event $event ) {
+		$event_id_or_error = parent::insert_event( $event );
+		if ( $event_id_or_error instanceof WP_Error ) {
+			return $event_id_or_error;
+		}
+
 		$this->invalidate_cache();
+		return $event_id_or_error;
 	}
 
 	public function update_event( Event $event ): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -2,34 +2,18 @@
 
 namespace Wporg\TranslationEvents\Event;
 
-use DateTimeImmutable;
-
-class Event_Repository_Cached implements Event_Repository_Interface {
+class Event_Repository_Cached extends Event_Repository {
 	private const CACHE_DURATION    = 60 * 60 * 24; // 24 hours.
 	private const ACTIVE_EVENTS_KEY = 'translation-events-active-events';
 
-	private Event_Repository $repository;
-
-	public function __construct( Event_Repository $repository ) {
-		$this->repository = $repository;
-	}
-
 	public function create_event( Event $event ): void {
+		parent::create_event( $event );
 		$this->invalidate_cache();
-		$this->repository->create_event( $event );
 	}
 
 	public function update_event( Event $event ): void {
+		parent::update_event( $event );
 		$this->invalidate_cache();
-		$this->repository->update_event( $event );
-	}
-
-	public function get_event( int $id ): Event {
-		return $this->repository->get_event( $id );
-	}
-
-	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
-		return $this->repository->get_active_events( $boundary_start, $boundary_end );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -46,9 +46,16 @@ class Event_Repository_Cached extends Event_Repository {
 			)
 		);
 
-		// TODO: paginate results.
+		if ( $current_page > 0 && $page_size > 0 ) {
+			// Convert from 1-indexed to 0-indexed.
+			--$current_page;
+			$pages = array_chunk( $events, $page_size );
+		} else {
+			$current_page = 0;
+			$pages        = array( $events );
+		}
 
-		return new Event_Query_Result( $events, 1 );
+		return new Event_Query_Result( $pages[ $current_page ], count( $pages ) );
 	}
 
 	private function invalidate_cache(): void {

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -4,6 +4,7 @@ namespace Wporg\TranslationEvents\Event;
 
 use Exception;
 use Throwable;
+use WP_Error;
 
 class EventNotFound extends Exception {
 	public function __construct( Throwable $previous = null ) {
@@ -11,14 +12,15 @@ class EventNotFound extends Exception {
 	}
 }
 
-class CreateEventFailed extends Exception {}
 class UpdateEventFailed extends Exception {}
 
 interface Event_Repository_Interface {
 	/**
-	 * @throws CreateEventFailed
+	 * @param Event $event Event to insert.
+	 *
+	 * @return int|WP_Error The id of the inserted event, or an error.
 	 */
-	public function create_event( Event $event ): void;
+	public function insert_event( Event $event );
 
 	/**
 	 * @throws UpdateEventFailed

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -35,5 +35,5 @@ interface Event_Repository_Interface {
 	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array;
+	public function get_active_events(): array;
 }

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -34,25 +34,25 @@ interface Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
+	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
+	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
+	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
+	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
 }
 
-class Event_Query_Result {
+class Events_Query_Result {
 	/**
 	 * @var Event[]
 	 */

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -3,14 +3,7 @@
 namespace Wporg\TranslationEvents\Event;
 
 use Exception;
-use Throwable;
 use WP_Error;
-
-class EventNotFound extends Exception {
-	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Event not found', 0, $previous );
-	}
-}
 
 interface Event_Repository_Interface {
 	/**
@@ -34,10 +27,7 @@ interface Event_Repository_Interface {
 	 */
 	public function delete_event( Event $event );
 
-	/**
-	 * @throws EventNotFound
-	 */
-	public function get_event( int $id ): Event;
+	public function get_event( int $id ): ?Event;
 
 	/**
 	 * @throws Exception

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -35,5 +35,5 @@ interface Event_Repository_Interface {
 	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_active_events(): array;
+	public function get_current_events(): array;
 }

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -28,6 +28,13 @@ interface Event_Repository_Interface {
 	public function update_event( Event $event );
 
 	/**
+	 * @param Event $event Event to delete.
+	 *
+	 * @return Event|false Deleted event or false on error.
+	 */
+	public function delete_event( Event $event );
+
+	/**
 	 * @throws EventNotFound
 	 */
 	public function get_event( int $id ): Event;

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -39,17 +39,17 @@ interface Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events_for_user( int $user_id ): Event_Query_Result;
+	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_past_events_for_user( int $user_id ): Event_Query_Result;
+	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_events_created_by_user( int $user_id ): Event_Query_Result;
+	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
 }
 
 class Event_Query_Result {

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\TranslationEvents\Event;
 
-use DateTimeImmutable;
 use Exception;
 use Throwable;
 

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -58,7 +58,10 @@ class Event_Query_Result {
 	 */
 	public array $events;
 
-	public function __construct( array $events ) {
-		$this->events = $events;
+	public int $page_count;
+
+	public function __construct( array $events, int $page_count ) {
+		$this->events     = $events;
+		$this->page_count = $page_count;
 	}
 }

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -34,7 +34,7 @@ interface Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events(): Event_Query_Result;
+	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result;
 
 	/**
 	 * @throws Exception

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -33,22 +33,22 @@ interface Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
+	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
+	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
+	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
 	 * @throws Exception
 	 */
-	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result;
+	public function get_events_created_by_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 }
 
 class Events_Query_Result {

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wporg\TranslationEvents\Event;
+
+use DateTimeImmutable;
+use Exception;
+use Throwable;
+
+class EventNotFound extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event not found', 0, $previous );
+	}
+}
+
+class CreateEventFailed extends Exception {}
+class UpdateEventFailed extends Exception {}
+
+interface Event_Repository_Interface {
+	/**
+	 * @throws CreateEventFailed
+	 */
+	public function create_event( Event $event ): void;
+
+	/**
+	 * @throws UpdateEventFailed
+	 */
+	public function update_event( Event $event ): void;
+
+	/**
+	 * @throws EventNotFound
+	 */
+	public function get_event( int $id ): Event;
+
+	/**
+	 * @return Event[]
+	 * @throws Exception
+	 */
+	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array;
+}

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -61,7 +61,9 @@ class Event_Query_Result {
 	public int $page_count;
 
 	public function __construct( array $events, int $page_count ) {
-		$this->events     = $events;
-		$this->page_count = $page_count;
+		$this->events = $events;
+
+		// The call to intval() is required because WP_Query::max_num_pages is sometimes a float, despite being type-hinted as int.
+		$this->page_count = intval( $page_count );
 	}
 }

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -36,4 +36,22 @@ interface Event_Repository_Interface {
 	 * @throws Exception
 	 */
 	public function get_current_events(): array;
+
+	/**
+	 * @return Event[]
+	 * @throws Exception
+	 */
+	public function get_current_events_for_user( int $user_id ): array;
+
+	/**
+	 * @return Event[]
+	 * @throws Exception
+	 */
+	public function get_past_events_for_user( int $user_id ): array;
+
+	/**
+	 * @return Event[]
+	 * @throws Exception
+	 */
+	public function get_events_created_by_user( int $user_id ): array;
 }

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -12,8 +12,6 @@ class EventNotFound extends Exception {
 	}
 }
 
-class UpdateEventFailed extends Exception {}
-
 interface Event_Repository_Interface {
 	/**
 	 * @param Event $event Event to insert.
@@ -23,9 +21,11 @@ interface Event_Repository_Interface {
 	public function insert_event( Event $event );
 
 	/**
-	 * @throws UpdateEventFailed
+	 * @param Event $event Event to update.
+	 *
+	 * @return int|WP_Error The id of the updated event, or an error.
 	 */
-	public function update_event( Event $event ): void;
+	public function update_event( Event $event );
 
 	/**
 	 * @throws EventNotFound

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -7,6 +7,8 @@ use WP_Error;
 
 interface Event_Repository_Interface {
 	/**
+	 * Insert a new Event.
+	 *
 	 * @param Event $event Event to insert.
 	 *
 	 * @return int|WP_Error The id of the inserted event, or an error.
@@ -14,6 +16,8 @@ interface Event_Repository_Interface {
 	public function insert_event( Event $event );
 
 	/**
+	 * Update an Event.
+	 *
 	 * @param Event $event Event to update.
 	 *
 	 * @return int|WP_Error The id of the updated event, or an error.
@@ -21,30 +25,70 @@ interface Event_Repository_Interface {
 	public function update_event( Event $event );
 
 	/**
+	 * Delete an Event.
+	 *
 	 * @param Event $event Event to delete.
 	 *
 	 * @return Event|false Deleted event or false on error.
 	 */
 	public function delete_event( Event $event );
 
+	/**
+	 * Get an Event.
+	 *
+	 * @param int $id Event id.
+	 *
+	 * @return Event|null
+	 */
 	public function get_event( int $id ): ?Event;
 
 	/**
 	 * @throws Exception
 	 */
+
+	/**
+	 * Get events that are currently active.
+	 *
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
+	 * @throws Exception
+	 */
 	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
+	 * Get events that are currently active for a given user.
+	 *
+	 * @param int $user_id   Id of the user.
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
 	 * @throws Exception
 	 */
 	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
+	 * Get events that are no longer active for a given user.
+	 *
+	 * @param int $user_id   Id of the user.
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
 	 * @throws Exception
 	 */
 	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
+	 * Get events created by a given user.
+	 *
+	 * @param int $user_id   Id of the user.
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
 	 * @throws Exception
 	 */
 	public function get_events_created_by_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -32,26 +32,33 @@ interface Event_Repository_Interface {
 	public function get_event( int $id ): Event;
 
 	/**
-	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_current_events(): array;
+	public function get_current_events(): Event_Query_Result;
 
 	/**
-	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_current_events_for_user( int $user_id ): array;
+	public function get_current_events_for_user( int $user_id ): Event_Query_Result;
 
 	/**
-	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_past_events_for_user( int $user_id ): array;
+	public function get_past_events_for_user( int $user_id ): Event_Query_Result;
 
 	/**
-	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_events_created_by_user( int $user_id ): array;
+	public function get_events_created_by_user( int $user_id ): Event_Query_Result;
+}
+
+class Event_Query_Result {
+	/**
+	 * @var Event[]
+	 */
+	public array $events;
+
+	public function __construct( array $events ) {
+		$this->events = $events;
+	}
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -72,7 +72,7 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 	}
 
-	public function get_active_events(): array {
+	public function get_current_events(): array {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		return $this->get_events_between( $now, $now );
 	}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -72,23 +72,17 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 	}
 
-	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
+	public function get_active_events(): array {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		if ( null === $boundary_start ) {
-			$boundary_start = $now;
-		}
-
-		return $this->get_events_between( $boundary_start, $boundary_end );
+		return $this->get_events_between( $now, $now );
 	}
 
 	/**
 	 * @return Event[]
 	 * @throws Exception
 	 */
-	protected function get_events_between( DateTimeImmutable $boundary_start, DateTimeImmutable $boundary_end = null ): array {
-		if ( null === $boundary_end ) {
-			$boundary_end = $boundary_start;
-		} elseif ( $boundary_end < $boundary_start ) {
+	protected function get_events_between( DateTimeImmutable $boundary_start, DateTimeImmutable $boundary_end ): array {
+		if ( $boundary_end < $boundary_start ) {
 			throw new Exception( 'boundary end must be after boundary start' );
 		}
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -75,7 +75,7 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 	}
 
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
@@ -88,7 +88,7 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 	}
 
-	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 
 		$attending_array = get_user_meta( $user_id, self::USER_META_KEY_ATTENDING, true );
@@ -109,7 +109,7 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 	}
 
-	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 
 		$attending_array = get_user_meta( $user_id, self::USER_META_KEY_ATTENDING, true );
@@ -135,10 +135,10 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 	}
 
-	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 		// TODO.
-		return new Event_Query_Result( array(), 1 );
+		return new Events_Query_Result( array(), 1 );
 	}
 
 	/**
@@ -150,7 +150,7 @@ class Event_Repository implements Event_Repository_Interface {
 		array $filter_by_ids = array(),
 		int $current_page = -1,
 		int $page_size = -1
-	): Event_Query_Result {
+	): Events_Query_Result {
 		if ( $boundary_end < $boundary_start ) {
 			throw new Exception( 'boundary end must not be before boundary start' );
 		}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -9,9 +9,10 @@ use WP_Error;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Route;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {
-	private const POST_TYPE               = 'translation_event';
+	private const POST_TYPE               = Translation_Events::CPT;
 	private const USER_META_KEY_ATTENDING = Route::USER_META_KEY_ATTENDING;
 
 	public function create_event( Event $event ): void {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Exception;
 use WP_Error;
 use WP_Post;
+use WP_Query;
 
 class Event_Repository implements Event_Repository_Interface {
 	public function create_event( Event $event ): void {
@@ -106,7 +107,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		$ids = get_posts(
+		$query = new WP_Query(
 			array(
 				'post_type'      => 'event',
 				'post_status'    => 'publish',
@@ -133,8 +134,10 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 		// phpcs:enable
 
-		$events = array();
-		foreach ( $ids as $id ) {
+		$event_ids = $query->get_posts();
+		$events    = array();
+
+		foreach ( $event_ids as $id ) {
 			$post     = $this->get_event_post( $id );
 			$meta     = $this->get_event_meta( $id );
 			$events[] = new Event(

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -66,7 +66,7 @@ class Event_Repository implements Event_Repository_Interface {
 		return $event;
 	}
 
-	public function get_event( int $id ): Event {
+	public function get_event( int $id ): ?Event {
 		$post = $this->get_event_post( $id );
 
 		try {
@@ -84,7 +84,7 @@ class Event_Repository implements Event_Repository_Interface {
 		} catch ( Exception $e ) {
 			// This should not be possible as it means data in the database is invalid.
 			// So we consider an invalid event to be not found.
-			throw new EventNotFound();
+			return null;
 		}
 	}
 
@@ -272,19 +272,16 @@ class Event_Repository implements Event_Repository_Interface {
 		return new Events_Query_Result( $events, $query->max_num_pages );
 	}
 
-	/**
-	 * @throws EventNotFound
-	 */
-	private function get_event_post( int $event_id ): WP_Post {
+	private function get_event_post( int $event_id ): ?WP_Post {
 		if ( 0 === $event_id ) {
-			throw new EventNotFound();
+			return null;
 		}
 		$post = get_post( $event_id );
 		if ( ! ( $post instanceof WP_Post ) ) {
-			throw new EventNotFound();
+			return null;
 		}
 		if ( self::POST_TYPE !== $post->post_type ) {
-			throw new EventNotFound();
+			return null;
 		}
 
 		return $post;

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -133,7 +133,8 @@ class Event_Repository implements Event_Repository_Interface {
 					),
 				),
 				'meta_key'       => '_event_start',
-				'orderby'        => 'meta_value',
+				'meta_type'      => 'DATETIME',
+				'orderby'        => array( 'meta_value', 'ID' ),
 			),
 		);
 		// phpcs:enable

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -77,6 +77,21 @@ class Event_Repository implements Event_Repository_Interface {
 		return $this->get_events_between( $now, $now );
 	}
 
+	public function get_current_events_for_user( int $user_id ): array {
+		// TODO.
+		return array();
+	}
+
+	public function get_past_events_for_user( int $user_id ): array {
+		// TODO.
+		return array();
+	}
+
+	public function get_events_created_by_user( int $user_id ): array {
+		// TODO.
+		return array();
+	}
+
 	/**
 	 * @return Event[]
 	 * @throws Exception

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -11,7 +11,7 @@ use WP_Query;
 use Wporg\TranslationEvents\Route;
 
 class Event_Repository implements Event_Repository_Interface {
-	private const POST_TYPE               = 'event';
+	private const POST_TYPE               = 'translation_event';
 	private const USER_META_KEY_ATTENDING = Route::USER_META_KEY_ATTENDING;
 
 	public function create_event( Event $event ): void {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -73,7 +73,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return new Event_Query_Result( $this->get_events_between( $now, $now, $current_page, $page_size ) );
+		return $this->get_events_between( $now, $now, $current_page, $page_size );
 	}
 
 	public function get_current_events_for_user( int $user_id ): Event_Query_Result {
@@ -92,7 +92,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	/**
-	 * @return Event[]
 	 * @throws Exception
 	 */
 	protected function get_events_between(
@@ -100,7 +99,7 @@ class Event_Repository implements Event_Repository_Interface {
 		DateTimeImmutable $boundary_end,
 		int $current_page = -1,
 		int $page_size = -1
-	): array {
+	): Event_Query_Result {
 		if ( $boundary_end < $boundary_start ) {
 			throw new Exception( 'boundary end must be after boundary start' );
 		}
@@ -150,7 +149,7 @@ class Event_Repository implements Event_Repository_Interface {
 			);
 		}
 
-		return $events;
+		return new Event_Query_Result( $events );
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -54,7 +54,6 @@ class Event_Repository implements Event_Repository_Interface {
 
 		try {
 			$meta = $this->get_event_meta( $id );
-
 			return new Event(
 				$post->ID,
 				$meta['start'],
@@ -72,24 +71,24 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 	}
 
-	public function get_current_events(): array {
+	public function get_current_events(): Event_Query_Result {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return $this->get_events_between( $now, $now );
+		return new Event_Query_Result( $this->get_events_between( $now, $now ) );
 	}
 
-	public function get_current_events_for_user( int $user_id ): array {
+	public function get_current_events_for_user( int $user_id ): Event_Query_Result {
 		// TODO.
-		return array();
+		return new Event_Query_Result( array() );
 	}
 
-	public function get_past_events_for_user( int $user_id ): array {
+	public function get_past_events_for_user( int $user_id ): Event_Query_Result {
 		// TODO.
-		return array();
+		return new Event_Query_Result( array() );
 	}
 
-	public function get_events_created_by_user( int $user_id ): array {
+	public function get_events_created_by_user( int $user_id ): Event_Query_Result {
 		// TODO.
-		return array();
+		return new Event_Query_Result( array() );
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -206,25 +206,23 @@ class Event_Repository implements Event_Repository_Interface {
 	/**
 	 * @throws InvalidStartOrEnd
 	 * @throws InvalidTitle
-	 * @throws EventNotFound
 	 * @throws InvalidStatus
+	 * @throws Exception
 	 */
 	private function execute_events_query( array $args ): Events_Query_Result {
 		$args = array_replace_recursive(
 			$args,
 			array(
 				'post_type' => 'event',
-				'fields'    => 'ids',
 			),
 		);
 
-		$query     = new WP_Query( $args );
-		$event_ids = $query->get_posts();
-		$events    = array();
+		$query  = new WP_Query( $args );
+		$posts  = $query->get_posts();
+		$events = array();
 
-		foreach ( $event_ids as $id ) {
-			$post     = $this->get_event_post( $id );
-			$meta     = $this->get_event_meta( $id );
+		foreach ( $posts as $post ) {
+			$meta     = $this->get_event_meta( $post->ID );
 			$events[] = new Event(
 				$post->ID,
 				$meta['start'],

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -152,8 +152,7 @@ class Event_Repository implements Event_Repository_Interface {
 			);
 		}
 
-		// The call to intval() is required because max_num_pages is sometimes a float, despite being type-hinted as int.
-		return new Event_Query_Result( $events, intval( $query->max_num_pages ) );
+		return new Event_Query_Result( $events, $query->max_num_pages );
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -94,7 +94,18 @@ class Event_Repository {
 	 * @return Event[]
 	 * @throws Exception
 	 */
-	public function get_active_events( DateTimeImmutable $boundary_start, DateTimeImmutable $boundary_end ): array {
+	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		if ( null === $boundary_start ) {
+			$boundary_start = $now;
+		}
+		if ( null === $boundary_end ) {
+			$boundary_end = $boundary_start;
+		}
+		if ( $boundary_end < $boundary_start ) {
+			throw new Exception( 'boundary end must be after boundary start' );
+		}
+
 		$ids = get_posts(
 			array(
 				'post_type'      => 'event',
@@ -133,6 +144,13 @@ class Event_Repository {
 				$post->post_content,
 			);
 		}
+
+		usort(
+			$events,
+			function ( Event $a, Event $b ) {
+				return $a->id() <=> $b->id();
+			}
+		);
 
 		return $events;
 	}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -9,7 +9,6 @@ use WP_Error;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee_Repository;
-use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -15,12 +15,6 @@ class EventNotFound extends Exception {
 	}
 }
 
-class InvalidTimezone extends Exception {
-	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Invalid timezone', 0, $previous );
-	}
-}
-
 class CreateEventFailed extends Exception {}
 
 class Event_Repository {
@@ -53,7 +47,6 @@ class Event_Repository {
 
 	/**
 	 * @throws EventNotFound
-	 * @throws InvalidTimezone
 	 */
 	public function get_event( int $id ): Event {
 		if ( 0 === $id ) {
@@ -75,12 +68,6 @@ class Event_Repository {
 
 		try {
 			$timezone = new DateTimeZone( $meta['_event_timezone'][0] );
-		} catch ( Exception $e ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new InvalidTimezone( $e );
-		}
-
-		try {
 			return new Event(
 				$post->ID,
 				$start,

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -55,6 +55,10 @@ class Event_Repository {
 			$start,
 			$end,
 			$timezone,
+			$post->post_name,
+			$post->post_status,
+			$post->post_title,
+			$post->post_content,
 		);
 	}
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -79,7 +79,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$this->assert_pagination_arguments( $current_page, $page_size );
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		return $this->get_events_between(
+		return $this->get_events_active_between(
 			$now,
 			$now,
 			array(),
@@ -100,7 +100,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$event_ids_user_is_attending = array_keys( $attending_array );
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return $this->get_events_between(
+		return $this->get_events_active_between(
 			$now,
 			$now,
 			$event_ids_user_is_attending,
@@ -126,7 +126,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$boundary_start = $boundary_start->setDate( 2024, 1, 1 )->setTime( 0, 0 );
 		$boundary_end   = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		return $this->get_events_between(
+		return $this->get_events_active_between(
 			$boundary_start,
 			$boundary_end,
 			$event_ids_user_is_attending,
@@ -144,7 +144,7 @@ class Event_Repository implements Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	protected function get_events_between(
+	protected function get_events_active_between(
 		DateTimeImmutable $boundary_start,
 		DateTimeImmutable $boundary_end,
 		array $filter_by_ids = array(),

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -76,17 +76,17 @@ class Event_Repository implements Event_Repository_Interface {
 		return $this->get_events_between( $now, $now, $current_page, $page_size );
 	}
 
-	public function get_current_events_for_user( int $user_id ): Event_Query_Result {
+	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
 		return new Event_Query_Result( array() );
 	}
 
-	public function get_past_events_for_user( int $user_id ): Event_Query_Result {
+	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
 		return new Event_Query_Result( array() );
 	}
 
-	public function get_events_created_by_user( int $user_id ): Event_Query_Result {
+	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
 		return new Event_Query_Result( array() );
 	}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -50,16 +50,22 @@ class Event_Repository {
 			throw new InvalidTimezone( $e );
 		}
 
-		return new Event(
-			$post->ID,
-			$start,
-			$end,
-			$timezone,
-			$post->post_name,
-			$post->post_status,
-			$post->post_title,
-			$post->post_content,
-		);
+		try {
+			return new Event(
+				$post->ID,
+				$start,
+				$end,
+				$timezone,
+				$post->post_name,
+				$post->post_status,
+				$post->post_title,
+				$post->post_content,
+			);
+		} catch ( Exception $e ) {
+			// This should not be possible as it means data in the database is invalid.
+			// So we consider an invalid event to be not found.
+			throw new EventNotFound();
+		}
 	}
 
 	private static function parse_utc_datetime( string $datetime ): DateTimeImmutable {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -73,21 +73,25 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+		$this->assert_pagination_arguments( $current_page, $page_size );
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		return $this->get_events_between( $now, $now, $current_page, $page_size );
 	}
 
 	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+		$this->assert_pagination_arguments( $current_page, $page_size );
 		// TODO.
 		return new Event_Query_Result( array(), 1 );
 	}
 
 	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+		$this->assert_pagination_arguments( $current_page, $page_size );
 		// TODO.
 		return new Event_Query_Result( array(), 1 );
 	}
 
 	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
+		$this->assert_pagination_arguments( $current_page, $page_size );
 		// TODO.
 		return new Event_Query_Result( array(), 1 );
 	}
@@ -153,6 +157,18 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 
 		return new Event_Query_Result( $events, $query->max_num_pages );
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	protected function assert_pagination_arguments( int $current_page, int $page_size ) {
+		if ( -1 !== $current_page && $current_page <= 0 ) {
+			throw new Exception( 'current page must be greater than 0' );
+		}
+		if ( -1 !== $page_size && $page_size <= 0 ) {
+			throw new Exception( 'page size must be greater than 0' );
+		}
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -79,17 +79,17 @@ class Event_Repository implements Event_Repository_Interface {
 
 	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
-		return new Event_Query_Result( array() );
+		return new Event_Query_Result( array(), 1 );
 	}
 
 	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
-		return new Event_Query_Result( array() );
+		return new Event_Query_Result( array(), 1 );
 	}
 
 	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Event_Query_Result {
 		// TODO.
-		return new Event_Query_Result( array() );
+		return new Event_Query_Result( array(), 1 );
 	}
 
 	/**
@@ -152,7 +152,8 @@ class Event_Repository implements Event_Repository_Interface {
 			);
 		}
 
-		return new Event_Query_Result( $events );
+		// The call to intval() is required because max_num_pages is sometimes a float, despite being type-hinted as int.
+		return new Event_Query_Result( $events, intval( $query->max_num_pages ) );
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -170,6 +170,9 @@ class Event_Repository implements Event_Repository_Interface {
 		if ( -1 !== $page_size && $page_size <= 0 ) {
 			throw new Exception( 'page size must be greater than 0' );
 		}
+		if ( $page_size > 0 && -1 === $current_page ) {
+			throw new Exception( 'if page size is specified, current page must also be' );
+		}
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -54,6 +54,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 		try {
 			$meta = $this->get_event_meta( $id );
+
 			return new Event(
 				$post->ID,
 				$meta['start'],
@@ -76,10 +77,18 @@ class Event_Repository implements Event_Repository_Interface {
 		if ( null === $boundary_start ) {
 			$boundary_start = $now;
 		}
+
+		return $this->get_events_between( $boundary_start, $boundary_end );
+	}
+
+	/**
+	 * @return Event[]
+	 * @throws Exception
+	 */
+	protected function get_events_between( DateTimeImmutable $boundary_start, DateTimeImmutable $boundary_end = null ): array {
 		if ( null === $boundary_end ) {
 			$boundary_end = $boundary_start;
-		}
-		if ( $boundary_end < $boundary_start ) {
+		} elseif ( $boundary_end < $boundary_start ) {
 			throw new Exception( 'boundary end must be after boundary start' );
 		}
 
@@ -146,6 +155,7 @@ class Event_Repository implements Event_Repository_Interface {
 		if ( 'event' !== $post->post_type ) {
 			throw new EventNotFound();
 		}
+
 		return $post;
 	}
 
@@ -154,6 +164,7 @@ class Event_Repository implements Event_Repository_Interface {
 	 */
 	private function get_event_meta( int $event_id ): array {
 		$meta = get_post_meta( $event_id );
+
 		return array(
 			'start'    => self::parse_utc_datetime( $meta['_event_start'][0] ),
 			'end'      => self::parse_utc_datetime( $meta['_event_end'][0] ),
@@ -173,6 +184,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 	private static function serialize_datetime( DateTimeImmutable $value ): string {
 		$value->setTimezone( new DateTimeZone( 'UTC' ) );
+
 		return $value->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -2,5 +2,37 @@
 
 namespace Wporg\TranslationEvents\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use Throwable;
+use WP_Post;
+
+class EventNotFound extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event not found', 0, $previous );
+	}
+}
+
 class Event_Repository {
+	/**
+	 * @throws EventNotFound
+	 */
+	public static function get_event( int $id ): ?Event {
+		if ( 0 === $id ) {
+			throw new EventNotFound();
+		}
+
+		$post = get_post( $id );
+		if ( ! ( $post instanceof WP_Post ) ) {
+			throw new EventNotFound();
+		}
+
+		if ( 'event' !== $post->post_type ) {
+			throw new EventNotFound();
+		}
+
+		// TODO: return an actual event.
+		return null;
+	}
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -5,24 +5,11 @@ namespace Wporg\TranslationEvents\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-use Throwable;
 use WP_Error;
 use WP_Post;
 
-class EventNotFound extends Exception {
-	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Event not found', 0, $previous );
-	}
-}
-
-class CreateEventFailed extends Exception {}
-class UpdateEventFailed extends Exception {}
-
-class Event_Repository {
-	/**
-	 * @throws CreateEventFailed
-	 */
-	public function create_event( Event $event ) {
+class Event_Repository implements Event_Repository_Interface {
+	public function create_event( Event $event ): void {
 		$event_id = wp_insert_post(
 			array(
 				'post_type'    => 'event',
@@ -43,10 +30,7 @@ class Event_Repository {
 		$this->update_event_meta( $event );
 	}
 
-	/**
-	 * @throws UpdateEventFailed
-	 */
-	public function update_event( Event $event ) {
+	public function update_event( Event $event ): void {
 		$error = wp_update_post(
 			array(
 				'ID'           => $event->id(),
@@ -65,9 +49,6 @@ class Event_Repository {
 		$this->update_event_meta( $event );
 	}
 
-	/**
-	 * @throws EventNotFound
-	 */
 	public function get_event( int $id ): Event {
 		$post = $this->get_event_post( $id );
 
@@ -90,10 +71,6 @@ class Event_Repository {
 		}
 	}
 
-	/**
-	 * @return Event[]
-	 * @throws Exception
-	 */
 	public function get_active_events( DateTimeImmutable $boundary_start = null, DateTimeImmutable $boundary_end = null ): array {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		if ( null === $boundary_start ) {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -53,7 +53,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$post = $this->get_event_post( $id );
 
 		try {
-			$meta = $this->get_event_post_meta( $id );
+			$meta = $this->get_event_meta( $id );
 			return new Event(
 				$post->ID,
 				$meta['start'],
@@ -109,7 +109,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$events = array();
 		foreach ( $ids as $id ) {
 			$post     = $this->get_event_post( $id );
-			$meta     = $this->get_event_post_meta( $id );
+			$meta     = $this->get_event_meta( $id );
 			$events[] = new Event(
 				$post->ID,
 				$meta['start'],
@@ -152,7 +152,7 @@ class Event_Repository implements Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	private function get_event_post_meta( int $event_id ): array {
+	private function get_event_meta( int $event_id ): array {
 		$meta = get_post_meta( $event_id );
 		return array(
 			'start'    => self::parse_utc_datetime( $meta['_event_start'][0] ),

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Wporg\TranslationEvents\Event;
+
+class Event_Repository {
+}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -306,18 +306,16 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	private function update_event_meta( Event $event ) {
-		update_post_meta( $event->id(), '_event_start', self::serialize_datetime( $event->start() ) );
-		update_post_meta( $event->id(), '_event_end', self::serialize_datetime( $event->end() ) );
+		update_post_meta( $event->id(), '_event_start', $this->serialize_utc_datetime( $event->start() ) );
+		update_post_meta( $event->id(), '_event_end', $this->serialize_utc_datetime( $event->end() ) );
 		update_post_meta( $event->id(), '_event_timezone', $event->timezone()->getName() );
 	}
 
-	private static function parse_utc_datetime( string $datetime ): DateTimeImmutable {
+	private function parse_utc_datetime( string $datetime ): DateTimeImmutable {
 		return DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $datetime, new DateTimeZone( 'UTC' ) );
 	}
 
-	private static function serialize_datetime( DateTimeImmutable $value ): string {
-		$value->setTimezone( new DateTimeZone( 'UTC' ) );
-
+	private function serialize_utc_datetime( DateTimeImmutable $value ): string {
 		return $value->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -39,8 +39,8 @@ class Event_Repository implements Event_Repository_Interface {
 		return $event->id();
 	}
 
-	public function update_event( Event $event ): void {
-		$error = wp_update_post(
+	public function update_event( Event $event ) {
+		$event_id_or_error = wp_update_post(
 			array(
 				'ID'           => $event->id(),
 				'post_name'    => $event->slug(),
@@ -49,13 +49,12 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_status'  => $event->status(),
 			)
 		);
-
-		if ( $error instanceof WP_Error ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new UpdateEventFailed( $error->get_error_message(), $error->get_error_code() );
+		if ( $event_id_or_error instanceof WP_Error ) {
+			return $event_id_or_error;
 		}
 
 		$this->update_event_meta( $event );
+		return $event->id();
 	}
 
 	public function get_event( int $id ): Event {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -20,8 +20,8 @@ class Event_Repository implements Event_Repository_Interface {
 		$this->attendee_repository = $attendee_repository;
 	}
 
-	public function create_event( Event $event ): void {
-		$event_id = wp_insert_post(
+	public function insert_event( Event $event ) {
+		$event_id_or_error = wp_insert_post(
 			array(
 				'post_type'    => self::POST_TYPE,
 				'post_name'    => $event->slug(),
@@ -30,15 +30,13 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_status'  => $event->status(),
 			)
 		);
-
-		if ( $event_id instanceof WP_Error ) {
-			$error = $event_id;
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new CreateEventFailed( $error->get_error_message(), $error->get_error_code() );
+		if ( $event_id_or_error instanceof WP_Error ) {
+			return $event_id_or_error;
 		}
 
-		$event->set_id( $event_id );
+		$event->set_id( $event_id_or_error );
 		$this->update_event_meta( $event );
+		return $event->id();
 	}
 
 	public function update_event( Event $event ): void {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -9,6 +9,7 @@ use WP_Error;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {
@@ -55,6 +56,14 @@ class Event_Repository implements Event_Repository_Interface {
 
 		$this->update_event_meta( $event );
 		return $event->id();
+	}
+
+	public function delete_event( Event $event ) {
+		$result = wp_trash_post( $event->id() );
+		if ( ! $result ) {
+			return false;
+		}
+		return $event;
 	}
 
 	public function get_event( int $id ): Event {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -161,8 +161,20 @@ class Event_Repository implements Event_Repository_Interface {
 
 	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
 		$this->assert_pagination_arguments( $current_page, $page_size );
-		// TODO.
-		return new Events_Query_Result( array(), 1 );
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		return $this->execute_events_query(
+			array(
+				'post_status'    => array( 'publish', 'draft' ),
+				'author'         => $user_id,
+				'paged'          => $current_page,
+				'posts_per_page' => $page_size,
+				'meta_key'       => '_event_start',
+				'orderby'        => array( 'meta_value', 'ID' ),
+				'order'          => 'DESC',
+			)
+		);
+		// phpcs:enable
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -76,21 +76,21 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 	}
 
-	public function get_current_events( int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
-		$this->assert_pagination_arguments( $current_page, $page_size );
+	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$this->assert_pagination_arguments( $page, $page_size );
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->get_events_active_between(
 			$now,
 			$now,
 			array(),
-			$current_page,
+			$page,
 			$page_size
 		);
 	}
 
-	public function get_current_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
-		$this->assert_pagination_arguments( $current_page, $page_size );
+	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$this->assert_pagination_arguments( $page, $page_size );
 
 		$attending_array = get_user_meta( $user_id, self::USER_META_KEY_ATTENDING, true );
 		if ( ! $attending_array ) {
@@ -105,13 +105,13 @@ class Event_Repository implements Event_Repository_Interface {
 			$now,
 			$now,
 			$event_ids_user_is_attending,
-			$current_page,
+			$page,
 			$page_size
 		);
 	}
 
-	public function get_past_events_for_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
-		$this->assert_pagination_arguments( $current_page, $page_size );
+	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$this->assert_pagination_arguments( $page, $page_size );
 
 		$attending_array = get_user_meta( $user_id, self::USER_META_KEY_ATTENDING, true );
 		if ( ! $attending_array ) {
@@ -134,7 +134,7 @@ class Event_Repository implements Event_Repository_Interface {
 			array(
 				'post_status'    => 'publish',
 				'post__in'       => $event_ids_user_is_attending,
-				'paged'          => $current_page,
+				'paged'          => $page,
 				'posts_per_page' => $page_size,
 				'meta_query'     => array(
 					array(
@@ -159,15 +159,15 @@ class Event_Repository implements Event_Repository_Interface {
 		// phpcs:enable
 	}
 
-	public function get_events_created_by_user( int $user_id, int $current_page = -1, int $page_size = -1 ): Events_Query_Result {
-		$this->assert_pagination_arguments( $current_page, $page_size );
+	public function get_events_created_by_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$this->assert_pagination_arguments( $page, $page_size );
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
 			array(
 				'post_status'    => array( 'publish', 'draft' ),
 				'author'         => $user_id,
-				'paged'          => $current_page,
+				'paged'          => $page,
 				'posts_per_page' => $page_size,
 				'meta_key'       => '_event_start',
 				'orderby'        => array( 'meta_value', 'ID' ),
@@ -184,7 +184,7 @@ class Event_Repository implements Event_Repository_Interface {
 		DateTimeImmutable $boundary_start,
 		DateTimeImmutable $boundary_end,
 		array $filter_by_ids = array(),
-		int $current_page = -1,
+		int $page = -1,
 		int $page_size = -1
 	): Events_Query_Result {
 		if ( $boundary_end < $boundary_start ) {
@@ -195,7 +195,7 @@ class Event_Repository implements Event_Repository_Interface {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		$query_args = array(
 			'post_status'    => 'publish',
-			'paged'          => $current_page,
+			'paged'          => $page,
 			'posts_per_page' => $page_size,
 			'meta_query'     => array(
 				array(
@@ -227,15 +227,15 @@ class Event_Repository implements Event_Repository_Interface {
 	/**
 	 * @throws Exception
 	 */
-	protected function assert_pagination_arguments( int $current_page, int $page_size ) {
-		if ( -1 !== $current_page && $current_page <= 0 ) {
-			throw new Exception( 'current page must be greater than 0' );
+	protected function assert_pagination_arguments( int $page, int $page_size ) {
+		if ( -1 !== $page && $page <= 0 ) {
+			throw new Exception( 'page must be greater than 0' );
 		}
 		if ( -1 !== $page_size && $page_size <= 0 ) {
 			throw new Exception( 'page size must be greater than 0' );
 		}
-		if ( $page_size > 0 && -1 === $current_page ) {
-			throw new Exception( 'if page size is specified, current page must also be' );
+		if ( $page_size > 0 && -1 === $page ) {
+			throw new Exception( 'if page size is specified, page must also be' );
 		}
 	}
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -11,12 +11,13 @@ use WP_Query;
 use Wporg\TranslationEvents\Route;
 
 class Event_Repository implements Event_Repository_Interface {
+	private const POST_TYPE               = 'event';
 	private const USER_META_KEY_ATTENDING = Route::USER_META_KEY_ATTENDING;
 
 	public function create_event( Event $event ): void {
 		$event_id = wp_insert_post(
 			array(
-				'post_type'    => 'event',
+				'post_type'    => self::POST_TYPE,
 				'post_name'    => $event->slug(),
 				'post_title'   => $event->title(),
 				'post_content' => $event->description(),
@@ -236,7 +237,7 @@ class Event_Repository implements Event_Repository_Interface {
 		$args = array_replace_recursive(
 			$args,
 			array(
-				'post_type' => 'event',
+				'post_type' => self::POST_TYPE,
 			),
 		);
 
@@ -272,7 +273,7 @@ class Event_Repository implements Event_Repository_Interface {
 		if ( ! ( $post instanceof WP_Post ) ) {
 			throw new EventNotFound();
 		}
-		if ( 'event' !== $post->post_type ) {
+		if ( self::POST_TYPE !== $post->post_type ) {
 			throw new EventNotFound();
 		}
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -8,12 +8,11 @@ use Exception;
 use WP_Error;
 use WP_Post;
 use WP_Query;
-use Wporg\TranslationEvents\Route;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {
 	private const POST_TYPE               = Translation_Events::CPT;
-	private const USER_META_KEY_ATTENDING = Route::USER_META_KEY_ATTENDING;
+	private const USER_META_KEY_ATTENDING = Translation_Events::USER_META_KEY_ATTENDING;
 
 	public function create_event( Event $event ): void {
 		$event_id = wp_insert_post(

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -5,6 +5,13 @@ namespace Wporg\TranslationEvents\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
+use Throwable;
+
+class InvalidStartOrEnd extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event end must be after start', 0, $previous );
+	}
+}
 
 class Event {
 	private int $id;
@@ -38,6 +45,9 @@ class Event {
 		);
 	}
 
+	/**
+	 * @throws InvalidStartOrEnd
+	 */
 	public function __construct(
 		int $id,
 		DateTimeImmutable $start,
@@ -48,6 +58,10 @@ class Event {
 		string $title,
 		string $description
 	) {
+		if ( $end <= $start ) {
+			throw new InvalidStartOrEnd();
+		}
+
 		$this->id          = $id;
 		$this->start       = $start;
 		$this->end         = $end;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -25,6 +25,12 @@ class InvalidTitle extends Exception {
 	}
 }
 
+class InvalidStatus extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event status is invalid', 0, $previous );
+	}
+}
+
 class Event {
 	private int $id;
 	private DateTimeImmutable $start;
@@ -50,8 +56,8 @@ class Event {
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
-			'foo-slug', // TODO: this function will be removed, this here so tests pass.
-			'',
+			'foo-slug',  // TODO: this function will be removed, this here so tests pass.
+			'publish',   // TODO: this function will be removed, this here so tests pass.
 			'Foo title', // TODO: this function will be removed, this here so tests pass.
 			''
 		);
@@ -61,6 +67,7 @@ class Event {
 	 * @throws InvalidStartOrEnd
 	 * @throws InvalidTitle
 	 * @throws InvalidSlug
+	 * @throws InvalidStatus
 	 */
 	public function __construct(
 		int $id,
@@ -80,6 +87,9 @@ class Event {
 		}
 		if ( ! $title ) {
 			throw new InvalidTitle();
+		}
+		if ( ! in_array( $status, array( 'draft', 'publish' ), true ) ) {
+			throw new InvalidStatus();
 		}
 
 		$this->id          = $id;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -30,7 +30,7 @@ class Event {
 		);
 	}
 
-	private function __construct( int $id, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeZone $timezone ) {
+	public function __construct( int $id, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeZone $timezone ) {
 		$this->id       = $id;
 		$this->start    = $start;
 		$this->end      = $end;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -13,12 +13,6 @@ class InvalidStartOrEnd extends Exception {
 	}
 }
 
-class InvalidSlug extends Exception {
-	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Event slug is invalid', 0, $previous );
-	}
-}
-
 class InvalidTitle extends Exception {
 	public function __construct( Throwable $previous = null ) {
 		parent::__construct( 'Event title is invalid', 0, $previous );
@@ -66,7 +60,6 @@ class Event {
 	/**
 	 * @throws InvalidStartOrEnd
 	 * @throws InvalidStatus
-	 * @throws InvalidSlug
 	 * @throws InvalidTitle
 	 */
 	public function __construct(
@@ -79,10 +72,11 @@ class Event {
 		string $title,
 		string $description
 	) {
+		$this->slug = $slug;
+
 		$this->set_id( $id );
 		$this->set_times( $start, $end );
 		$this->set_timezone( $timezone );
-		$this->set_slug( $slug );
 		$this->set_status( $status );
 		$this->set_title( $title );
 		$this->set_description( $description );
@@ -135,16 +129,6 @@ class Event {
 
 	public function set_timezone( DateTimeZone $timezone ): void {
 		$this->timezone = $timezone;
-	}
-
-	/**
-	 * @throws InvalidSlug
-	 */
-	public function set_slug( string $slug ): void {
-		if ( ! $slug ) {
-			throw new InvalidSlug();
-		}
-		$this->slug = $slug;
 	}
 
 	/**

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -13,6 +13,18 @@ class InvalidStartOrEnd extends Exception {
 	}
 }
 
+class InvalidSlug extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event slug is invalid', 0, $previous );
+	}
+}
+
+class InvalidTitle extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event title is invalid', 0, $previous );
+	}
+}
+
 class Event {
 	private int $id;
 	private DateTimeImmutable $start;
@@ -38,15 +50,17 @@ class Event {
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
+			'foo-slug', // TODO: this function will be removed, this here so tests pass.
 			'',
-			'',
-			'',
+			'Foo title', // TODO: this function will be removed, this here so tests pass.
 			''
 		);
 	}
 
 	/**
 	 * @throws InvalidStartOrEnd
+	 * @throws InvalidTitle
+	 * @throws InvalidSlug
 	 */
 	public function __construct(
 		int $id,
@@ -60,6 +74,12 @@ class Event {
 	) {
 		if ( $end <= $start ) {
 			throw new InvalidStartOrEnd();
+		}
+		if ( ! $slug ) {
+			throw new InvalidSlug();
+		}
+		if ( ! $title ) {
+			throw new InvalidTitle();
 		}
 
 		$this->id          = $id;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -65,9 +65,9 @@ class Event {
 
 	/**
 	 * @throws InvalidStartOrEnd
-	 * @throws InvalidTitle
-	 * @throws InvalidSlug
 	 * @throws InvalidStatus
+	 * @throws InvalidSlug
+	 * @throws InvalidTitle
 	 */
 	public function __construct(
 		int $id,
@@ -79,33 +79,16 @@ class Event {
 		string $title,
 		string $description
 	) {
-		if ( $end <= $start ) {
-			throw new InvalidStartOrEnd();
-		}
-		if ( ! $start->getTimezone() || 'UTC' !== $start->getTimezone()->getName() ) {
-			throw new InvalidStartOrEnd();
-		}
-		if ( ! $end->getTimezone() || 'UTC' !== $end->getTimezone()->getName() ) {
-			throw new InvalidStartOrEnd();
-		}
-		if ( ! $slug ) {
-			throw new InvalidSlug();
-		}
-		if ( ! $title ) {
-			throw new InvalidTitle();
-		}
-		if ( ! in_array( $status, array( 'draft', 'publish' ), true ) ) {
-			throw new InvalidStatus();
-		}
+		$this->validate_times( $start, $end );
 
-		$this->id          = $id;
-		$this->start       = $start;
-		$this->end         = $end;
-		$this->timezone    = $timezone;
-		$this->slug        = $slug;
-		$this->status      = $status;
-		$this->title       = $title;
-		$this->description = $description;
+		$this->set_id( $id );
+		$this->set_start( $start );
+		$this->set_end( $end );
+		$this->set_timezone( $timezone );
+		$this->set_slug( $slug );
+		$this->set_status( $status );
+		$this->set_title( $title );
+		$this->set_description( $description );
 	}
 
 	public function id(): int {
@@ -156,15 +139,33 @@ class Event {
 		$this->timezone = $timezone;
 	}
 
+	/**
+	 * @throws InvalidSlug
+	 */
 	public function set_slug( string $slug ): void {
+		if ( ! $slug ) {
+			throw new InvalidSlug();
+		}
 		$this->slug = $slug;
 	}
 
+	/**
+	 * @throws InvalidStatus
+	 */
 	public function set_status( string $status ): void {
+		if ( ! in_array( $status, array( 'draft', 'publish' ), true ) ) {
+			throw new InvalidStatus();
+		}
 		$this->status = $status;
 	}
 
+	/**
+	 * @throws InvalidTitle
+	 */
 	public function set_title( string $title ): void {
+		if ( ! $title ) {
+			throw new InvalidTitle();
+		}
 		$this->title = $title;
 	}
 
@@ -196,5 +197,20 @@ class Event {
 		}
 
 		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
+	}
+
+	/**
+	 * @throws InvalidStartOrEnd
+	 */
+	private function validate_times( DateTimeImmutable $start, DateTimeImmutable $end ) {
+		if ( $end <= $start ) {
+			throw new InvalidStartOrEnd();
+		}
+		if ( ! $start->getTimezone() || 'UTC' !== $start->getTimezone()->getName() ) {
+			throw new InvalidStartOrEnd();
+		}
+		if ( ! $end->getTimezone() || 'UTC' !== $end->getTimezone()->getName() ) {
+			throw new InvalidStartOrEnd();
+		}
 	}
 }

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class InvalidStartOrEnd extends Exception {
 	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Event end must be after start', 0, $previous );
+		parent::__construct( 'Event start or end are invalid', 0, $previous );
 	}
 }
 
@@ -80,6 +80,12 @@ class Event {
 		string $description
 	) {
 		if ( $end <= $start ) {
+			throw new InvalidStartOrEnd();
+		}
+		if ( ! $start->getTimezone() || 'UTC' !== $start->getTimezone()->getName() ) {
+			throw new InvalidStartOrEnd();
+		}
+		if ( ! $end->getTimezone() || 'UTC' !== $end->getTimezone()->getName() ) {
 			throw new InvalidStartOrEnd();
 		}
 		if ( ! $slug ) {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -56,9 +56,9 @@ class Event {
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
-			'foo-slug',  // TODO: this function will be removed, this here so tests pass.
-			'publish',   // TODO: this function will be removed, this here so tests pass.
-			'Foo title', // TODO: this function will be removed, this here so tests pass.
+			'foo-slug',  // TODO: this function will be removed, this is here so tests pass.
+			'publish',   // TODO: this function will be removed, this is here so tests pass.
+			'Foo title', // TODO: this function will be removed, this is here so tests pass.
 			''
 		);
 	}
@@ -112,10 +112,6 @@ class Event {
 		return $this->id;
 	}
 
-	public function set_id( int $id ): void {
-		$this->id = $id;
-	}
-
 	public function start(): DateTimeImmutable {
 		return $this->start;
 	}
@@ -142,6 +138,38 @@ class Event {
 
 	public function description(): string {
 		return $this->description;
+	}
+
+	public function set_id( int $id ): void {
+		$this->id = $id;
+	}
+
+	public function set_start( DateTimeImmutable $start ): void {
+		$this->start = $start;
+	}
+
+	public function set_end( DateTimeImmutable $end ): void {
+		$this->end = $end;
+	}
+
+	public function set_timezone( DateTimeZone $timezone ): void {
+		$this->timezone = $timezone;
+	}
+
+	public function set_slug( string $slug ): void {
+		$this->slug = $slug;
+	}
+
+	public function set_status( string $status ): void {
+		$this->status = $status;
+	}
+
+	public function set_title( string $title ): void {
+		$this->title = $title;
+	}
+
+	public function set_description( string $description ): void {
+		$this->description = $description;
 	}
 
 	/**

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -11,6 +11,10 @@ class Event {
 	private DateTimeImmutable $start;
 	private DateTimeImmutable $end;
 	private DateTimeZone $timezone;
+	private string $slug;
+	private string $status;
+	private string $title;
+	private string $description;
 
 	/**
 	 * Make an Event from post meta.
@@ -27,14 +31,31 @@ class Event {
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
+			'',
+			'',
+			'',
+			''
 		);
 	}
 
-	public function __construct( int $id, DateTimeImmutable $start, DateTimeImmutable $end, DateTimeZone $timezone ) {
-		$this->id       = $id;
-		$this->start    = $start;
-		$this->end      = $end;
-		$this->timezone = $timezone;
+	public function __construct(
+		int $id,
+		DateTimeImmutable $start,
+		DateTimeImmutable $end,
+		DateTimeZone $timezone,
+		string $slug,
+		string $status,
+		string $title,
+		string $description
+	) {
+		$this->id          = $id;
+		$this->start       = $start;
+		$this->end         = $end;
+		$this->timezone    = $timezone;
+		$this->slug        = $slug;
+		$this->status      = $status;
+		$this->title       = $title;
+		$this->description = $description;
 	}
 
 	public function id(): int {
@@ -51,6 +72,22 @@ class Event {
 
 	public function timezone(): DateTimeZone {
 		return $this->timezone;
+	}
+
+	public function slug(): string {
+		return $this->slug;
+	}
+
+	public function status(): string {
+		return $this->status;
+	}
+
+	public function title(): string {
+		return $this->title;
+	}
+
+	public function description(): string {
+		return $this->description;
 	}
 
 	/**
@@ -75,6 +112,7 @@ class Event {
 			/* translators: %s: Number of hours left. */
 			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
 		}
+
 		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
 	}
 }

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -106,6 +106,10 @@ class Event {
 		return $this->id;
 	}
 
+	public function set_id( int $id ): void {
+		$this->id = $id;
+	}
+
 	public function start(): DateTimeImmutable {
 		return $this->start;
 	}

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -79,11 +79,8 @@ class Event {
 		string $title,
 		string $description
 	) {
-		$this->validate_times( $start, $end );
-
 		$this->set_id( $id );
-		$this->set_start( $start );
-		$this->set_end( $end );
+		$this->set_times( $start, $end );
 		$this->set_timezone( $timezone );
 		$this->set_slug( $slug );
 		$this->set_status( $status );
@@ -127,12 +124,13 @@ class Event {
 		$this->id = $id;
 	}
 
-	public function set_start( DateTimeImmutable $start ): void {
+	/**
+	 * @throws InvalidStartOrEnd
+	 */
+	public function set_times( DateTimeImmutable $start, DateTimeImmutable $end ): void {
+		$this->validate_times( $start, $end );
 		$this->start = $start;
-	}
-
-	public function set_end( DateTimeImmutable $end ): void {
-		$this->end = $end;
+		$this->end   = $end;
 	}
 
 	public function set_timezone( DateTimeZone $timezone ): void {

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Exception;
 use GP_Translation;
 use GP_Translation_Set;
+use Wporg\TranslationEvents\Event\Event;
 
 class Stats_Listener {
 	const ACTION_CREATE          = 'create';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,7 @@
         <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
         <exclude name="Squiz.Commenting.VariableComment.Missing"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
         <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
         <exclude name="Generic.Files.OneObjectStructurePerFile.MultipleFound"/>
         <exclude name="Universal.Operators.DisallowShortTernary.Found"/>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -7,6 +7,7 @@ namespace Wporg\TranslationEvents;
 
 use DateTime;
 use WP_Query;
+use Wporg\TranslationEvents\Event\Event;
 
 /** @var WP_Query $current_events_query */
 /** @var WP_Query $upcoming_events_query */

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -36,4 +36,31 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		$events = $this->repository->get_active_events( $now->modify( '+10 years' ), $now->modify( '+11 years' ) );
 		$this->assertEmpty( $events );
 	}
+
+	public function test_invalidates_cache_when_events_are_created() {
+		$now   = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event = new Event(
+			0,
+			$now,
+			$now->modify( '+1 hour' ),
+			new DateTimeZone( 'Europe/Lisbon' ),
+			'foo',
+			'draft',
+			'Foo',
+			'Foo.'
+		);
+
+		wp_cache_set( 'translation-events-active-events', 'foo' );
+		$this->repository->create_event( $event );
+		$this->assertFalse( wp_cache_get( 'translation-events-active-events' ) );
+	}
+
+	public function test_invalidates_cache_when_events_are_updated() {
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->repository->get_event( $event_id );
+
+		wp_cache_set( 'translation-events-active-events', 'foo' );
+		$this->repository->update_event( $event );
+		$this->assertFalse( wp_cache_get( 'translation-events-active-events' ) );
+	}
 }

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -28,13 +28,10 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_active_events( $now, $now->modify( '+1 minute' ) );
+		$events = $this->repository->get_active_events();
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
-
-		$events = $this->repository->get_active_events( $now->modify( '+10 years' ), $now->modify( '+11 years' ) );
-		$this->assertEmpty( $events );
 	}
 
 	public function test_invalidates_cache_when_events_are_created() {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -4,20 +4,22 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use WP_UnitTestCase;
+use GP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
-class Event_Repository_Cached_Test extends WP_UnitTestCase {
+class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	private Event_Repository_Cached $repository;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
-		$this->repository    = new Event_Repository_Cached();
+		$this->repository    = new Event_Repository_Cached( new Attendee_Repository() );
 
 		wp_cache_delete( 'translation-events-active-events' );
+		$this->set_normal_user_as_current();
 	}
 
 	public function test_get_active_events() {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -31,7 +31,7 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_active_events();
+		$events = $this->repository->get_current_events();
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -31,10 +31,24 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_current_events()->events;
+		$result = $this->repository->get_current_events();
+		$events = $result->events;
 		$this->assertCount( 2, $events );
+		$this->assertEquals( 1, $result->page_count );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$result = $this->repository->get_current_events( 1, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+
+		$result = $this->repository->get_current_events( 2, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
 
 	public function test_invalidates_cache_when_events_are_created() {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -19,12 +19,15 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
 		$this->repository    = new Event_Repository_Cached();
+
+		wp_cache_delete( 'translation-events-active-events' );
 	}
 
 	public function test_get_active_events() {
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event1_id = $this->event_factory->create_active( array(), $now );
-		$event2_id = $this->event_factory->create_active( array(), $now->modify( '+1 minute' ) );
+		$event2_id = $this->event_factory->create_active( array(), $now );
+		$this->event_factory->create_active( array(), $now->modify( '+2 hours' ) );
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -76,4 +76,13 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 		$this->repository->update_event( $event );
 		$this->assertFalse( wp_cache_get( 'translation-events-active-events' ) );
 	}
+
+	public function test_invalidates_cache_when_events_are_deleted() {
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->repository->get_event( $event_id );
+
+		wp_cache_set( 'translation-events-active-events', 'foo' );
+		$this->repository->delete_event( $event );
+		$this->assertFalse( wp_cache_get( 'translation-events-active-events' ) );
+	}
 }

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -4,12 +4,9 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use Exception;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
-use Wporg\TranslationEvents\Event\Event_Repository;
-use Wporg\TranslationEvents\Event\EventNotFound;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Cached_Test extends WP_UnitTestCase {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -31,7 +31,7 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_current_events();
+		$events = $this->repository->get_current_events()->events;
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -18,7 +18,7 @@ class Event_Repository_Cached_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
-		$this->repository    = new Event_Repository_Cached( new Event_Repository() );
+		$this->repository    = new Event_Repository_Cached();
 	}
 
 	public function test_get_active_events() {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -64,7 +64,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 		);
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );
-		$this->repository->create_event( $event );
+		$this->repository->insert_event( $event );
 		$this->assertFalse( wp_cache_get( 'translation-events-active-events' ) );
 	}
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -90,8 +90,7 @@ class Event_Repository_Test extends WP_UnitTestCase {
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		// phpcs:disable Squiz.PHP.DisallowMultipleAssignments.Found
-		$event->set_start( $updated_start = $now->modify( '+1 days' ) );
-		$event->set_end( $updated_end = $now->modify( '+2 days' ) );
+		$event->set_times( $updated_start = $now->modify( '+1 days' ), $updated_end = $now->modify( '+2 days' ) );
 		$event->set_timezone( $updated_timezone = new DateTimeZone( 'Europe/Madrid' ) );
 		$event->set_slug( $updated_slug = 'updated-slug' );
 		$event->set_status( $updated_status = 'draft' );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\Tests\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Event\EventNotFound;
@@ -26,5 +28,19 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$post_id = $this->factory()->post->create();
 		$this->expectException( EventNotFound::class );
 		$this->repository->get_event( $post_id );
+	}
+
+	public function test_get_event() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+		$start    = $now->modify( '-1 hours' );
+		$end      = $now->modify( '+1 hours' );
+
+		$event_id = $this->event_factory->create_event( $start, $end, array() );
+		$event    = $this->repository->get_event( $event_id );
+
+		$this->assertEquals( $start->getTimestamp(), $event->start()->getTimestamp() );
+		$this->assertEquals( $end->getTimestamp(), $event->end()->getTimestamp() );
+		$this->assertEquals( $timezone, $event->timezone() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -117,7 +117,7 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_active_events();
+		$events = $this->repository->get_current_events();
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -120,27 +120,5 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
-
-		$events = $this->repository->get_active_events( $now );
-		$this->assertCount( 2, $events );
-		$this->assertEquals( $event1_id, $events[0]->id() );
-		$this->assertEquals( $event2_id, $events[1]->id() );
-
-		$events = $this->repository->get_active_events( null, $now->modify( '+1 minute' ) );
-		$this->assertCount( 2, $events );
-		$this->assertEquals( $event1_id, $events[0]->id() );
-		$this->assertEquals( $event2_id, $events[1]->id() );
-
-		$events = $this->repository->get_active_events( $now, $now->modify( '+1 minute' ) );
-		$this->assertCount( 2, $events );
-		$this->assertEquals( $event1_id, $events[0]->id() );
-		$this->assertEquals( $event2_id, $events[1]->id() );
-
-		$events = $this->repository->get_active_events( $now->modify( '+10 years' ), $now->modify( '+11 years' ) );
-		$this->assertEmpty( $events );
-
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'boundary end must be after boundary start' );
-		$this->repository->get_active_events( $now, $now->modify( '-1 minute' ) );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -122,7 +122,6 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
 
-
 		$events = $this->repository->get_current_events( 1, 1 )->events;
 		$this->assertCount( 1, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -10,14 +10,17 @@ use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Event\EventNotFound;
 use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Tests\Stats_Factory;
 
 class Event_Repository_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
+	private Stats_Factory $stats_factory;
 	private Event_Repository $repository;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
+		$this->stats_factory = new Stats_Factory();
 		$this->repository    = new Event_Repository( new Attendee_Repository() );
 
 		$this->set_normal_user_as_current();
@@ -109,6 +112,16 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $updated_status, $updated_event->status() );
 		$this->assertEquals( $updated_title, $updated_event->title() );
 		$this->assertEquals( $updated_description, $updated_event->description() );
+	}
+
+	public function test_delete_event() {
+		$event_id = $this->event_factory->create_active();
+
+		$event = $this->repository->get_event( $event_id );
+		$this->repository->delete_event( $event );
+
+		$this->expectException( EventNotFound::class );
+		$this->repository->get_event( $event_id );
 	}
 
 	public function test_get_active_events() {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -107,4 +107,17 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $updated_title, $updated_event->title() );
 		$this->assertEquals( $updated_description, $updated_event->description() );
 	}
+
+	public function test_get_active_events() {
+		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event1_id = $this->event_factory->create_active( array(), $now );
+		$event2_id = $this->event_factory->create_active( array(), $now->modify( '+1 minute' ) );
+		$this->event_factory->create_inactive_future();
+		$this->event_factory->create_inactive_past();
+
+		$events = $this->repository->get_active_events( $now, $now );
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -9,17 +9,14 @@ use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
-use Wporg\TranslationEvents\Tests\Stats_Factory;
 
 class Event_Repository_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
-	private Stats_Factory $stats_factory;
 	private Event_Repository $repository;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
-		$this->stats_factory = new Stats_Factory();
 		$this->repository    = new Event_Repository( new Attendee_Repository() );
 
 		$this->set_normal_user_as_current();

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -112,7 +112,8 @@ class Event_Repository_Test extends WP_UnitTestCase {
 	public function test_get_active_events() {
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event1_id = $this->event_factory->create_active( array(), $now );
-		$event2_id = $this->event_factory->create_active( array(), $now->modify( '+1 minute' ) );
+		$event2_id = $this->event_factory->create_active( array(), $now );
+		$this->event_factory->create_active( array(), $now->modify( '+2 hours' ) );
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -117,7 +117,7 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_current_events();
+		$events = $this->repository->get_current_events()->events;
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -4,6 +4,7 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Exception;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -115,9 +116,31 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->event_factory->create_inactive_future();
 		$this->event_factory->create_inactive_past();
 
-		$events = $this->repository->get_active_events( $now, $now );
+		$events = $this->repository->get_active_events();
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$events = $this->repository->get_active_events( $now );
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$events = $this->repository->get_active_events( null, $now->modify( '+1 minute' ) );
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$events = $this->repository->get_active_events( $now, $now->modify( '+1 minute' ) );
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$events = $this->repository->get_active_events( $now->modify( '+10 years' ), $now->modify( '+11 years' ) );
+		$this->assertEmpty( $events );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'boundary end must be after boundary start' );
+		$this->repository->get_active_events( $now, $now->modify( '-1 minute' ) );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -5,6 +5,7 @@ namespace Wporg\Tests\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use GP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Event\EventNotFound;
@@ -17,7 +18,9 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
-		$this->repository    = new Event_Repository();
+		$this->repository    = new Event_Repository( new Attendee_Repository() );
+
+		$this->set_normal_user_as_current();
 	}
 
 	public function test_get_event_throws_not_found_when_event_does_not_exist() {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -49,7 +49,7 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertStringStartsWith( 'Event content', $event->description() );
 	}
 
-	public function test_creates_event() {
+	public function test_create_event() {
 		$now         = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$start       = $now->modify( '-1 hours' );
 		$end         = $now->modify( '+1 hours' );
@@ -82,5 +82,32 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $status, $created_event->status() );
 		$this->assertEquals( $title, $created_event->title() );
 		$this->assertEquals( $description, $created_event->description() );
+	}
+
+	public function test_update_event() {
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->repository->get_event( $event_id );
+
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		// phpcs:disable Squiz.PHP.DisallowMultipleAssignments.Found
+		$event->set_start( $updated_start = $now->modify( '+1 days' ) );
+		$event->set_end( $updated_end = $now->modify( '+2 days' ) );
+		$event->set_timezone( $updated_timezone = new DateTimeZone( 'Europe/Madrid' ) );
+		$event->set_slug( $updated_slug = 'updated-slug' );
+		$event->set_status( $updated_status = 'draft' );
+		$event->set_title( $updated_title = 'Updated title' );
+		$event->set_description( $updated_description = 'Updated description' );
+		// phpcs:enable
+
+		$this->repository->update_event( $event );
+		$updated_event = $this->repository->get_event( $event_id );
+
+		$this->assertEquals( $updated_start->getTimestamp(), $updated_event->start()->getTimestamp() );
+		$this->assertEquals( $updated_end->getTimestamp(), $updated_event->end()->getTimestamp() );
+		$this->assertEquals( $updated_timezone->getName(), $updated_event->timezone()->getName() );
+		$this->assertEquals( $updated_slug, $updated_event->slug() );
+		$this->assertEquals( $updated_status, $updated_event->status() );
+		$this->assertEquals( $updated_title, $updated_event->title() );
+		$this->assertEquals( $updated_description, $updated_event->description() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -42,5 +42,9 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $start->getTimestamp(), $event->start()->getTimestamp() );
 		$this->assertEquals( $end->getTimestamp(), $event->end()->getTimestamp() );
 		$this->assertEquals( $timezone, $event->timezone() );
+		$this->assertStringStartsWith( 'event-title-', $event->slug() );
+		$this->assertEquals( 'publish', $event->status() );
+		$this->assertStringStartsWith( 'Event title', $event->title() );
+		$this->assertStringStartsWith( 'Event content', $event->description() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -73,7 +73,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 			$description,
 		);
 
-		$this->repository->create_event( $event );
+		$this->repository->insert_event( $event );
 		$this->assertGreaterThan( 0, $event->id() );
 
 		$created_event = $this->repository->get_event( $event->id() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -121,5 +121,14 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertCount( 2, $events );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
+
+
+		$events = $this->repository->get_current_events( 1, 1 )->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+
+		$events = $this->repository->get_current_events( 2, 1 )->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Wporg\Tests\Event;
+
+use WP_UnitTestCase;
+use Wporg\TranslationEvents\Event\Event_Repository;
+use Wporg\TranslationEvents\Tests\Event_Factory;
+
+class Event_Repository_Test extends WP_UnitTestCase {
+	private Event_Factory $event_factory;
+	private Event_Repository $repository;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->event_factory = new Event_Factory();
+		$this->repository    = new Event_Repository();
+	}
+}

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -32,10 +32,10 @@ class Event_Repository_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_event() {
-		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$start    = $now->modify( '-1 hours' );
 		$end      = $now->modify( '+1 hours' );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$event_id = $this->event_factory->create_event( $start, $end, $timezone, array() );
 		$event    = $this->repository->get_event( $event_id );
@@ -50,10 +50,10 @@ class Event_Repository_Test extends WP_UnitTestCase {
 	}
 
 	public function test_creates_event() {
-		$timezone    = new DateTimeZone( 'Europe/Lisbon' );
-		$now         = new DateTimeImmutable( 'now', $timezone );
+		$now         = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$start       = $now->modify( '-1 hours' );
 		$end         = $now->modify( '+1 hours' );
+		$timezone    = new DateTimeZone( 'Europe/Lisbon' );
 		$slug        = 'foo-slug';
 		$status      = 'publish';
 		$title       = 'Foo title';

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -122,12 +122,16 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $event1_id, $events[0]->id() );
 		$this->assertEquals( $event2_id, $events[1]->id() );
 
-		$events = $this->repository->get_current_events( 1, 1 )->events;
+		$result = $this->repository->get_current_events( 1, 1 );
+		$events = $result->events;
 		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
 		$this->assertEquals( $event1_id, $events[0]->id() );
 
-		$events = $this->repository->get_current_events( 2, 1 )->events;
+		$result = $this->repository->get_current_events( 2, 1 );
+		$events = $result->events;
 		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
 		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -36,7 +36,7 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$start    = $now->modify( '-1 hours' );
 		$end      = $now->modify( '+1 hours' );
 
-		$event_id = $this->event_factory->create_event( $start, $end, array() );
+		$event_id = $this->event_factory->create_event( $start, $end, $timezone, array() );
 		$event    = $this->repository->get_event( $event_id );
 
 		$this->assertEquals( $start->getTimestamp(), $event->start()->getTimestamp() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -189,4 +189,25 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( 2, $result->page_count );
 		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
+
+	public function test_get_events_created_by_user() {
+		$user_id   = $this->set_normal_user_as_current();
+		$event1_id = $this->event_factory->create_inactive_past();
+		$event2_id = $this->event_factory->create_active();
+		$event3_id = $this->event_factory->create_active();
+		$event4_id = $this->event_factory->create_inactive_future();
+
+		$this->set_admin_user_as_current();
+		$this->event_factory->create_inactive_past();
+		$this->event_factory->create_active();
+		$this->event_factory->create_inactive_future();
+
+		$events = $this->repository->get_events_created_by_user( $user_id )->events;
+
+		$this->assertCount( 4, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+		$this->assertEquals( $event3_id, $events[2]->id() );
+		$this->assertEquals( $event4_id, $events[3]->id() );
+	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -92,7 +92,6 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		// phpcs:disable Squiz.PHP.DisallowMultipleAssignments.Found
 		$event->set_times( $updated_start = $now->modify( '+1 days' ), $updated_end = $now->modify( '+2 days' ) );
 		$event->set_timezone( $updated_timezone = new DateTimeZone( 'Europe/Madrid' ) );
-		$event->set_slug( $updated_slug = 'updated-slug' );
 		$event->set_status( $updated_status = 'draft' );
 		$event->set_title( $updated_title = 'Updated title' );
 		$event->set_description( $updated_description = 'Updated description' );
@@ -104,7 +103,6 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $updated_start->getTimestamp(), $updated_event->start()->getTimestamp() );
 		$this->assertEquals( $updated_end->getTimestamp(), $updated_event->end()->getTimestamp() );
 		$this->assertEquals( $updated_timezone->getName(), $updated_event->timezone()->getName() );
-		$this->assertEquals( $updated_slug, $updated_event->slug() );
 		$this->assertEquals( $updated_status, $updated_event->status() );
 		$this->assertEquals( $updated_title, $updated_event->title() );
 		$this->assertEquals( $updated_description, $updated_event->description() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -161,4 +161,32 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( 2, $result->page_count );
 		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
+
+	public function test_get_past_events_for_user() {
+		$user_id = $this->set_normal_user_as_current();
+
+		$event1_id = $this->event_factory->create_inactive_past( array( $user_id ) );
+		$event2_id = $this->event_factory->create_inactive_past( array( $user_id ) );
+
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$this->event_factory->create_active( array( $user_id ), $now );
+		$this->event_factory->create_active( array( $user_id ), $now );
+
+		$events = $this->repository->get_past_events_for_user( $user_id )->events;
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$result = $this->repository->get_past_events_for_user( $user_id, 1, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+
+		$result = $this->repository->get_past_events_for_user( $user_id, 2, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event2_id, $events[0]->id() );
+	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -5,6 +5,7 @@ namespace Wporg\Tests\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTestCase;
+use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Event\EventNotFound;
 use Wporg\TranslationEvents\Tests\Event_Factory;
@@ -46,5 +47,40 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $event->status() );
 		$this->assertStringStartsWith( 'Event title', $event->title() );
 		$this->assertStringStartsWith( 'Event content', $event->description() );
+	}
+
+	public function test_creates_event() {
+		$timezone    = new DateTimeZone( 'Europe/Lisbon' );
+		$now         = new DateTimeImmutable( 'now', $timezone );
+		$start       = $now->modify( '-1 hours' );
+		$end         = $now->modify( '+1 hours' );
+		$slug        = 'foo-slug';
+		$status      = 'publish';
+		$title       = 'Foo title';
+		$description = 'Foo Description';
+
+		$event = new Event(
+			0,
+			$start,
+			$end,
+			$timezone,
+			$slug,
+			$status,
+			$title,
+			$description,
+		);
+
+		$this->repository->create_event( $event );
+		$this->assertGreaterThan( 0, $event->id() );
+
+		$created_event = $this->repository->get_event( $event->id() );
+
+		$this->assertEquals( $start->getTimestamp(), $created_event->start()->getTimestamp() );
+		$this->assertEquals( $end->getTimestamp(), $created_event->end()->getTimestamp() );
+		$this->assertEquals( $timezone, $created_event->timezone() );
+		$this->assertEquals( $slug, $created_event->slug() );
+		$this->assertEquals( $status, $created_event->status() );
+		$this->assertEquals( $title, $created_event->title() );
+		$this->assertEquals( $description, $created_event->description() );
 	}
 }

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -8,7 +8,6 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
-use Wporg\TranslationEvents\Event\EventNotFound;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 
@@ -26,15 +25,13 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 	}
 
-	public function test_get_event_throws_not_found_when_event_does_not_exist() {
-		$this->expectException( EventNotFound::class );
-		$this->repository->get_event( 42 );
+	public function test_get_event_returns_null_when_event_does_not_exist() {
+		$this->assertNull( $this->repository->get_event( 42 ) );
 	}
 
-	public function test_get_event_throws_not_found_when_post_is_not_event() {
+	public function test_get_event_returns_null_when_post_is_not_event() {
 		$post_id = $this->factory()->post->create();
-		$this->expectException( EventNotFound::class );
-		$this->repository->get_event( $post_id );
+		$this->assertNull( $this->repository->get_event( $post_id ) );
 	}
 
 	public function test_get_event() {
@@ -120,8 +117,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$event = $this->repository->get_event( $event_id );
 		$this->repository->delete_event( $event );
 
-		$this->expectException( EventNotFound::class );
-		$this->repository->get_event( $event_id );
+		$this->assertNull( $this->repository->get_event( $event_id ) );
 	}
 
 	public function test_get_active_events() {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -4,6 +4,7 @@ namespace Wporg\Tests\Event;
 
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event_Repository;
+use Wporg\TranslationEvents\Event\EventNotFound;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Test extends WP_UnitTestCase {
@@ -14,5 +15,16 @@ class Event_Repository_Test extends WP_UnitTestCase {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
 		$this->repository    = new Event_Repository();
+	}
+
+	public function test_get_event_throws_not_found_when_event_does_not_exist() {
+		$this->expectException( EventNotFound::class );
+		$this->repository->get_event( 42 );
+	}
+
+	public function test_get_event_throws_not_found_when_post_is_not_event() {
+		$post_id = $this->factory()->post->create();
+		$this->expectException( EventNotFound::class );
+		$this->repository->get_event( $post_id );
 	}
 }

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -8,6 +8,7 @@ use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\InvalidSlug;
 use Wporg\TranslationEvents\Event\InvalidStartOrEnd;
+use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\InvalidTitle;
 
 class Event_Test extends WP_UnitTestCase {
@@ -22,7 +23,7 @@ class Event_Test extends WP_UnitTestCase {
 			$now->modify( '-1 hours' ),
 			$timezone,
 			'foo-slug',
-			'',
+			'publish',
 			'Foo title',
 			'',
 		);
@@ -39,7 +40,7 @@ class Event_Test extends WP_UnitTestCase {
 			$now->modify( '+1 hours' ),
 			$timezone,
 			'',
-			'',
+			'publish',
 			'Foo title',
 			'',
 		);
@@ -56,8 +57,25 @@ class Event_Test extends WP_UnitTestCase {
 			$now->modify( '+1 hours' ),
 			$timezone,
 			'foo-slug',
+			'publish',
 			'',
 			'',
+		);
+	}
+
+	public function test_validates_status() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$this->expectException( InvalidStatus::class );
+		new Event(
+			1,
+			$now,
+			$now->modify( '+1 hours' ),
+			$timezone,
+			'foo-slug',
+			'',
+			'Foo title',
 			'',
 		);
 	}

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -13,8 +13,8 @@ use Wporg\TranslationEvents\Event\InvalidTitle;
 
 class Event_Test extends WP_UnitTestCase {
 	public function test_validates_start_and_end() {
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		$this->expectException( InvalidStartOrEnd::class );
 		new Event(
@@ -29,9 +29,26 @@ class Event_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_validates_slug() {
+	public function test_validates_start_and_end_timezone() {
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'Europe/Lisbon' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$this->expectException( InvalidStartOrEnd::class );
+		new Event(
+			1,
+			$now,
+			$now->modify( '+1 hours' ),
+			$timezone,
+			'foo-slug',
+			'publish',
+			'Foo title',
+			'',
+		);
+	}
+
+	public function test_validates_slug() {
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$this->expectException( InvalidSlug::class );
 		new Event(
@@ -47,8 +64,8 @@ class Event_Test extends WP_UnitTestCase {
 	}
 
 	public function test_validates_title() {
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		$this->expectException( InvalidTitle::class );
 		new Event(
@@ -64,8 +81,8 @@ class Event_Test extends WP_UnitTestCase {
 	}
 
 	public function test_validates_status() {
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		$this->expectException( InvalidStatus::class );
 		new Event(

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -2,7 +2,27 @@
 
 namespace Wporg\Tests\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use WP_UnitTestCase;
+use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Event\InvalidStartOrEnd;
 
 class Event_Test extends WP_UnitTestCase {
+	public function test_validates_start_and_end() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$this->expectException( InvalidStartOrEnd::class );
+		new Event(
+			1,
+			$now,
+			$now->modify( '-1 hours' ),
+			$timezone,
+			'',
+			'',
+			'',
+			'',
+		);
+	}
 }

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -6,7 +6,9 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Event\InvalidSlug;
 use Wporg\TranslationEvents\Event\InvalidStartOrEnd;
+use Wporg\TranslationEvents\Event\InvalidTitle;
 
 class Event_Test extends WP_UnitTestCase {
 	public function test_validates_start_and_end() {
@@ -19,7 +21,41 @@ class Event_Test extends WP_UnitTestCase {
 			$now,
 			$now->modify( '-1 hours' ),
 			$timezone,
+			'foo-slug',
 			'',
+			'Foo title',
+			'',
+		);
+	}
+
+	public function test_validates_slug() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$this->expectException( InvalidSlug::class );
+		new Event(
+			1,
+			$now,
+			$now->modify( '+1 hours' ),
+			$timezone,
+			'',
+			'',
+			'Foo title',
+			'',
+		);
+	}
+
+	public function test_validates_title() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
+
+		$this->expectException( InvalidTitle::class );
+		new Event(
+			1,
+			$now,
+			$now->modify( '+1 hours' ),
+			$timezone,
+			'foo-slug',
 			'',
 			'',
 			'',

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Wporg\Tests\Event;
+
+use WP_UnitTestCase;
+
+class Event_Test extends WP_UnitTestCase {
+}

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -6,7 +6,6 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
-use Wporg\TranslationEvents\Event\InvalidSlug;
 use Wporg\TranslationEvents\Event\InvalidStartOrEnd;
 use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\InvalidTitle;
@@ -40,23 +39,6 @@ class Event_Test extends WP_UnitTestCase {
 			$now->modify( '+1 hours' ),
 			$timezone,
 			'foo-slug',
-			'publish',
-			'Foo title',
-			'',
-		);
-	}
-
-	public function test_validates_slug() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-
-		$this->expectException( InvalidSlug::class );
-		new Event(
-			1,
-			$now,
-			$now->modify( '+1 hours' ),
-			$timezone,
-			'',
 			'publish',
 			'Foo title',
 			'',

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -38,12 +38,14 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		return $event_id;
 	}
 
-	public function create_active( array $attendee_ids = array(), $now = 'now' ): int {
+	public function create_active( array $attendee_ids = array(), $now = null ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+		if ( null === $now ) {
+			$now = new DateTimeImmutable( 'now', $timezone );
+		}
 
 		return $this->create_event(
-			$now->modify( '-1 hours' ),
+			$now->modify( '-1 second' ),
 			$now->modify( '+1 hours' ),
 			$timezone,
 			$attendee_ids,
@@ -55,8 +57,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		return $this->create_event(
-			$now->modify( '-2 hours' ),
-			$now->modify( '-1 hours' ),
+			$now->modify( '-2 month' ),
+			$now->modify( '-1 month' ),
 			$timezone,
 			$attendee_ids,
 		);
@@ -67,8 +69,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		return $this->create_event(
-			$now->modify( '+1 hours' ),
-			$now->modify( '+2 hours' ),
+			$now->modify( '+1 month' ),
+			$now->modify( '+2 month' ),
 			$timezone,
 			$attendee_ids,
 		);

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -21,11 +21,13 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 	}
 
 	public function create_draft(): int {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		$event_id = $this->create_event(
 			$now->modify( '-1 hours' ),
 			$now->modify( '+1 hours' ),
+			$timezone,
 			array(),
 		);
 
@@ -37,36 +39,42 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 	}
 
 	public function create_active( array $attendee_ids = array(), $now = 'now' ): int {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		return $this->create_event(
 			$now->modify( '-1 hours' ),
 			$now->modify( '+1 hours' ),
+			$timezone,
 			$attendee_ids,
 		);
 	}
 
 	public function create_inactive_past( array $attendee_ids = array() ): int {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		return $this->create_event(
 			$now->modify( '-2 hours' ),
 			$now->modify( '-1 hours' ),
+			$timezone,
 			$attendee_ids,
 		);
 	}
 
 	public function create_inactive_future( array $attendee_ids = array() ): int {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$now      = new DateTimeImmutable( 'now', $timezone );
 
 		return $this->create_event(
 			$now->modify( '+1 hours' ),
 			$now->modify( '+2 hours' ),
+			$timezone,
 			$attendee_ids,
 		);
 	}
 
-	public function create_event( DateTimeImmutable $start, DateTimeImmutable $end, array $attendee_ids ): int {
+	public function create_event( DateTimeImmutable $start, DateTimeImmutable $end, DateTimeZone $timezone, array $attendee_ids ): int {
 		$event_id = $this->create();
 		$meta_key = Translation_Events::USER_META_KEY_ATTENDING;
 
@@ -81,7 +89,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 		update_post_meta( $event_id, '_event_start', $start->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event_id, '_event_end', $end->format( 'Y-m-d H:i:s' ) );
-		update_post_meta( $event_id, '_event_timezone', 'Europe/Lisbon' );
+		update_post_meta( $event_id, '_event_timezone', $timezone->getName() );
 
 		foreach ( $attendee_ids as $user_id ) {
 			$event_ids   = get_user_meta( $user_id, $meta_key, true ) ?: array();

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -86,7 +86,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 			// the caller of this function. So we remove the current user as attendee.
 			$event_ids = get_user_meta( $user_id, $meta_key, true );
 			unset( $event_ids[ $event_id ] );
-			update_user_meta( $user_id, $meta_key, array() );
+			update_user_meta( $user_id, $meta_key, $event_ids );
 		}
 
 		update_post_meta( $event_id, '_event_start', $start->format( 'Y-m-d H:i:s' ) );

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -36,7 +36,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		return $event_id;
 	}
 
-	public function create_active( array $attendee_ids = array() ): int {
+	public function create_active( array $attendee_ids = array(), $now = 'now' ): int {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->create_event(
@@ -66,7 +66,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		);
 	}
 
-	private function create_event( DateTimeImmutable $start, DateTimeImmutable $end, array $attendee_ids ): int {
+	public function create_event( DateTimeImmutable $start, DateTimeImmutable $end, array $attendee_ids ): int {
 		$event_id = $this->create();
 		$meta_key = Translation_Events::USER_META_KEY_ATTENDING;
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -61,8 +61,9 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
-		require_once __DIR__ . '/includes/event/event-repository.php';
 		require_once __DIR__ . '/includes/event/event.php';
+		require_once __DIR__ . '/includes/event/event-repository-interface.php';
+		require_once __DIR__ . '/includes/event/event-repository.php';
 		require_once __DIR__ . '/includes/active-events-cache.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
 		require_once __DIR__ . '/includes/stats-listener.php';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -64,6 +64,7 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/event/event.php';
 		require_once __DIR__ . '/includes/event/event-repository-interface.php';
 		require_once __DIR__ . '/includes/event/event-repository.php';
+		require_once __DIR__ . '/includes/event/event-repository-cached.php';
 		require_once __DIR__ . '/includes/active-events-cache.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
 		require_once __DIR__ . '/includes/stats-listener.php';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -55,7 +55,7 @@ class Translation_Events {
 	public function gp_init() {
 		require_once __DIR__ . '/templates/helper-functions.php';
 		require_once __DIR__ . '/includes/active-events-cache.php';
-		require_once __DIR__ . '/includes/event.php';
+		require_once __DIR__ . '/includes/event/event.php';
 		require_once __DIR__ . '/includes/routes/route.php';
 		require_once __DIR__ . '/includes/routes/event/create.php';
 		require_once __DIR__ . '/includes/routes/event/details.php';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -54,8 +54,6 @@ class Translation_Events {
 
 	public function gp_init() {
 		require_once __DIR__ . '/templates/helper-functions.php';
-		require_once __DIR__ . '/includes/active-events-cache.php';
-		require_once __DIR__ . '/includes/event/event.php';
 		require_once __DIR__ . '/includes/routes/route.php';
 		require_once __DIR__ . '/includes/routes/event/create.php';
 		require_once __DIR__ . '/includes/routes/event/details.php';
@@ -63,6 +61,9 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
+		require_once __DIR__ . '/includes/event/event-repository.php';
+		require_once __DIR__ . '/includes/event/event.php';
+		require_once __DIR__ . '/includes/active-events-cache.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
 		require_once __DIR__ . '/includes/stats-listener.php';
 


### PR DESCRIPTION
 
> Please read this description before reviewing the PR :) It provides important context that I think is essential to consider while reviewing.
>
> I would recommend reviewing the final result instead of individual commits.

Recently, we identified the need to refactor the code that retrieves active events, as documented in #117. While looking into that issue, I realised that there was opportunity for a more extensive refactor, that would address #117 but also improve other parts of the codebase.

I took the liberty to implement such a refactor, and I'm proposing it in this PR. If you agree that this proposal is beneficial to the project, we can iterate on it here until we're happy with the result. If you don't agree, we can scrap this PR.

Note that the code introduced in here is not being called anywhere. Once/if this PR is merged, I will make it so that the codebase uses the code introduced here.

As always, I welcome any feedback you might have.
## The problem
Before going into the proposed solution, I think it's important to provide context on what problems this PR solves. What follows are some examples I identified that are addressed, or at least improved by this PR.
### Duplication of code
An example of this is retrieving active events (#117), where we have the same logic with slight variations in multiple places:

1. When storing stats
2. When displaying the active events of a user
3. When displaying the currently active events in the "homepage" (`/events`)
### Duplication of validation and/or incomplete validation
An example of this is creating an instance of an event. Whenever we need to create an instance of an event, we need to perform the same checks on the event. For example, checking that the `$end` is after the `$start`, or that the `$title` is not empty.

There are also instances where we are not fully validating the event data, for example, making sure that the title is not empty.
### Duplication of other checks
An example of this is validating that the `post_type` is `event`. This needs to be done every time an event is retrieved from the database. It should not be possible for the developer to retrieve an event from the database that is not of type `event`.
### Side-effects not guaranteed
An example of this is making sure that the active events cache is invalidated when events are created of modified. The developer must remember to invalidate the cache when required.
### Data access is hard to cover by unit tests
Because data access is spread throughout the codebase, it's difficult to cover with unit tests. We would only be able to test data access indirectly (by testing other features), but ensuring the validity of the stored data is essential, so it should be relatively easy for the developer to cover data access with tests.
### Error prone
IMHO, the combination of the above issues, results in error-prone code, because it's easy for the developer to make mistakes, because they need to consider a large number of things when making changes.

For example, when a developer is writing business logic (currently in the `Route` class and main plugin file), I think they should not need to consider details of data access like validating that the post has type `event`. 

IMHO all the little things the developer must consider add up, and make for a codebase that is hard to understand and maintain.
## Proposed solution
To address some of the issues mentioned above, this PR introduces a *Data access layer* for events. This layer can be thought of as a black box that abstracts details of how events are stored, through a higher-level API for manipulating and retrieving events. 

This API is specified by the `Event_Repository_Interface`, which I believe contains all the operations we currently need to perform on events:

```php
interface Event_Repository_Interface {  
    public function create_event( Event $event ): void;  
    public function update_event( Event $event ): void;  
    public function get_event( int $id ): Event;  
    public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result;  
    public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;  
    public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;  
    public function get_events_created_by_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;  
}
```

`Event` represents an event, and contains all the data of the event, e.g. `$start`, `$end`, `$timezone`, `$title`, etc. It is not possible for there to be an instance of `Event` that contains invalid data. The `Event` constructor and setters perform validation, which ensures we're validating as soon as possible, before data gets stored in the database.

Operations that retrieve a list of events (e.g. `get_current_events()` or `get_events_created_by_user()`) return an instance of `Events_Query_Result`, which carries the retrieved events themselves, and information needed for pagination (e.g. total number of results).

There are two implementations of `Event_Repository_Interface`:

1. `Event_Repository`: this is the "normal" repository
2. `Event_Repository_Cached`: extends `Event_Repository` and overrides methods that require caching.

The reasoning for having an interface and two different implementations is so that calling code does not depend on a specific implementation. The calling code should not need to care whether caching is enabled or not.

Finally, this "black box" is covered by some unit tests, so we can be reasonably confident that it will operate as expected.