### PR TITLE
Improve event dates

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -204,10 +204,11 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 .event-details-date {
 	background: #f4f4f4;
 	color: #606161;
-	padding: .5em;
+	padding: 0.1em .5em;
 	font-size: .9em;
 	line-height: 1.8em;
 	font-weight: 500;
+	margin-bottom: 1em;
 }
 .event-page-edit-link {
 	float: right;

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -3,28 +3,34 @@
 	width: 140px;
 	vertical-align: top;
 }
+
 .translation-event-form #event-title,
 .translation-event-form #event-description {
 	width: 30%;
 }
+
 .translation-event-form input[type="text"],
 .translation-event-form input[type="date"] {
 	width: 13%;
 }
+
 .translation-event-form div {
 	margin-top: 1em;
 }
+
 .translation-event-form #submit-event {
 	margin-left: 10%;
 	width: 30%;
 	margin-top: 1em;
 	display: block;
 }
+
 .event-details-page {
 	border-bottom: #cfd4d4 thin solid;
 	width: 60%;
 	margin: 0 auto;
 }
+
 .event-details-left {
 	width: 77%;
 	float: left;
@@ -32,38 +38,48 @@
 	margin-right: 1%;
 	padding-right: 1em;
 }
+
 .event-details-right {
 	width: 22%;
 	float: right;
 	padding-top: 1em;
 }
+
 .event-details-stats {
 	clear: both;
 	margin: 1em;
 }
+
 .event-details-stats table {
 	width: 100%;
 	table-layout: fixed;
 }
-.event-details-stats table th, .event-details-stats table td {
+
+.event-details-stats table th,
+.event-details-stats table td {
 	padding: 1em;
 	text-align: center;
 }
+
 .event-details-stats table td:first-child {
 	text-align: left;
 	word-break: break-all;
 }
+
 .event-details-stats table tr {
 	border-bottom: thin solid #f0f0f0;
 }
+
 .event-details-stats table th {
 	background-color: #e9e9e9;
 	/* allow breaking the word anywhere so that it doesn't overflow */
 	word-break: break-all;
 }
+
 .event-details-stats-totals td {
 	font-weight: bold;
 }
+
 .event-contributors li {
 	display: inline-block;
 	list-style-type: none;
@@ -71,48 +87,60 @@
 	margin-bottom: .5em;
 	width: 15em;
 }
+
 .event-contributors li .avatar {
 	border-radius: 50%;
 	vertical-align: middle;
 }
+
 .hide-event-url {
 	display: none;
 }
+
 .translation-event-form button.save-draft {
 	background: #fff;
 	color: var(--gp-color-btn-primary-bg);
 }
+
 #event-url span {
 	width: 10%;
 	display: inline-block;
 }
+
 span.event-list-date {
 	display: block;
 	color: #939393;
 	font-size: .8em;
 	font-weight: normal;
 }
+
 span.event-list-date.events-i-am-attending {
 	font-size: .8em;
 	font-weight: normal;
 }
-.event-list-item a{
+
+.event-list-item a {
 	font-weight: bold;
 	font-size: 1.2em;
 }
+
 li.event-list-item {
 	list-style-type: none;
+	margin-bottom: .5em;
 }
+
 li.event-list-item p {
 	margin-top: 0;
 	color: #5a5a5a;
 	font-size: .95em;
 }
+
 h2.event_page_title {
 	border-bottom: #e0e0e0 thin solid;
 	padding-bottom: 0.5em;
 	font-weight: bold;
 }
+
 .event-list-top-bar {
 	width: 80%;
 	margin: 0 auto;
@@ -122,45 +150,57 @@ h2.event_page_title {
 	border-bottom: #d9d8d8 thin solid;
 	padding-bottom: .5em;
 }
+
 .event-list-nav li {
 	display: inline;
 	margin: 0 0.1rem;
 }
+
 .event-list-nav li a {
 	text-decoration: none;
 	font-weight: bold;
 }
+
 .event-list-nav li:not(:first-child):not(:last-child):before {
 	content: " | ";
 }
+
 .event-left-col {
 	width: 75%;
 	float: left;
 	border-right: var(--gp-color-secondary-400) thin solid;
 }
+
 .event-right-col {
 	width: 25%;
 	float: left;
 	padding-left: 1em;
 }
+
 .event-attending-list {
 	list-style-type: none;
 	padding: 0;
 }
+
 .event-attending-list li {
 	margin-bottom: 1em;
 }
+
 .event-list-nav li a.button {
 	background-color: var(--gp-color-btn-primary-bg) !important;
 	color: #fff !important;
 }
+
 a.event-link-draft {
-	color:#80807f;
+	color: #80807f;
 }
-span.event-label-draft, span.event-details-join-expired, span.active-events-before-translation-table {
+
+span.event-label-draft,
+span.event-details-join-expired,
+span.active-events-before-translation-table {
 	font-weight: 500;
-	color: var( --gp-color-bubble-inactive-project-text );
-	border: 1px solid var( --gp-color-bubble-inactive-project-text );
+	color: var(--gp-color-bubble-inactive-project-text);
+	border: 1px solid var(--gp-color-bubble-inactive-project-text);
 	font-size: .7em;
 	margin-right: 0.3em;
 	width: 6em;
@@ -169,25 +209,30 @@ span.event-label-draft, span.event-details-join-expired, span.active-events-befo
 	border-radius: 1em;
 	text-transform: capitalize;
 }
+
 span.active-events-before-translation-table a {
-	color: var( --gp-color-bubble-inactive-project-text );
+	color: var(--gp-color-bubble-inactive-project-text);
 	text-decoration: none;
 }
+
 .active-events-before-translation-table {
 	width: 100%;
-	border: 1px solid var( --gp-color-border-default );
-	background: var( --gp-color-status-waiting-subtle );
+	border: 1px solid var(--gp-color-border-default);
+	background: var(--gp-color-status-waiting-subtle);
 	margin: 1rem 0;
 	padding: 0.3rem 0.8rem;
 }
+
 .event-page-wrapper {
 	margin: 0 auto;
 	width: 80%;
 }
+
 .event-list {
 	margin: 0;
 	padding: 0;
 }
+
 input[type="submit"].attend-btn {
 	width: 100%;
 	text-align: center;
@@ -195,12 +240,15 @@ input[type="submit"].attend-btn {
 	margin-top: 1em;
 	font-weight: bold;
 }
-input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
+
+input[type="submit"].attending-btn,
+a.button.is-primary.attend-btn {
 	width: 100%;
 	text-align: center;
 	display: block;
 	margin-top: 1em;
 }
+
 .event-details-date {
 	background: #f4f4f4;
 	color: #606161;
@@ -210,15 +258,18 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 	font-weight: 500;
 	margin-bottom: 1em;
 }
+
 .event-page-edit-link {
 	float: right;
 	text-decoration: none;
 	justify-self: end;
 	grid-column: 2;
 }
+
 .event-stats-summary {
 	margin-top: 1em;
 }
+
 .event-stats-summary summary {
 	background: #f8f8f8;
 	padding: 0.4em;
@@ -227,6 +278,7 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 	font-weight: 500;
 	font-size: .9em;
 }
+
 .event-stats-summary p.event-stats-text {
 	margin: 0;
 	background: #f8f8f8;
@@ -234,42 +286,58 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 	font-size: .9em;
 	border-top: thin solid #e0e0e0;
 }
+
 .event-details-date time {
 	font-size: .95em;
 	font-weight: normal;
 }
+
+.event-details-date time:last-child {
+	margin-bottom: 0;
+}
+
 .event-details-date time.full-time {
 	display: block;
 	border-bottom: #cdcdcd thin solid;
 	padding-bottom: 0.5em;
 	margin-bottom: 0.5em;
 }
+
 span.event-details-date-label {
 	font-weight: bold;
 	color: #5a5a5a;
 	display: block;
 }
+
 .event-host {
 	grid-column: 1;
 }
+
 p.event-sub-head {
 	grid-column: 1 / -1;
 	margin-top: 0;
 }
+
 a.event-page-edit-link {
 	font-size: .9em;
 	text-decoration: none;
 }
+
 a.event-page-edit-link:hover {
 	border-bottom: var(--gp-color-btn-primary-bg) thin solid;
 	text-decoration: none;
 }
+
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {
-	.event-page-wrapper, .event-details-right, .event-details-left {
+
+	.event-page-wrapper,
+	.event-details-right,
+	.event-details-left {
 		width: 100%;
 		float: none;
 	}
+
 	.event-details-left {
 		border-right: none;
 		margin: 0;

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -233,11 +233,12 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 	font-size: .9em;
 	border-top: thin solid #e0e0e0;
 }
-time.event-utc-time {
-	display: block;
+.event-details-date time {
 	font-size: .95em;
+	font-weight: normal;
 }
-.event-utc-time:first-of-type{
+.event-details-date time.full-time {
+	display: block;
 	border-bottom: #cdcdcd thin solid;
 	padding-bottom: 0.5em;
 	margin-bottom: 0.5em;

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -9,6 +9,7 @@
 				}
 				validateEventDates();
 				convertToUserLocalTime();
+				setInterval( convertToUserLocalTime, 10000 );
 
 				$( '.submit-event' ).on(
 					'click',
@@ -148,10 +149,66 @@
 			}
 			timeElements.forEach(
 				function ( timeEl ) {
-					const eventDateObj         = new Date( timeEl.getAttribute( 'datetime' ) );
+					const datetime = timeEl.getAttribute( 'datetime' );
+					if ( ! datetime ) {
+						return;
+					}
+					const eventDateObj = new Date( datetime );
+					timeEl.title = eventDateObj.toUTCString();
+
 					const userTimezoneOffset   = new Date().getTimezoneOffset();
 					const userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
 					const userLocalDateTime    = new Date( eventDateObj.getTime() - userTimezoneOffsetMs );
+
+					if ( timeEl.classList.contains( 'relative' ) ) {
+						// Display the relative time
+						const now = new Date();
+						let diff = userLocalDateTime - now;
+						let in_text = 'in ';
+						let ago_text = '';
+						if ( diff < 0 ) {
+							in_text = '';
+							ago_text = ' ago';
+							diff = - diff;
+						}
+						const seconds = Math.floor( diff / 1000 );
+						const minutes = Math.floor( seconds / 60 );
+						const hours = Math.floor( minutes / 60 );
+						const days = Math.floor( hours / 24 );
+						const weeks = Math.floor( days / 7 );
+						const months = Math.floor( days / 30 );
+						const years = Math.floor( days / 365.25 );
+						let relativeTime = '';
+						if ( years > 1 ) {
+							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) ) {
+								relativeTime = years + ' year' + ( years > 1 ? 's' : '' );
+							} else {
+								in_text = '';
+							}
+						} else if ( months > 1 ) {
+							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) ) {
+								relativeTime = months + ' month' + ( months > 1 ? 's' : '' );
+							} else {
+								in_text = '';
+							}
+						} else if ( weeks > 1 ) {
+							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) || weeks < 3 ) {
+								relativeTime = weeks + ' week' + ( weeks > 1 ? 's' : '' );
+							} else {
+								in_text = '';
+							}
+						} else if ( days > 0 ) {
+							relativeTime = days + ' day' + ( days > 1 ? 's' : '' );
+						} else if ( hours > 0 ) {
+							relativeTime = hours + ' hour' + ( hours > 1 ? 's' : '' );
+						} else if ( minutes > 0 ) {
+							relativeTime = minutes + ' minute' + ( minutes > 1 ? 's' : '' );
+						} else {
+							relativeTime = seconds + ' second' + ( seconds > 1 ? 's' : '' );
+						}
+						timeEl.textContent = in_text + relativeTime + ago_text;
+						return;
+					}
 
 					const options      = {
 						weekday: 'short',

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -154,30 +154,30 @@
 						return;
 					}
 					const eventDateObj = new Date( datetime );
-					timeEl.title = eventDateObj.toUTCString();
+					timeEl.title       = eventDateObj.toUTCString();
 
 					const userTimezoneOffset   = new Date().getTimezoneOffset();
 					const userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
 					const userLocalDateTime    = new Date( eventDateObj.getTime() - userTimezoneOffsetMs );
 
 					if ( timeEl.classList.contains( 'relative' ) ) {
-						// Display the relative time
-						const now = new Date();
-						let diff = userLocalDateTime - now;
-						let in_text = 'in ';
+						// Display the relative time.
+						const now    = new Date();
+						let diff     = userLocalDateTime - now;
+						let in_text  = 'in ';
 						let ago_text = '';
 						if ( diff < 0 ) {
-							in_text = '';
+							in_text  = '';
 							ago_text = ' ago';
-							diff = - diff;
+							diff     = - diff;
 						}
-						const seconds = Math.floor( diff / 1000 );
-						const minutes = Math.floor( seconds / 60 );
-						const hours = Math.floor( minutes / 60 );
-						const days = Math.floor( hours / 24 );
-						const weeks = Math.floor( days / 7 );
-						const months = Math.floor( days / 30 );
-						const years = Math.floor( days / 365.25 );
+						const seconds    = Math.floor( diff / 1000 );
+						const minutes    = Math.floor( seconds / 60 );
+						const hours      = Math.floor( minutes / 60 );
+						const days       = Math.floor( hours / 24 );
+						const weeks      = Math.floor( days / 7 );
+						const months     = Math.floor( days / 30 );
+						const years      = Math.floor( days / 365.25 );
 						let relativeTime = '';
 						if ( years > 1 ) {
 							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) ) {

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -215,7 +215,7 @@
 						return;
 					}
 
-					const options      = {
+					const options = {
 						weekday: 'short',
 						year: 'numeric',
 						month: 'short',

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -167,10 +167,15 @@
 						let in_text  = 'in ';
 						let ago_text = '';
 						if ( diff < 0 ) {
+							if ( timeEl.classList.contains( 'future' ) ) {
+								// If an event transitions from future to past, reload the page to move it from active to past events and vice versa.
+								location.reload();
+							}
 							in_text  = '';
 							ago_text = ' ago';
 							diff     = - diff;
 						}
+
 						const seconds    = Math.floor( diff / 1000 );
 						const minutes    = Math.floor( seconds / 60 );
 						const hours      = Math.floor( minutes / 60 );
@@ -204,7 +209,7 @@
 						} else if ( minutes > 0 ) {
 							relativeTime = minutes + ' minute' + ( minutes > 1 ? 's' : '' );
 						} else {
-							relativeTime = seconds + ' second' + ( seconds > 1 ? 's' : '' );
+							relativeTime = 'less than a minute';
 						}
 						timeEl.textContent = in_text + relativeTime + ago_text;
 						return;
@@ -219,6 +224,18 @@
 						minute: 'numeric',
 						timeZoneName: 'short'
 					};
+					if ( timeEl.dataset.format ) {
+						if ( timeEl.dataset.format.includes( 'l' ) ) {
+							options.weekday = 'long';
+						} else if ( ! timeEl.dataset.format.includes( 'D' ) ) {
+							delete options.weekday;
+						}
+						if ( timeEl.dataset.format.includes( 'F' ) ) {
+							options.month = 'long';
+						} else if ( timeEl.dataset.format.includes( 'm' ) || timeEl.dataset.format.includes( 'n' ) ) {
+							options.month = 'numeric';
+						}
+					}
 					timeEl.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
 				}
 			);

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -62,7 +62,6 @@ abstract class Event_Date extends DateTimeImmutable {
 			return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
 		}
 
-
 		$interval       = $this->diff( $current_date_time );
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
 		$hours_in_a_day = 24;

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -15,8 +15,13 @@ abstract class Event_Date extends DateTimeImmutable {
 			$timezone = new DateTimeZone( 'UTC' );
 		}
 
-		$utc_date = new DateTime( $date, new DateTimeZone( 'UTC' ) );
-		$utc_date->setTimezone( $timezone );
+		try {
+			$utc_date = new DateTime( $date, new DateTimeZone( 'UTC' ) );
+			$utc_date->setTimezone( $timezone );
+		} catch ( Exception $e ) {
+			$utc_date = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		}
+
 		parent::__construct( $utc_date->format( 'Y-m-d H:i:s' ), $timezone );
 		$this->timezone = $timezone;
 	}

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Wporg\TranslationEvents;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+abstract class Event_Date extends DateTimeImmutable {
+	abstract public function is_end_date() : bool;
+	public $timezone;
+	public function __construct( string $date, DateTimeZone $timezone = null ) {
+		if ( ! $timezone ) {
+			$timezone = new DateTimeZone( 'UTC' );
+		}
+
+		$utc_date = new DateTime( $date, new DateTimeZone( 'UTC' ) );
+		$utc_date->setTimezone( $timezone );
+		parent::__construct( $utc_date->format( 'Y-m-d H:i:s' ), $timezone );
+		$this->timezone = $timezone;
+	}
+
+	/**
+	 * Get the standard formatted text for the date in UTC.
+	 *
+	 * @return string The date text.
+	 */
+	public function __toString(): string {
+		return $this->utc( 'Y-m-d H:i:s' );
+	}
+	/**
+	 * Get the local formatted text for the date in UTC.
+	 *
+	 * @return string The date text.
+	 */
+	public function utc( $format ): string {
+		return $this->setTimeZone( new DateTimeZone( 'UTC' ) )->format( $format );
+	}
+
+	public function is_in_the_past() {
+		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		return $this < $current_date_time;
+	}
+
+	/**
+	 * Generate variable text depending on when the event starts or ends.
+	 *
+	 * @return string The end date text.
+	 */
+	public static function get_variable_text(): string {
+		if ( ! $this->is_end_date() ) {
+			return $this->__toString( $this );
+		}
+
+		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		$interval       = $this->diff( $current_date_time );
+		$hours_left     = ( $interval->d * 24 ) + $interval->h;
+		$hours_in_a_day = 24;
+
+		if ( 0 === $hours_left ) {
+			/* translators: %s: Number of minutes left. */
+			return sprintf( _n( 'ends in %s minute', 'ends in %s minutes', $interval->i ), $interval->i );
+		} elseif ( $hours_left <= $hours_in_a_day ) {
+			/* translators: %s: Number of hours left. */
+			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
+		}
+		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
+	}
+}
+
+class Event_Start_Date extends Event_Date {
+	public function is_end_date() : bool {
+		return false;
+	}
+}
+
+class Event_End_Date extends Event_Date {
+	public function is_end_date() : bool {
+		return true;
+	}
+}

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -58,41 +58,116 @@ abstract class Event_Date extends DateTimeImmutable {
 		return $this->utc() < $current_date_time;
 	}
 
+	public function print_relative_time_html( $format = false ) {
+		echo wp_kses(
+			'<time
+				class="event-utc-time relative' . ( $this->is_in_the_past() ? '' : ' future' ) . '"
+				datetime="' . esc_attr( $this ) . '">' . esc_html( $format ? $this->format( $format ) : $this->get_variable_text() ) . '</time>',
+			array(
+				'time' => array(
+					'class'    => array(),
+					'datetime' => array(),
+				),
+			)
+		);
+	}
+
+	public function print_time_html( $format = 'D, F j, Y H:i T' ) {
+		echo wp_kses(
+			'<time
+				class="event-utc-time full-time"
+				data-format="' . esc_attr( $format ) . '"
+				datetime="' . esc_attr( $this ) . '">' . esc_html( $this->format( $format ) ) . '</time>',
+			array(
+				'time' => array(
+					'class'       => array(),
+					'datetime'    => array(),
+					'data-format' => array(),
+				),
+			)
+		);
+	}
+
 	/**
 	 * Generate variable text depending on when the event starts or ends.
 	 *
 	 * @return string The end date text.
 	 */
-	public function get_variable_text(): string {
-		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		if ( $this instanceof Event_Start_Date ) {
-			if ( $this->is_in_the_past() ) {
-				return sprintf( 'started %s', $this->format( 'l, F j, Y' ) );
-			}
-			return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
-		}
+	abstract public function get_variable_text(): string;
+}
 
-		$interval       = $this->diff( $current_date_time );
+class Event_Start_Date extends Event_Date {
+	public function get_variable_text(): string {
+		$interval       = $this->diff( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) );
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
 		$hours_in_a_day = 24;
 
-		if ( 0 === $hours_left ) {
-			/* translators: %s: Number of minutes left. */
-			return sprintf( _n( 'ends in %s minute', 'ends in %s minutes', $interval->i ), $interval->i );
-		} elseif ( $hours_left <= $hours_in_a_day ) {
-			/* translators: %s: Number of hours left. */
-			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
+		if ( $this->is_in_the_past() ) {
+			if ( 0 === $hours_left ) {
+				/* translators: %s: Number of minutes left. */
+				return sprintf( _n( 'started %s minute ago', 'started %s minutes ago', $interval->i ), $interval->i );
+			}
+
+			if ( $hours_left >= $hours_in_a_day ) {
+				/* translators: %s: Number of hours left. */
+				return sprintf( _n( 'started %s hour ago', 'started %s hours ago', $hours_left ), $hours_left );
+			}
+
+			// translators: %s: A date.
+			return sprintf( __( 'started %s', 'gp-translation-events' ), $this->format( 'D, F j, Y H:i T' ) );
 		}
+
+		if ( 0 === $hours_left ) {
+			if ( ! $interval->i ) {
+				return __( 'starts in less than a minute', 'gp-translation-events' );
+			}
+			/* translators: %s: Number of minutes left. */
+			return sprintf( _n( 'starts in %s minute', 'starts in %s minutes', $interval->i, 'gp-translation-events' ), $interval->i );
+		}
+
+		if ( $hours_left <= $hours_in_a_day ) {
+			/* translators: %s: Number of hours left. */
+			$out = sprintf( _n( 'starts in %s hour', 'starts in %s hours', $hours_left, 'gp-translation-events' ), $hours_left );
+			if ( $interval->i ) {
+				/* translators: %s: Number of minutes left. */
+				$out .= sprintf( _n( ' and %s minute', ' and %s minutes', $interval->i, 'gp-translation-events' ), $interval->i );
+			}
+			return $out;
+		}
+
+		// translators: %s: A date.
+		return sprintf( __( 'started %s', 'gp-translation-events' ), $this->format( 'D, F j, Y H:i T' ) );
+	}
+}
+
+class Event_End_Date extends Event_Date {
+	public function get_variable_text(): string {
 		if ( $this->is_in_the_past() ) {
 			return sprintf( 'ended %s', $this->format( 'l, F j, Y' ) );
 		}
 
-		return sprintf( 'until %s', $this->format( 'l, F j, Y' ) );
+		$interval       = $this->diff( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) );
+		$hours_left     = ( $interval->d * 24 ) + $interval->h;
+		$hours_in_a_day = 24;
+
+		if ( 0 === $hours_left ) {
+			if ( ! $interval->i ) {
+				return __( 'ends in less than a minute', 'gp-translation-events' );
+			}
+			/* translators: %s: Number of minutes left. */
+			return sprintf( _n( 'ends in %s minute', 'ends in %s minutes', $interval->i, 'gp-translation-events' ), $interval->i );
+		}
+
+		if ( $hours_left <= $hours_in_a_day ) {
+			/* translators: %s: Number of hours left. */
+			$out = sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left, 'gp-translation-events' ), $hours_left );
+			if ( $interval->i ) {
+				/* translators: %s: Number of minutes left. */
+				$out .= sprintf( _n( ' and %s minute', ' and %s minutes', $interval->i, 'gp-translation-events' ), $interval->i );
+			}
+			return $out;
+		}
+
+		return sprintf( 'until %s', $this->format( 'l, F j, Y H:i' ) );
 	}
-}
-
-class Event_Start_Date extends Event_Date {
-}
-
-class Event_End_Date extends Event_Date {
 }

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -8,7 +8,7 @@ use DateTimeZone;
 use Exception;
 
 /**
- * class Event_Date
+ * Event_Date
  *
  * The event date is in local time, get the UTC time via the utc() method.
  *

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -50,7 +50,7 @@ abstract class Event_Date extends DateTimeImmutable {
 	 */
 	public static function get_variable_text(): string {
 		if ( ! $this->is_end_date() ) {
-			return $this->__toString( $this );
+		return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
 		}
 
 		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
@@ -66,7 +66,7 @@ abstract class Event_Date extends DateTimeImmutable {
 			/* translators: %s: Number of hours left. */
 			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
 		}
-		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
+		return sprintf( 'until %s', $this->format( 'M j, Y' ) );
 	}
 }
 

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -8,7 +8,7 @@ use DateTimeZone;
 use Exception;
 
 abstract class Event_Date extends DateTimeImmutable {
-	abstract public function is_end_date() : bool;
+	abstract public function is_end_date(): bool;
 	public $timezone;
 	public function __construct( string $date, DateTimeZone $timezone = null ) {
 		if ( ! $timezone ) {
@@ -50,7 +50,7 @@ abstract class Event_Date extends DateTimeImmutable {
 	 */
 	public static function get_variable_text(): string {
 		if ( ! $this->is_end_date() ) {
-		return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
+			return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
 		}
 
 		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
@@ -71,13 +71,13 @@ abstract class Event_Date extends DateTimeImmutable {
 }
 
 class Event_Start_Date extends Event_Date {
-	public function is_end_date() : bool {
+	public function is_end_date(): bool {
 		return false;
 	}
 }
 
 class Event_End_Date extends Event_Date {
-	public function is_end_date() : bool {
+	public function is_end_date(): bool {
 		return true;
 	}
 }

--- a/includes/event-date.php
+++ b/includes/event-date.php
@@ -48,12 +48,15 @@ abstract class Event_Date extends DateTimeImmutable {
 	 *
 	 * @return string The end date text.
 	 */
-	public static function get_variable_text(): string {
+	public function get_variable_text(): string {
+		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		if ( ! $this->is_end_date() ) {
+			if ( $this < $current_date_time ) {
+				return sprintf( 'started %s', $this->format( 'l, F j, Y' ) );
+			}
 			return sprintf( 'starts %s', $this->format( 'l, F j, Y' ) );
 		}
 
-		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		$interval       = $this->diff( $current_date_time );
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
@@ -66,7 +69,11 @@ abstract class Event_Date extends DateTimeImmutable {
 			/* translators: %s: Number of hours left. */
 			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
 		}
-		return sprintf( 'until %s', $this->format( 'M j, Y' ) );
+		if ( $this < $current_date_time ) {
+			return sprintf( 'ended %s', $this->format( 'l, F j, Y' ) );
+		}
+
+		return sprintf( 'until %s', $this->format( 'l, F j, Y' ) );
 	}
 }
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -300,16 +300,12 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	private function update_event_meta( Event $event ) {
-		update_post_meta( $event->id(), '_event_start', $this->serialize_utc_datetime( $event->start() ) );
-		update_post_meta( $event->id(), '_event_end', $this->serialize_utc_datetime( $event->end() ) );
+		update_post_meta( $event->id(), '_event_start', $event->start()->utc()->format( 'Y-m-d H:i:s' ) );
+		update_post_meta( $event->id(), '_event_end', $event->end()->utc()->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event->id(), '_event_timezone', $event->timezone()->getName() );
 	}
 
 	private function parse_utc_datetime( string $datetime ): DateTimeImmutable {
 		return DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $datetime, new DateTimeZone( 'UTC' ) );
-	}
-
-	private function serialize_utc_datetime( DateTimeImmutable $value ): string {
-		return $value->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -66,7 +66,8 @@ class Event {
 	}
 
 	/**
-	 * @throws InvalidStartOrEnd
+	 * @throws InvalidStart
+	 * @throws InvalidEnd
 	 * @throws InvalidStatus
 	 * @throws InvalidTitle
 	 */
@@ -190,7 +191,8 @@ class Event {
 	}
 
 	/**
-	 * @throws InvalidStartOrEnd
+	 * @throws InvalidStart
+	 * @throws InvalidEnd
 	 */
 	private function validate_times( DateTimeImmutable $start, DateTimeImmutable $end ) {
 		if ( $end <= $start ) {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -4,12 +4,20 @@ namespace Wporg\TranslationEvents\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event_End_Date;
 use Exception;
 use Throwable;
 
-class InvalidStartOrEnd extends Exception {
+class InvalidStart extends Exception {
 	public function __construct( Throwable $previous = null ) {
-		parent::__construct( 'Event start or end are invalid', 0, $previous );
+		parent::__construct( 'Event start is invalid', 0, $previous );
+	}
+}
+
+class InvalidEnd extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event end is invalid', 0, $previous );
 	}
 }
 
@@ -186,13 +194,13 @@ class Event {
 	 */
 	private function validate_times( DateTimeImmutable $start, DateTimeImmutable $end ) {
 		if ( $end <= $start ) {
-			throw new InvalidStartOrEnd();
+			throw new InvalidEnd();
 		}
 		if ( ! $start->getTimezone() || 'UTC' !== $start->getTimezone()->getName() ) {
-			throw new InvalidStartOrEnd();
+			throw new InvalidStart();
 		}
 		if ( ! $end->getTimezone() || 'UTC' !== $end->getTimezone()->getName() ) {
-			throw new InvalidStartOrEnd();
+			throw new InvalidEnd();
 		}
 	}
 }

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -86,12 +86,12 @@ class Event {
 		return $this->id;
 	}
 
-	public function start(): DateTimeImmutable {
-		return $this->start;
+	public function start(): Event_Start_Date {
+		return new Event_Start_Date( $this->start->format( 'Y-m-d H:i:s' ), $this->timezone() );
 	}
 
-	public function end(): DateTimeImmutable {
-		return $this->end;
+	public function end(): Event_End_Date {
+		return new Event_End_Date( $this->end->format( 'Y-m-d H:i:s' ), $this->timezone() );
 	}
 
 	public function timezone(): DateTimeZone {

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -4,6 +4,9 @@ namespace Wporg\TranslationEvents\Routes\Event;
 
 use Wporg\TranslationEvents\Routes\Route;
 
+use DateTimeZone;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 /**
  * Displays the event create page.
  */
@@ -20,12 +23,12 @@ class Create_Route extends Route {
 		$event_id                 = null;
 		$event_title              = '';
 		$event_description        = '';
-		$event_timezone           = '';
-		$event_start              = '';
-		$event_end                = '';
 		$event_url                = '';
 		$create_delete_button     = true;
 		$visibility_delete_button = 'none';
+		$event_timezone           = null;
+		$event_start              = new Event_Start_Date( date_i18n( 'Y - m - d H:i' ) );
+		$event_end                = new Event_End_Date( date_i18n( 'Y - m - d H:i' ) );
 
 		$this->tmpl( 'events-form', get_defined_vars() );
 	}

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -62,7 +62,7 @@ class Details_Route extends Route {
 		$is_editable_event = true;
 		$event_end_utc     = new DateTime( get_post_meta( $event_id, '_event_end', true ), new DateTimeZone( 'UTC' ) );
 		$now_utc           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-		if ( $now_utc > $event_end_utc || $stats_calculator->event_has_stats( $event ) ) {
+		if ( $event_end->is_in_the_past() || $stats_calculator->event_has_stats( $event ) ) {
 			$is_editable_event = false;
 		}
 

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -10,6 +10,8 @@ use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event_End_Date;
 
 /**
  * Displays the event details page.
@@ -42,8 +44,8 @@ class Details_Route extends Route {
 		$event_id          = $event->ID;
 		$event_title       = $event->post_title;
 		$event_description = $event->post_content;
-		$event_start       = get_post_meta( $event->ID, '_event_start', true ) ?: '';
-		$event_end         = get_post_meta( $event->ID, '_event_end', true ) ?: '';
+		$event_start       = new Event_Start_Date( get_post_meta( $event->ID, '_event_start', true ) ?: '' );
+		$event_end         = new Event_End_Date( get_post_meta( $event->ID, '_event_end', true ) ?: '' );
 		$user_is_attending = $this->attendee_repository->is_attending( $event_id, $user->ID );
 
 		$stats_calculator = new Stats_Calculator();

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -72,16 +72,4 @@ class Edit_Route extends Route {
 
 		$this->tmpl( 'events-form', get_defined_vars() );
 	}
-
-	/**
-	 * Convert date time stored in UTC to a date time in a time zone.
-	 *
-	 * @param string $date_time The date time in UTC.
-	 * @param string $time_zone The time zone.
-	 *
-	 * @return string The date time in the time zone.
-	 * @throws Exception When date is invalid.
-	 */
-	private static function convertToTimezone( string $date_time, string $time_zone ): string {
-	}
 }

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -9,6 +9,8 @@ use Exception;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event_End_Date;
 
 /**
  * Displays the event edit page.
@@ -38,23 +40,20 @@ class Edit_Route extends Route {
 		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
 		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
 		$event_url                     = get_site_url() . gp_url( wp_make_link_relative( $permalink ) );
-		$event_timezone                = get_post_meta( $event_id, '_event_timezone', true ) ?: '';
+		$event_timezone                = new DateTimeZone( get_post_meta( $event_id, '_event_timezone', true ) ?: 'UTC' );
 		$create_delete_button          = false;
 		$visibility_delete_button      = 'inline-flex';
 
 		try {
-			$event_start   = self::convertToTimezone( get_post_meta( $event_id, '_event_start', true ), $event_timezone );
-			$event_end     = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone );
-			$now           = self::convertToTimezone( 'now', $event_timezone );
-			$event_end_utc = new DateTime( get_post_meta( $event_id, '_event_end', true ), new DateTimeZone( 'UTC' ) );
-			$now_utc       = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$event_start = new Event_Start_Date( get_post_meta( $event_id, '_event_start', true ), $event_timezone );
+			$event_end   = new Event_End_Date( get_post_meta( $event_id, '_event_end', true ), $event_timezone );
 		} catch ( Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $e );
 			$this->die_with_error( esc_html__( 'Something is wrong.', 'gp-translation-events' ) );
 		}
 
-		if ( $now_utc > $event_end_utc ) {
+		if ( $event_end->is_in_the_past() ) {
 			$this->die_with_error( esc_html__( 'You cannot edit a past event.', 'gp-translation-events' ), 403 );
 		}
 
@@ -84,6 +83,5 @@ class Edit_Route extends Route {
 	 * @throws Exception When date is invalid.
 	 */
 	private static function convertToTimezone( string $date_time, string $time_zone ): string {
-		return ( new DateTime( $date_time, new DateTimeZone( 'UTC' ) ) )->setTimezone( new DateTimeZone( $time_zone ) )->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -65,7 +65,7 @@ class Edit_Route extends Route {
 
 		if ( ! $stats_calculator->event_has_stats( $event ) ) {
 			$current_user = wp_get_current_user();
-			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ( $now_utc < $event_end_utc ) ) {
+			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ! $event_end->is_in_the_past() ) {
 				$create_delete_button = true;
 			}
 		}

--- a/includes/routes/event/list.php
+++ b/includes/routes/event/list.php
@@ -122,7 +122,7 @@ class List_Route extends Route {
 				),
 			),
 			'orderby'        => 'meta_value',
-			'order'          => 'ASC',
+			'order'          => 'DESC',
 		);
 		$past_events_query = new WP_Query( $past_events_args );
 

--- a/templates/event.php
+++ b/templates/event.php
@@ -22,7 +22,6 @@ gp_breadcrumb_translation_events( array( esc_html( $event_title ) ) );
 gp_tmpl_header();
 $event_page_title = $event_title;
 gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
-$current_utc_time = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 ?>
 
 <div class="event-page-wrapper">

--- a/templates/event.php
+++ b/templates/event.php
@@ -151,8 +151,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div class="event-details-right">
 		<div class="event-details-date">
 			<p>
-				<span class="event-details-date-label">Starts:</span> <time class="event-utc-time" datetime="<?php echo esc_attr( $event_start ); ?>"></time>
-				<span class="event-details-date-label">Ends:</span><time class="event-utc-time" datetime="<?php echo esc_attr( $event_end ); ?>"></time>
+				<span class="event-details-date-label">Starts: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label">Ends: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>

--- a/templates/event.php
+++ b/templates/event.php
@@ -11,8 +11,8 @@ use WP_Post;
 /** @var int $event_id */
 /** @var string $event_title */
 /** @var string $event_description */
-/** @var string $event_start */
-/** @var string $event_end */
+/** @var Event_Start_Date $event_start */
+/** @var Event_End_Date $event_end */
 /** @var bool $user_is_attending */
 /** @var Event_Stats $event_stats */
 
@@ -152,13 +152,22 @@ $current_utc_time = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 	<div class="event-details-right">
 		<div class="event-details-date">
 			<p>
-				<span class="event-details-date-label"><?php echo esc_html( $event_start < $current_utc_time ? __( 'Started', 'gp-translation-events' ) : __( 'Starts', 'gp-translation-events' ) ); ?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
-				<span class="event-details-date-label"><?php echo esc_html( $event_end < $current_utc_time ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>" style="border-bottom: 0"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label">
+					<?php echo esc_html( $event_start->is_in_the_past() ? __( 'Started', 'gp-translation-events' ) : __( 'Starts', 'gp-translation-events' ) ); ?>:
+					<?php $event_start->print_relative_time_html(); ?>
+				</span>
+				<?php $event_start->print_time_html(); ?>
+				<span class="event-details-date-label">
+					<?php echo esc_html( $event_end->is_in_the_past() ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>:
+					<?php $event_end->print_relative_time_html(); ?>
+
+				</span>
+				<?php $event_end->print_time_html(); ?>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
-			<?php if ( $event_end > $current_utc_time ) : ?>
+			<?php if ( $event_end->is_in_the_past() ) : ?>
 				<?php if ( $user_is_attending ) : ?>
 					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></button>
 				<?php endif; ?>
@@ -175,7 +184,7 @@ $current_utc_time = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 		<?php else : ?>
 		<div class="event-details-join">
 			<p>
-				<?php if ( $event_end > $current_utc_time ) : ?>
+				<?php if ( ! $event_end->is_in_the_past() ) : ?>
 					<a href="<?php echo esc_url( wp_login_url() ); ?>" class="button is-primary attend-btn"><?php esc_html_e( 'Login to attend', 'gp-translation-events' ); ?></a>
 				<?php else : ?>
 					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'Event is over', 'gp-translation-events' ); ?></button>

--- a/templates/event.php
+++ b/templates/event.php
@@ -22,6 +22,7 @@ gp_breadcrumb_translation_events( array( esc_html( $event_title ) ) );
 gp_tmpl_header();
 $event_page_title = $event_title;
 gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
+$current_utc_time = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 ?>
 
 <div class="event-page-wrapper">
@@ -151,34 +152,34 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div class="event-details-right">
 		<div class="event-details-date">
 			<p>
-				<span class="event-details-date-label">Starts: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
-				<span class="event-details-date-label">Ends: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label"><?php echo esc_html( $event_start < $current_utc_time ? __( 'Started', 'gp-translation-events' ) : __( 'Starts', 'gp-translation-events' ) );?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label"><?php echo esc_html( $event_end < $current_utc_time ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) );?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>" style="border-bottom: 0"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>
 		<div class="event-details-join">
-			<?php
-			$current_time = gmdate( 'Y-m-d H:i:s' );
-			if ( strtotime( $current_time ) > strtotime( $event_end ) ) :
-				?>
+			<?php if ( $event_end > $current_utc_time ) : ?>
 				<?php if ( $user_is_attending ) : ?>
-					<span class="event-details-join-expired"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></span>
-				<?php endif ?>
+					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></button>
+				<?php endif; ?>
 			<?php else : ?>
 				<form class="event-details-attend" method="post" action="<?php echo esc_url( gp_url( "/events/attend/$event_id" ) ); ?>">
 					<?php if ( ! $user_is_attending ) : ?>
 						<input type="submit" class="button is-primary attend-btn" value="Attend Event"/>
 					<?php else : ?>
 						<input type="submit" class="button is-secondary attending-btn" value="You're attending"/>
-					<?php endif ?>
+					<?php endif; ?>
 				</form>
-			<?php endif ?>
+			<?php endif; ?>
 		</div>
 		<?php else : ?>
 		<div class="event-details-join">
 			<p>
-				<?php global $wp; ?>
-				<a href="<?php echo esc_url( wp_login_url( home_url( $wp->request ) ) ); ?>" class="button is-primary attend-btn"><?php esc_html_e( 'Login to attend', 'gp-translation-events' ); ?></a>
+				<?php if ( $event_end > $current_utc_time ) : ?>
+					<a href="<?php echo esc_url( wp_login_url() ); ?>" class="button is-primary attend-btn"><?php esc_html_e( 'Login to attend', 'gp-translation-events' ); ?></a>
+				<?php else : ?>
+					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'Event is over', 'gp-translation-events' ); ?></button>
+				<?php endif; ?>
 			</p>
 		</div>
 		<?php endif; ?>

--- a/templates/event.php
+++ b/templates/event.php
@@ -152,8 +152,8 @@ $current_utc_time = new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) );
 	<div class="event-details-right">
 		<div class="event-details-date">
 			<p>
-				<span class="event-details-date-label"><?php echo esc_html( $event_start < $current_utc_time ? __( 'Started', 'gp-translation-events' ) : __( 'Starts', 'gp-translation-events' ) );?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
-				<span class="event-details-date-label"><?php echo esc_html( $event_end < $current_utc_time ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) );?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>" style="border-bottom: 0"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label"><?php echo esc_html( $event_start < $current_utc_time ? __( 'Started', 'gp-translation-events' ) : __( 'Starts', 'gp-translation-events' ) ); ?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_start ); ?>"></time></span> <time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_start ); ?>"><?php echo esc_attr( $event_start->format( 'l, F j, Y H:i T' ) ); ?></time>
+				<span class="event-details-date-label"><?php echo esc_html( $event_end < $current_utc_time ? __( 'Ended', 'gp-translation-events' ) : __( 'Ends', 'gp-translation-events' ) ); ?>: <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></span><time class="event-utc-time full-time" datetime="<?php echo esc_attr( $event_end ); ?>" style="border-bottom: 0"><?php echo esc_attr( $event_end->format( 'l, F j, Y H:i T' ) ); ?></time>
 			</p>
 		</div>
 		<?php if ( is_user_logged_in() ) : ?>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -42,11 +42,11 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<div>
 		<label for="event-start">Start Date</label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s') ); ?>" required>
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" required>
 	</div>
 	<div>
 		<label for="event-end">End Date</label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s') ); ?>" required>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" required>
 	</div>
 	<div>
 		<label for="event-timezone">Event Timezone</label>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -42,18 +42,18 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<div>
 		<label for="event-start">Start Date</label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start ); ?>" required>
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s') ); ?>" required>
 	</div>
 	<div>
 		<label for="event-end">End Date</label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end ); ?>" required>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s') ); ?>" required>
 	</div>
 	<div>
 		<label for="event-timezone">Event Timezone</label>
 		<select id="event-timezone" name="event_timezone"  required>
 			<?php
 			echo wp_kses(
-				wp_timezone_choice( $event_timezone, get_user_locale() ),
+				wp_timezone_choice( $event_timezone->getName(), get_user_locale() ),
 				array(
 					'optgroup' => array( 'label' => array() ),
 					'option'   => array(

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -10,9 +10,9 @@ namespace Wporg\TranslationEvents;
 /** @var int    $event_id */
 /** @var string $event_title */
 /** @var string $event_description */
-/** @var string $event_start */
-/** @var string $event_end */
-/** @var string $event_timezone */
+/** @var Event_Start_Date $event_start */
+/** @var Event_End_Date $event_end */
+/** @var Datetime_Timezone|null $event_timezone */
 /** @var string $event_url */
 /** @var string $css_show_url */
 
@@ -50,10 +50,10 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<div>
 		<label for="event-timezone">Event Timezone</label>
-		<select id="event-timezone" name="event_timezone"  required>
+		<select id="event-timezone" name="event_timezone" required>
 			<?php
 			echo wp_kses(
-				wp_timezone_choice( $event_timezone->getName(), get_user_locale() ),
+				wp_timezone_choice( $event_timezone ? $event_timezone->getName() : null, get_user_locale() ),
 				array(
 					'optgroup' => array( 'label' => array() ),
 					'option'   => array(

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -35,7 +35,7 @@ if ( $current_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date">ends <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></time></span>
+				<span class="event-list-date">ends <?php $event_end->print_relative_time_html(); ?></time></span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -35,7 +35,7 @@ if ( $current_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date">ends <time datetime="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time"><?php echo esc_html( $event_end ); ?></time> (<time datetime="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" class="relative hide-if-too-far event-utc-time"><?php echo esc_html( $event_end ); ?></time>)</span>
+				<span class="event-list-date">ends <time class="event-utc-time relative" datetime="<?php echo esc_attr( $event_end ); ?>"></time></span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php
@@ -69,7 +69,7 @@ if ( $upcoming_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date">starts <time datetime="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time"><?php echo esc_html( $event_start ); ?></time> (<time datetime="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time relative hide-if-too-far"><?php echo esc_html( $event_start ); ?></time>)</span>
+				<span class="event-list-date">starts <?php $event_start->print_relative_time_html(); ?></span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php
@@ -99,12 +99,11 @@ if ( $past_events_query->have_posts() ) :
 		<?php
 		while ( $past_events_query->have_posts() ) :
 			$past_events_query->the_post();
-			$event_start = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) );
-			$event_end   = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
+			$event_end = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date"><?php echo esc_html( $event_end->get_variable_text() ); ?></span>
+				<span class="event-list-date">ended <?php $event_end->print_relative_time_html( 'F j, Y H:i T' ); ?></span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php
@@ -135,7 +134,7 @@ endif;
 </div>
 <?php if ( is_user_logged_in() ) : ?>
 	<div class="event-right-col">
-		<h3 class="">Events I'm Attending</h3>
+		<h2>Events I'm Attending</h2>
 		<?php if ( ! $user_attending_events_query->have_posts() ) : ?>
 			<p>You don't have any events to attend.</p>
 		<?php else : ?>
@@ -149,9 +148,9 @@ endif;
 					<li class="event-list-item">
 						<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
 						<?php if ( $event_start === $event_end ) : ?>
-							<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?></span>
+							<span class="event-list-date events-i-am-attending"><?php $event_start->print_time_html( 'F j, Y H:i T' ); ?></span>
 						<?php else : ?>
-							<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
+							<span class="event-list-date events-i-am-attending"><?php $event_start->print_time_html( 'F j, Y H:i T' ); ?> - <?php $event_end->print_time_html( 'F j, Y H:i T' ); ?></span>
 						<?php endif; ?>
 					</li>
 					<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -104,11 +104,7 @@ if ( $past_events_query->have_posts() ) :
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
-				<?php if ( $event_start === $event_end ) : ?>
-					<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
-				<?php else : ?>
-					<span class="event-list-date"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
-				<?php endif; ?>
+				<span class="event-list-date"><?php echo esc_html( $event_end->get_variable_text() ); ?></span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -30,12 +30,12 @@ if ( $current_events_query->have_posts() ) :
 		<?php
 		while ( $current_events_query->have_posts() ) :
 			$current_events_query->the_post();
-			$event_end = Event::get_end_date_text( get_post_meta( get_the_ID(), '_event_end', true ) );
+			$event_end = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
 			$event_url = gp_url( wp_make_link_relative( get_the_permalink() ) );
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date"><?php echo esc_html( $event_end ); ?></span>
+				<span class="event-list-date">ends <time datetime="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time"><?php echo esc_html( $event_end ); ?></time> (<time datetime="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" class="relative hide-if-too-far event-utc-time"><?php echo esc_html( $event_end ); ?></time>)</span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php
@@ -65,11 +65,11 @@ if ( $upcoming_events_query->have_posts() ) :
 		<?php
 		while ( $upcoming_events_query->have_posts() ) :
 			$upcoming_events_query->the_post();
-			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'l, F j, Y' );
+			$event_start = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) );
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
-				<span class="event-list-date"><?php echo esc_html( $event_start ); ?></span>
+				<span class="event-list-date">starts <time datetime="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time"><?php echo esc_html( $event_start ); ?></time> (<time datetime="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" class="event-utc-time relative hide-if-too-far"><?php echo esc_html( $event_start ); ?></time>)</span>
 				<?php the_excerpt(); ?>
 			</li>
 			<?php
@@ -99,8 +99,8 @@ if ( $past_events_query->have_posts() ) :
 		<?php
 		while ( $past_events_query->have_posts() ) :
 			$past_events_query->the_post();
-			$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
-			$event_end   = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+			$event_start = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) );
+			$event_end   = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
 			?>
 			<li class="event-list-item">
 				<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>
@@ -147,8 +147,8 @@ endif;
 				<?php
 				while ( $user_attending_events_query->have_posts() ) :
 					$user_attending_events_query->the_post();
-					$event_start = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
-					$event_end   = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+					$event_start = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) );
+					$event_end   = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
 					?>
 					<li class="event-list-item">
 						<a href="<?php echo esc_url( gp_url( wp_make_link_relative( get_the_permalink() ) ) ); ?>"><?php the_title(); ?></a>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -33,8 +33,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
 			$event_edit_url                = gp_url( 'events/edit/' . $event_id );
 			$event_status                  = get_post_status( $event_id );
-			$event_start                   = ( new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
-			$event_end                     = ( new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+			$event_start                   = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) ) );
+			$event_end                     = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) ) );
 			$stats_calculator              = new Stats_Calculator();
 			$has_stats                     = $stats_calculator->event_has_stats( get_post() );
 
@@ -47,7 +47,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 				<?php if ( 'draft' === $event_status ) : ?>
 					<span class="event-label-<?php echo esc_attr( $event_status ); ?>"><?php echo esc_html( $event_status ); ?></span>
 				<?php endif; ?>
-				<?php if ( $event_start === $event_end ) : ?>
+				<?php if ( $event_start->format( 'Y-m-d' ) === $event_end->format( 'Y-m-d' ) ) : ?>
 					<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?></span>
 				<?php else : ?>
 					<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -33,17 +33,15 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
 			$event_edit_url                = gp_url( 'events/edit/' . $event_id );
 			$event_status                  = get_post_status( $event_id );
-			$event_start                   = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
-			$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
-			$event_end_utc                 = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
-			$now                           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$event_start                   = ( new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
+			$event_end                     = ( new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
 			$stats_calculator              = new Stats_Calculator();
 			$has_stats                     = $stats_calculator->event_has_stats( get_post() );
 
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<?php if ( $event_end_utc > $now && ! $has_stats ) : ?>
+				<?php if ( $event_end->is_in_the_past() && ! $has_stats ) : ?>
 					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>
@@ -91,8 +89,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
 			$event_edit_url                = gp_url( 'events/edit/' . $event_id );
 			$event_status                  = get_post_status( $event_id );
-			$event_start                   = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
-			$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+			$event_start                   = ( new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
+			$event_end                     = ( new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -33,8 +33,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
 			$event_edit_url                = gp_url( 'events/edit/' . $event_id );
 			$event_status                  = get_post_status( $event_id );
-			$event_start                   = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) ) );
-			$event_end                     = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) ) );
+			$event_start                   = new Event_Start_Date( get_post_meta( get_the_ID(), '_event_start', true ) );
+			$event_end                     = new Event_End_Date( get_post_meta( get_the_ID(), '_event_end', true ) );
 			$stats_calculator              = new Stats_Calculator();
 			$has_stats                     = $stats_calculator->event_has_stats( get_post() );
 
@@ -48,9 +48,9 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 					<span class="event-label-<?php echo esc_attr( $event_status ); ?>"><?php echo esc_html( $event_status ); ?></span>
 				<?php endif; ?>
 				<?php if ( $event_start->format( 'Y-m-d' ) === $event_end->format( 'Y-m-d' ) ) : ?>
-					<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?></span>
+					<span class="event-list-date events-i-am-attending"><?php $event_start->print_time_html(); ?></span>
 				<?php else : ?>
-					<span class="event-list-date events-i-am-attending"><?php echo esc_html( $event_start ); ?> - <?php echo esc_html( $event_end ); ?></span>
+					<span class="event-list-date events-i-am-attending"><?php $event_start->print_time_html(); ?> - <?php $event_end->print_time_html(); ?></span>
 				<?php endif; ?>
 				<p><?php the_excerpt(); ?></p>
 			</li>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -41,7 +41,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<?php if ( $event_end->is_in_the_past() && ! $has_stats ) : ?>
+				<?php if ( ! $event_end->is_in_the_past() && ! $has_stats ) : ?>
 					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>

--- a/tests/event-date.php
+++ b/tests/event-date.php
@@ -9,17 +9,19 @@ use Wporg\TranslationEvents\Event_End_Date;
 class Event_Date_Test extends GP_UnitTestCase {
 	public function test_timezone() {
 		$start = new Event_Start_Date( '2024-03-07 12:00:00', new \DateTimeZone( 'UTC' ) );
-		$this->assertEquals( 'UTC', $start->timezone->getName() );
-		$this->assertEquals( '2024-03-07 12:00:00', $start->utc( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( 'UTC', $start->timezone()->getName() );
+		$this->assertEquals( 'UTC', $start->utc()->getTimezone()->getName() );
+		$this->assertEquals( '2024-03-07 12:00:00', $start->utc()->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( '2024-03-07 12:00:00', $start->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( '2024-03-07 12:00:00', strval( $start ) );
-		$this->assertEquals( 'Thursday, March 7, 2024', $start->utc( 'l, F j, Y' ) );
+		$this->assertEquals( 'Thursday, March 7, 2024', $start->utc()->format( 'l, F j, Y' ) );
 		$this->assertEquals( 'Thursday, March 7, 2024', $start->format( 'l, F j, Y' ) );
 
 		$start = new Event_Start_Date( '2024-03-07 12:00:00', new \DateTimeZone( 'Asia/Taipei' ) );
-		$this->assertEquals( 'Asia/Taipei', $start->timezone->getName() );
+		$this->assertEquals( 'Asia/Taipei', $start->timezone()->getName() );
+		$this->assertEquals( 'UTC', $start->utc()->getTimezone()->getName() );
 		$this->assertEquals( '2024-03-07 20:00:00', $start->format( 'Y-m-d H:i:s' ) );
-		$this->assertEquals( '2024-03-07 12:00:00', $start->utc( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( '2024-03-07 12:00:00', $start->utc()->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( '2024-03-07 12:00:00', strval( $start ) );
 	}
 }

--- a/tests/event-date.php
+++ b/tests/event-date.php
@@ -21,6 +21,5 @@ class Event_Date_Test extends GP_UnitTestCase {
 		$this->assertEquals( '2024-03-07 20:00:00', $start->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( '2024-03-07 12:00:00', $start->utc( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( '2024-03-07 12:00:00', strval( $start ) );
-
 	}
 }

--- a/tests/event-date.php
+++ b/tests/event-date.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Wporg\Tests;
+
+use GP_UnitTestCase;
+use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event_End_Date;
+
+class Event_Date_Test extends GP_UnitTestCase {
+	public function test_timezone() {
+		$start = new Event_Start_Date( '2024-03-07 12:00:00', new \DateTimeZone( 'UTC' ) );
+		$this->assertEquals( 'UTC', $start->timezone->getName() );
+		$this->assertEquals( '2024-03-07 12:00:00', $start->utc( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( '2024-03-07 12:00:00', $start->format( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( '2024-03-07 12:00:00', strval( $start ) );
+		$this->assertEquals( 'Thursday, March 7, 2024', $start->utc( 'l, F j, Y' ) );
+		$this->assertEquals( 'Thursday, March 7, 2024', $start->format( 'l, F j, Y' ) );
+
+		$start = new Event_Start_Date( '2024-03-07 12:00:00', new \DateTimeZone( 'Asia/Taipei' ) );
+		$this->assertEquals( 'Asia/Taipei', $start->timezone->getName() );
+		$this->assertEquals( '2024-03-07 20:00:00', $start->format( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( '2024-03-07 12:00:00', $start->utc( 'Y-m-d H:i:s' ) );
+		$this->assertEquals( '2024-03-07 12:00:00', strval( $start ) );
+
+	}
+}

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -100,8 +100,8 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->repository->update_event( $event );
 		$updated_event = $this->repository->get_event( $event_id );
 
-		$this->assertEquals( $updated_start->getTimestamp(), $updated_event->start()->getTimestamp() );
-		$this->assertEquals( $updated_end->getTimestamp(), $updated_event->end()->getTimestamp() );
+		$this->assertEquals( $updated_start->getTimestamp(), $updated_event->start()->utc()->getTimestamp() );
+		$this->assertEquals( $updated_end->getTimestamp(), $updated_event->end()->utc()->getTimestamp() );
 		$this->assertEquals( $updated_timezone->getName(), $updated_event->timezone()->getName() );
 		$this->assertEquals( $updated_status, $updated_event->status() );
 		$this->assertEquals( $updated_title, $updated_event->title() );

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -6,7 +6,8 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
-use Wporg\TranslationEvents\Event\InvalidStartOrEnd;
+use Wporg\TranslationEvents\Event\InvalidStart;
+use Wporg\TranslationEvents\Event\InvalidEnd;
 use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\InvalidTitle;
 
@@ -15,7 +16,7 @@ class Event_Test extends WP_UnitTestCase {
 		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
-		$this->expectException( InvalidStartOrEnd::class );
+		$this->expectException( InvalidEnd::class );
 		new Event(
 			1,
 			$now,
@@ -32,7 +33,7 @@ class Event_Test extends WP_UnitTestCase {
 		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'Europe/Lisbon' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
-		$this->expectException( InvalidStartOrEnd::class );
+		$this->expectException( InvalidStart::class );
 		new Event(
 			1,
 			$now,

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -185,15 +185,16 @@ class Translation_Events {
 	 *
 	 * @param string $event_start The event start date.
 	 * @param string $event_end The event end date.
+	 * @param string $event_timezone The event timezone.
 	 * @return bool Whether the event dates are valid.
 	 * @throws Exception When dates are invalid.
 	 */
-	public function validate_event_dates( string $event_start, string $event_end ): bool {
+	public function validate_event_dates( string $event_start, string $event_end, string $event_timezone ): bool {
 		if ( ! $event_start || ! $event_end ) {
 			return false;
 		}
-		$event_start = new DateTime( $event_start, new DateTimeZone( 'UTC' ) );
-		$event_end   = new DateTime( $event_end, new DateTimeZone( 'UTC' ) );
+		$event_start = new DateTime( $event_start, new DateTimeZone( $event_timezone ) );
+		$event_end   = new DateTime( $event_end, new DateTimeZone( $event_timezone ) );
 		$now         = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		if ( ( $event_start < $event_end ) && ( $event_end > $now ) ) {
 			return true;
@@ -264,7 +265,7 @@ class Translation_Events {
 
 		$is_valid_event_date = false;
 		try {
-			$is_valid_event_date = $this->validate_event_dates( $event_start, $event_end );
+			$is_valid_event_date = $this->validate_event_dates( $event_start, $event_end, $event_timezone );
 		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Deliberately ignored, handled below.
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -53,6 +53,8 @@ class Translation_Events {
 
 	public function gp_init() {
 		require_once __DIR__ . '/templates/helper-functions.php';
+		require_once __DIR__ . '/includes/active-events-cache.php';
+		require_once __DIR__ . '/includes/event-date.php';
 		require_once __DIR__ . '/includes/routes/route.php';
 		require_once __DIR__ . '/includes/routes/event/create.php';
 		require_once __DIR__ . '/includes/routes/event/details.php';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -53,7 +53,6 @@ class Translation_Events {
 
 	public function gp_init() {
 		require_once __DIR__ . '/templates/helper-functions.php';
-		require_once __DIR__ . '/includes/active-events-cache.php';
 		require_once __DIR__ . '/includes/event-date.php';
 		require_once __DIR__ . '/includes/routes/route.php';
 		require_once __DIR__ . '/includes/routes/event/create.php';


### PR DESCRIPTION
This adds a new `Event_Date` class that tries to make handling dates more unified. It also adds relative JavaScript time formatting:

<img width="297" alt="Screenshot 2024-03-07 at 11 08 06" src="https://github.com/WordPress/wporg-gp-translation-events/assets/203408/db96a30e-8235-4fa9-b586-9a9d09ffee79">

<img width="297" alt="Screenshot 2024-03-07 at 11 08 06" src="https://github.com/WordPress/wporg-gp-translation-events/assets/203408/70c4b499-ed1c-4316-bf16-5ad26b8e4f3b">

