### PR TITLE
Display language names instead of locale slugs

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -49,9 +49,12 @@
 	width: 100%;
 	table-layout: fixed;
 }
-.event-details-stats table th, .event-details-stats table td{
+.event-details-stats table th, .event-details-stats table td {
 	padding: 1em;
 	text-align: center;
+}
+.event-details-stats table td:first-child {
+	text-align: left;
 }
 .event-details-stats table tr {
 	border-bottom: thin solid #f0f0f0;
@@ -217,7 +220,6 @@ input[type="submit"].attending-btn, a.button.is-primary.attend-btn {
 	padding: 0.8em;
 	font-size: .9em;
 	border-top: thin solid #e0e0e0;
-	font-family: monospace;
 }
 time.event-utc-time {
 	display: block;

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -62,7 +62,7 @@
 .event-details-stats table th {
 	background-color: #e9e9e9;
 }
-.event-details-stats-totals {
+.event-details-stats-totals td {
 	font-weight: bold;
 }
 .hide-event-url {

--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -136,41 +136,6 @@ class Stats_Calculator {
 	}
 
 	/**
-	 * Get contributors for an event.
-	 */
-	public function get_contributors( WP_Post $event ): Event_Stats {
-		global $wpdb, $gp_table_prefix;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs thinks we're doing a schema change but we aren't.
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-				select distinct user_id, group_concat( locale ) as locales
-				from {$gp_table_prefix}event_actions
-				where event_id = %d
-			",
-				array(
-					$event->ID,
-				)
-			)
-		);
-		// phpcs:enable
-
-		$users = array();
-		foreach ( $rows as $row ) {
-			$user          = new WP_User( $row->user_id );
-			$user->locales = explode( ',', $row->locales );
-			$users[]       = $user;
-		}
-
-		return $users;
-	}
-
-	/**
 	 * Check if an event has stats.
 	 *
 	 * @param WP_Post $event The event to check.

--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -11,15 +11,13 @@ class Stats_Row {
 	public int $created;
 	public int $reviewed;
 	public int $users;
-	public GP_Locale $language;
+	public ?GP_Locale $language = null;
 
 	public function __construct( $created, $reviewed, $users, ?GP_Locale $language = null ) {
 		$this->created  = $created;
 		$this->reviewed = $reviewed;
 		$this->users    = $users;
-		if ( $language ) {
-			$this->language = $language;
-		}
+		$this->language = $language;
 	}
 }
 
@@ -58,6 +56,16 @@ class Event_Stats {
 		uasort(
 			$this->rows,
 			function ( $a, $b ) {
+				if ( ! $a->language && ! $b->language ) {
+					return 0;
+				}
+				if ( ! $a->language ) {
+					return -1;
+				}
+				if ( ! $b->language ) {
+					return 1;
+				}
+
 				return strcasecmp( $a->language->english_name, $b->language->english_name );
 			}
 		);

--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -55,9 +55,12 @@ class Event_Stats {
 	 * @return Stats_Row[]
 	 */
 	public function rows(): array {
-		uasort( $this->rows, function ( $a, $b ) {
-			return strcasecmp( $a->language->english_name, $b->language->english_name );
-		} );
+		uasort(
+			$this->rows,
+			function ( $a, $b ) {
+				return strcasecmp( $a->language->english_name, $b->language->english_name );
+			}
+		);
 
 		return $this->rows;
 	}
@@ -159,9 +162,9 @@ class Stats_Calculator {
 
 		$users = array();
 		foreach ( $rows as $row ) {
-			$user = new WP_User( $row->user_id );
+			$user          = new WP_User( $row->user_id );
 			$user->locales = explode( ',', $row->locales );
-			$users[] = $user;
+			$users[]       = $user;
 		}
 
 		return $users;

--- a/templates/event.php
+++ b/templates/event.php
@@ -102,11 +102,8 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 				)
 			);
 			?>
-									</p>
+			</p>
 	</details>
-	<div class="event-contributors">
-		<h2><?php esc_html_e( 'Contributors', 'gp-translation-events' ); ?></h2>
-	</div>
 	<?php endif ?>
 	</div>
 	<div class="event-details-right">

--- a/templates/event.php
+++ b/templates/event.php
@@ -60,7 +60,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			<?php /** @var $row Stats_Row */ ?>
 			<?php foreach ( $event_stats->rows() as $_locale => $row ) : ?>
 			<tr>
-				<td title="<?php echo esc_html( $_locale ); ?> "><?php echo esc_html( $row->language->english_name ); ?></td>
+				<td title="<?php echo esc_html( $_locale ); ?> "><a href="<?php echo esc_url( gp_url( '/locale/' . $row->language->slug ) ); ?>"><?php echo esc_html( $row->language->english_name ); ?></a></td>
 				<td><?php echo esc_html( $row->created ); ?></td>
 				<td><?php echo esc_html( $row->reviewed ); ?></td>
 				<td><?php echo esc_html( $row->users ); ?></td>

--- a/templates/event.php
+++ b/templates/event.php
@@ -77,7 +77,32 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<details class="event-stats-summary">
 		<summary>View stats summary in text </summary>
-		<p class="event-stats-text"><?php echo esc_html( sprintf( __( 'At the %s event, %d people contributed in %d languages (%s), translated %d strings and reviewed %d strings.', 'gp-translation-events' ), esc_html( $event_title ), esc_html( $event_stats->totals()->users ), count( $event_stats->rows() ), esc_html( implode( ', ', array_map( $event_stats->rows(), function( $row ) { return $row->language->english_name; } ) ) ), esc_html( $event_stats->totals()->created ), esc_html( $event_stats->totals()->reviewed ) ) ); ?></p>
+		<p class="event-stats-text">
+			<?php
+			echo esc_html(
+				sprintf(
+					// translators: %1$s: Event title, %2$d: Number of contributors, %3$d: Number of languages, %4$s: List of languages, %5$d: Number of strings translated, %6$d: Number of strings reviewed.
+					__( 'At the %1$s event, %2$d people contributed in %3$d languages (%4$s), translated %5$d strings and reviewed %6$d strings.', 'gp-translation-events' ),
+					esc_html( $event_title ),
+					esc_html( $event_stats->totals()->users ),
+					count( $event_stats->rows() ),
+					esc_html(
+						implode(
+							', ',
+							array_map(
+								function ( $row ) {
+									return $row->language->english_name;
+								},
+								$event_stats->rows()
+							)
+						)
+					),
+					esc_html( $event_stats->totals()->created ),
+					esc_html( $event_stats->totals()->reviewed )
+				)
+			);
+			?>
+									</p>
 	</details>
 	<div class="event-contributors">
 		<h2><?php esc_html_e( 'Contributors', 'gp-translation-events' ); ?></h2>

--- a/templates/event.php
+++ b/templates/event.php
@@ -60,7 +60,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			<?php /** @var $row Stats_Row */ ?>
 			<?php foreach ( $event_stats->rows() as $_locale => $row ) : ?>
 			<tr>
-				<td title="<?php echo esc_html( $_locale ); ?> "><a href="<?php echo esc_url( gp_url( '/locale/' . $row->language->slug ) ); ?>"><?php echo esc_html( $row->language->english_name ); ?></a></td>
+				<td title="<?php echo esc_html( $_locale ); ?> "><a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $row->language->slug ) ); ?>"><?php echo esc_html( $row->language->english_name ); ?></a></td>
 				<td><?php echo esc_html( $row->created ); ?></td>
 				<td><?php echo esc_html( $row->reviewed ); ?></td>
 				<td><?php echo esc_html( $row->users ); ?></td>

--- a/templates/event.php
+++ b/templates/event.php
@@ -46,7 +46,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		</div>
 		<?php if ( ! empty( $event_stats->rows() ) ) : ?>
 	<div class="event-details-stats">
-		<h2>Stats</h2>
+		<h2><?php esc_html_e( 'Stats', 'gp-translation-events' ); ?></h2>
 		<table>
 			<thead>
 			<tr>
@@ -58,9 +58,9 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			</thead>
 			<tbody>
 			<?php /** @var $row Stats_Row */ ?>
-			<?php foreach ( $event_stats->rows() as $locale_ => $row ) : ?>
+			<?php foreach ( $event_stats->rows() as $_locale => $row ) : ?>
 			<tr>
-				<td><?php echo esc_html( $locale_ ); ?></td>
+				<td title="<?php echo esc_html( $_locale ); ?> "><?php echo esc_html( $row->language->english_name ); ?></td>
 				<td><?php echo esc_html( $row->created ); ?></td>
 				<td><?php echo esc_html( $row->reviewed ); ?></td>
 				<td><?php echo esc_html( $row->users ); ?></td>
@@ -77,8 +77,11 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<details class="event-stats-summary">
 		<summary>View stats summary in text </summary>
-		<p class="event-stats-text"><?php echo esc_html( sprintf( 'At the %s event, %d people contributed in %d languages (%s), translated %d strings and reviewed %d strings.', esc_html( $event_title ), esc_html( $event_stats->totals()->users ), count( $event_stats->rows() ), esc_html( implode( ',', array_keys( $event_stats->rows() ) ) ), esc_html( $event_stats->totals()->created ), esc_html( $event_stats->totals()->reviewed ) ) ); ?></p>
+		<p class="event-stats-text"><?php echo esc_html( sprintf( __( 'At the %s event, %d people contributed in %d languages (%s), translated %d strings and reviewed %d strings.', 'gp-translation-events' ), esc_html( $event_title ), esc_html( $event_stats->totals()->users ), count( $event_stats->rows() ), esc_html( implode( ', ', array_map( $event_stats->rows(), function( $row ) { return $row->language->english_name; } ) ) ), esc_html( $event_stats->totals()->created ), esc_html( $event_stats->totals()->reviewed ) ) ); ?></p>
 	</details>
+	<div class="event-contributors">
+		<h2><?php esc_html_e( 'Contributors', 'gp-translation-events' ); ?></h2>
+	</div>
 	<?php endif ?>
 	</div>
 	<div class="event-details-right">


### PR DESCRIPTION
Instead of the list of locales:
<img width="960" alt="Screenshot 2024-03-07 at 13 28 16" src="https://github.com/WordPress/wporg-gp-translation-events/assets/203408/362e8d60-7852-4972-9873-1df01f3fd8f3">
show the language names:
<img width="940" alt="Screenshot 2024-03-07 at 13 28 27" src="https://github.com/WordPress/wporg-gp-translation-events/assets/203408/b08ed41d-7308-42fd-b3dd-865034437d15">

Also in the text:
<img width="971" alt="Screenshot 2024-03-07 at 13 33 06" src="https://github.com/WordPress/wporg-gp-translation-events/assets/203408/a87815ac-0fd6-4a8a-90c0-ab7b73d1e3f9">
