### PR TITLE
Check if we have an $user_id in the "handle_action" method

### DIFF
--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -65,6 +65,9 @@ class Stats_Listener {
 
 	private function handle_action( GP_Translation $translation, int $user_id, string $action, DateTimeImmutable $happened_at ): void {
 		try {
+			if ( ! $user_id ) {
+				return;
+			}
 			// Get events that are active when the action happened, for which the user is registered for.
 			$active_events = $this->get_active_events( $happened_at );
 			$events        = $this->select_events_user_is_registered_for( $active_events, $user_id );


### PR DESCRIPTION
If the `handle_action` receives a null `$user_id`, it fires an error.
This PR checks if the `$user_id` is not null to go on with the `handle_action` method.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/149