### PR TITLE
Check user_id value before calling handle_action()

### DIFF
--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -38,6 +38,7 @@ class Stats_Listener {
 				$user_id     = $translation->user_id_last_modified;
 				$status      = $translation->status;
 				$happened_at = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, new DateTimeZone( 'UTC' ) );
+
 				if ( $translation_before->status === $status ) {
 					// Translation hasn't changed status, so there's nothing for us to track.
 					return;

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -38,7 +38,6 @@ class Stats_Listener {
 				$user_id     = $translation->user_id_last_modified;
 				$status      = $translation->status;
 				$happened_at = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $translation->date_modified, new DateTimeZone( 'UTC' ) );
-
 				if ( $translation_before->status === $status ) {
 					// Translation hasn't changed status, so there's nothing for us to track.
 					return;
@@ -68,9 +67,6 @@ class Stats_Listener {
 
 	private function handle_action( GP_Translation $translation, int $user_id, string $action, DateTimeImmutable $happened_at ): void {
 		try {
-			if ( ! $user_id ) {
-				return;
-			}
 			// Get events that are active when the action happened, for which the user is registered for.
 			$active_events = $this->get_active_events( $happened_at );
 			$events        = $this->select_events_user_is_registered_for( $active_events, $user_id );

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -25,6 +25,9 @@ class Stats_Listener {
 			'gp_translation_created',
 			function ( $translation ) {
 				$happened_at = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $translation->date_added, new DateTimeZone( 'UTC' ) );
+				if ( ! $translation->user_id ) {
+					return;
+				}
 				$this->handle_action( $translation, $translation->user_id, self::ACTION_CREATE, $happened_at );
 			},
 		);
@@ -54,7 +57,7 @@ class Stats_Listener {
 						break;
 				}
 
-				if ( $action ) {
+				if ( $action && $user_id ) {
 					$this->handle_action( $translation, $user_id, $action, $happened_at );
 				}
 			},

--- a/tests/lib/translation-factory.php
+++ b/tests/lib/translation-factory.php
@@ -13,7 +13,7 @@ class Translation_Factory {
 		$this->set        = $this->gp_factory->translation_set->create_with_project_and_locale();
 	}
 
-	public function create( int $user_id ) {
+	public function create( $user_id ) {
 		$original = $this->gp_factory->original->create(
 			array(
 				'project_id' => $this->set->project->id,

--- a/tests/lib/translation-factory.php
+++ b/tests/lib/translation-factory.php
@@ -13,7 +13,7 @@ class Translation_Factory {
 		$this->set        = $this->gp_factory->translation_set->create_with_project_and_locale();
 	}
 
-	public function create( $user_id ) {
+	public function create( int $user_id ) {
 		$original = $this->gp_factory->original->create(
 			array(
 				'project_id' => $this->set->project->id,

--- a/tests/stats-listener.php
+++ b/tests/stats-listener.php
@@ -58,6 +58,14 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
 
+		// Simulate a translation that arrived via import.
+		$translation = $this->translation_factory->create( 0 );
+		$translation->user_id = null;
+		do_action( 'gp_translation_created', $translation );
+		$modified_translation = clone $translation;
+		$modified_translation->status = 'rejected';
+		do_action( 'gp_translation_saved', $modified_translation, $translation );
+
 		$stats_count = $this->stats_factory->get_count();
 		$this->assertEquals( 0, $stats_count );
 	}

--- a/tests/stats-listener.php
+++ b/tests/stats-listener.php
@@ -59,10 +59,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		// Stats_Listener will have been called.
 
 		// Simulate a translation that arrived via import.
-		$translation = $this->translation_factory->create( 0 );
+		$translation          = $this->translation_factory->create( 0 );
 		$translation->user_id = null;
 		do_action( 'gp_translation_created', $translation );
-		$modified_translation = clone $translation;
+		$modified_translation         = clone $translation;
 		$modified_translation->status = 'rejected';
 		do_action( 'gp_translation_saved', $modified_translation, $translation );
 


### PR DESCRIPTION
Fixes this error
`
E_ERROR: Uncaught TypeError: Argument 2 passed to Wporg\TranslationEvents\Stats_Listener::handle_action() must be of the type int, null given, called in /home/wporg/public_html/wp-content/plugins/wporg-gp-translation-events/includes/stats-listener.php on line 28 and defined in /home/wporg/public_html/wp-content/plugins/wporg-gp-translation-events/includes/stats-listener.php:66
`