### PR TITLE
Use gp_table_prefix instead of base_prefix

### DIFF
--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -65,7 +65,7 @@ class Stats_Calculator {
 	 */
 	public function for_event( WP_Post $event ): Event_Stats {
 		$stats = new Event_Stats();
-		global $wpdb;
+		global $wpdb, $gp_table_prefix;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -78,7 +78,7 @@ class Stats_Calculator {
 					   sum(action = 'create') as created,
 					   count(*) as total,
 					   count(distinct user_id) as users
-				from {$wpdb->base_prefix}event_actions
+				from {$gp_table_prefix}event_actions
 				where event_id = %d
 				group by locale with rollup
 			",

--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -67,6 +67,7 @@ class Stats_Calculator {
 		$stats = new Event_Stats();
 		global $wpdb, $gp_table_prefix;
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs thinks we're doing a schema change but we aren't.

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -80,6 +80,7 @@ class Stats_Listener {
 			foreach ( $events as $event ) {
 				// A given user can only do one action on a specific translation.
 				// So we insert ignore, which will keep only the first action.
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 				$wpdb->query(

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -75,7 +75,7 @@ class Stats_Listener {
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			/** @var GP_Translation_Set $translation_set Translation set */
 			$translation_set = ( new GP_Translation_Set() )->find_one( array( 'id' => $translation->translation_set_id ) );
-			global $wpdb;
+			global $wpdb, $gp_table_prefix;
 
 			foreach ( $events as $event ) {
 				// A given user can only do one action on a specific translation.
@@ -84,7 +84,7 @@ class Stats_Listener {
 				// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 				$wpdb->query(
 					$wpdb->prepare(
-						"insert ignore into {$wpdb->base_prefix}event_actions (event_id, locale, user_id, original_id, action, happened_at) values (%d, %s, %d, %d, %s, %s)",
+						"insert ignore into {$gp_table_prefix}event_actions (event_id, locale, user_id, original_id, action, happened_at) values (%d, %s, %d, %d, %s, %s)",
 						array(
 							// Start unique key.
 							'event_id'    => $event->id(),

--- a/tests/lib/stats-factory.php
+++ b/tests/lib/stats-factory.php
@@ -6,11 +6,11 @@ use wpdb;
 
 class Stats_Factory {
 	public function clean() {
-		global $wpdb;
+		global $wpdb, $gp_table_prefix;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query( "delete from {$wpdb->base_prefix}event_actions" );
+		$wpdb->query( "delete from {$gp_table_prefix}event_actions" );
 		// phpcs:enable
 	}
 
@@ -18,7 +18,7 @@ class Stats_Factory {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->insert(
-			$wpdb->base_prefix . 'event_actions',
+			$gp_table_prefix . 'event_actions',
 			array(
 				'event_id'    => $event_id,
 				'user_id'     => $user_id,
@@ -30,18 +30,18 @@ class Stats_Factory {
 	}
 
 	public function get_count(): int {
-		global $wpdb;
+		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		return intval( $wpdb->get_var( "select count(*) from {$wpdb->base_prefix}event_actions" ) );
+		return intval( $wpdb->get_var( "select count(*) from {$gp_table_prefix}event_actions" ) );
 		// phpcs:enable
 	}
 
 	public function get_by_event_id( $event_id ): array {
-		global $wpdb;
+		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		return $wpdb->get_row( $wpdb->prepare( "select * from {$wpdb->base_prefix}event_actions where event_id = %s", $event_id ), ARRAY_A );
+		return $wpdb->get_row( $wpdb->prepare( "select * from {$gp_table_prefix}event_actions where event_id = %s", $event_id ), ARRAY_A );
 		// phpcs:enable
 	}
 }

--- a/tests/lib/stats-factory.php
+++ b/tests/lib/stats-factory.php
@@ -10,6 +10,7 @@ class Stats_Factory {
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query( "delete from {$gp_table_prefix}event_actions" );
 		// phpcs:enable
 	}
@@ -18,6 +19,7 @@ class Stats_Factory {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->insert(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$gp_table_prefix . 'event_actions',
 			array(
 				'event_id'    => $event_id,
@@ -33,6 +35,7 @@ class Stats_Factory {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return intval( $wpdb->get_var( "select count(*) from {$gp_table_prefix}event_actions" ) );
 		// phpcs:enable
 	}
@@ -41,6 +44,7 @@ class Stats_Factory {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return $wpdb->get_row( $wpdb->prepare( "select * from {$gp_table_prefix}event_actions where event_id = %s", $event_id ), ARRAY_A );
 		// phpcs:enable
 	}

--- a/tests/lib/stats-factory.php
+++ b/tests/lib/stats-factory.php
@@ -15,7 +15,7 @@ class Stats_Factory {
 	}
 
 	public function create( int $event_id, $user_id, $original_id, $action, $locale = 'aa' ) {
-		global $wpdb;
+		global $wpdb, $gp_table_prefix;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$wpdb->insert(
 			$gp_table_prefix . 'event_actions',

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -26,7 +26,7 @@ use WP_Post;
 use WP_Query;
 
 class Translation_Events {
-	const CPT      = 'translation_event';
+	const CPT = 'translation_event';
 
 	public static function get_instance() {
 		static $instance = null;

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -26,7 +26,7 @@ use WP_Post;
 use WP_Query;
 
 class Translation_Events {
-	const CPT = 'translation_event';
+	const CPT      = 'translation_event';
 	const DB_TABLE = 'translate_event_actions';
 
 	public static function get_instance() {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -27,6 +27,7 @@ use WP_Query;
 
 class Translation_Events {
 	const CPT = 'translation_event';
+	const DB_TABLE = 'translate_event_actions';
 
 	public static function get_instance() {
 		static $instance = null;
@@ -72,9 +73,9 @@ class Translation_Events {
 	}
 
 	public function activate() {
-		global $wpdb;
+		global $gp_table_prefix;
 		$create_table = "
-		CREATE TABLE `{$wpdb->base_prefix}event_actions` (
+		CREATE TABLE `{$gp_table_prefix}event_actions` (
 			`translate_event_actions_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
 			`original_id` int(10) NOT NULL COMMENT 'ID of the translation',

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -27,7 +27,6 @@ use WP_Query;
 
 class Translation_Events {
 	const CPT      = 'translation_event';
-	const DB_TABLE = 'translate_event_actions';
 
 	public static function get_instance() {
 		static $instance = null;


### PR DESCRIPTION
GlotPress doesn’t use the WordPress table namespace and has its own prefix. As per @dd32's advice, this switches it over to using that so that on WordPress.org we use a `translate_` table prefix.

In order to get the new table created, you need to deactivate and reactivate the plugin.