### PR TITLE
Fix issue when retrieveing the number of current events the user is attending

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -461,7 +461,11 @@ class Translation_Events {
 	 * @return void
 	 */
 	public function add_active_events_current_user(): void {
-		$user_attending_events      = get_user_meta( get_current_user_id(), Route::USER_META_KEY_ATTENDING, true ) ?: array();
+		$user_attending_events = get_user_meta( get_current_user_id(), Route::USER_META_KEY_ATTENDING, true ) ?: array();
+		if ( empty( $user_attending_events ) ) {
+			return;
+		}
+
 		$current_datetime_utc       = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
 		$user_attending_events_args = array(
 			'post_type'   => self::CPT,


### PR DESCRIPTION
Fixes #147 

The cause of the issue is that we're setting `post__in` in the query to an empty array, which results in all events being returned. We have previously fixed a similar issue [here](https://github.com/WordPress/wporg-gp-translation-events/blob/trunk/includes/route.php#L130) (note the `array( 0 )` at the end of the line).

If I may plug my proposal at #145 :), #147 would not have happened if we had a single location in the code that retrieves the events of a user (because we would have fixed it globally when we changed it to `array( 0 )`. Event attendance is a core concept of this plugin, so I think it would make sense to enforce that concept through code, instead of relying on low-level WordPress functions in every part of the codebase that requires dealing with attendance.