### PR TITLE
Prepare for storing attendees of an event

### DIFF
--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Wporg\TranslationEvents;
+
+class Attendee_Repository {
+
+}

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -2,11 +2,28 @@
 
 namespace Wporg\TranslationEvents;
 
+use Exception;
+
 class Attendee_Repository {
 	public const USER_META_KEY = 'translation-events-attending';
 
+	/**
+	 * @throws Exception
+	 */
 	public function add_attendee( int $event_id, int $user_id ): void {
-		// TODO.
+		if ( $event_id < 1 ) {
+			throw new Exception( 'invalid event id' );
+		}
+		if ( $user_id < 1 ) {
+			throw new Exception( 'invalid user id' );
+		}
+
+		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
+		if ( ! $event_ids ) {
+			$event_ids = array();
+		}
+		$event_ids[ $event_id ] = true;
+		update_user_meta( $user_id, self::USER_META_KEY, $event_ids );
 	}
 
 	public function remove_attendee( int $event_id, int $user_id ): void {

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -3,6 +3,8 @@
 namespace Wporg\TranslationEvents;
 
 class Attendee_Repository {
+	public const USER_META_KEY = 'translation-events-attending';
+
 	public function add_attendee( int $event_id, int $user_id ): void {
 		// TODO.
 	}

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -26,8 +26,27 @@ class Attendee_Repository {
 		update_user_meta( $user_id, self::USER_META_KEY, $event_ids );
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function remove_attendee( int $event_id, int $user_id ): void {
-		// TODO.
+		if ( $event_id < 1 ) {
+			throw new Exception( 'invalid event id' );
+		}
+		if ( $user_id < 1 ) {
+			throw new Exception( 'invalid user id' );
+		}
+
+		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
+		if ( ! $event_ids ) {
+			$event_ids = array();
+		}
+
+		if ( isset( $event_ids[ $event_id ] ) ) {
+			unset( $event_ids[ $event_id ] );
+		}
+
+		update_user_meta( $user_id, self::USER_META_KEY, $event_ids );
 	}
 
 	public function is_attending( int $event_id, int $user_id ): bool {

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -5,7 +5,7 @@ namespace Wporg\TranslationEvents;
 use Exception;
 
 class Attendee_Repository {
-	public const USER_META_KEY = 'translation-events-attending';
+	private const USER_META_KEY = 'translation-events-attending';
 
 	/**
 	 * @throws Exception

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -3,5 +3,24 @@
 namespace Wporg\TranslationEvents;
 
 class Attendee_Repository {
+	public function add_attendee( int $event_id, int $user_id ): void {
+		// TODO.
+	}
 
+	public function remove_attendee( int $event_id, int $user_id ): void {
+		// TODO.
+	}
+
+	public function is_attending( int $event_id, int $user_id ): bool {
+		// TODO.
+		return false;
+	}
+
+	/**
+	 * @return int[] User ids.
+	 */
+	public function get_attendees( int $event_id ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		// TODO.
+		return array();
+	}
 }

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -50,8 +50,12 @@ class Attendee_Repository {
 	}
 
 	public function is_attending( int $event_id, int $user_id ): bool {
-		// TODO.
-		return false;
+		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
+		if ( ! $event_ids ) {
+			$event_ids = array();
+		}
+
+		return isset( $event_ids[ $event_id ] );
 	}
 
 	/**

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -76,7 +76,11 @@ class Attendee_Repository {
 	 * @return int[] Event ids.
 	 */
 	public function get_events_for_user( int $user_id ): array {
-		// TODO.
-		return array();
+		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
+		if ( ! $event_ids ) {
+			$event_ids = array();
+		}
+
+		return array_keys( $event_ids );
 	}
 }

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -65,4 +65,18 @@ class Attendee_Repository {
 		// TODO.
 		return array();
 	}
+
+	/**
+	 * @deprecated
+	 * TODO: This method should be moved out of this class because it's not about attendance,
+	 *       it returns events that match a condition (belong to a user), so it belongs in an event repository.
+	 *       However, since we don't have an event repository yet, the method is placed here for now.
+	 *       When the method is moved to an event repository, it should return Event instances instead of event ids.
+	 *
+	 * @return int[] Event ids.
+	 */
+	public function get_events_for_user( int $user_id ): array {
+		// TODO.
+		return array();
+	}
 }

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -4,6 +4,7 @@ namespace Wporg\TranslationEvents\Routes\Event;
 
 use Exception;
 use GP;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
@@ -34,7 +35,7 @@ class Details_Route extends Route {
 		$event_description   = $event->post_content;
 		$event_start         = get_post_meta( $event->ID, '_event_start', true ) ?: '';
 		$event_end           = get_post_meta( $event->ID, '_event_end', true ) ?: '';
-		$attending_event_ids = get_user_meta( $user->ID, Translation_Events::USER_META_KEY_ATTENDING, true ) ?: array();
+		$attending_event_ids = get_user_meta( $user->ID, Attendee_Repository::USER_META_KEY, true ) ?: array();
 		$user_is_attending   = isset( $attending_event_ids[ $event_id ] );
 
 		$stats_calculator = new Stats_Calculator();

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -13,6 +13,13 @@ use Wporg\TranslationEvents\Translation_Events;
  * Displays the event details page.
  */
 class Details_Route extends Route {
+	private Attendee_Repository $attendee_repository;
+
+	public function __construct() {
+		parent::__construct();
+		$this->attendee_repository = new Attendee_Repository();
+	}
+
 	public function handle( string $event_slug ): void {
 		$user  = wp_get_current_user();
 		$event = get_page_by_path( $event_slug, OBJECT, Translation_Events::CPT );
@@ -30,13 +37,12 @@ class Details_Route extends Route {
 			$this->die_with_error( esc_html__( 'You are not authorized to view this page.', 'gp-translation-events' ), 403 );
 		}
 
-		$event_id            = $event->ID;
-		$event_title         = $event->post_title;
-		$event_description   = $event->post_content;
-		$event_start         = get_post_meta( $event->ID, '_event_start', true ) ?: '';
-		$event_end           = get_post_meta( $event->ID, '_event_end', true ) ?: '';
-		$attending_event_ids = get_user_meta( $user->ID, Attendee_Repository::USER_META_KEY, true ) ?: array();
-		$user_is_attending   = isset( $attending_event_ids[ $event_id ] );
+		$event_id          = $event->ID;
+		$event_title       = $event->post_title;
+		$event_description = $event->post_content;
+		$event_start       = get_post_meta( $event->ID, '_event_start', true ) ?: '';
+		$event_end         = get_post_meta( $event->ID, '_event_end', true ) ?: '';
+		$user_is_attending = $this->attendee_repository->is_attending( $event_id, $user->ID );
 
 		$stats_calculator = new Stats_Calculator();
 		try {

--- a/includes/routes/event/list.php
+++ b/includes/routes/event/list.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeZone;
 use Exception;
 use WP_Query;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Translation_Events;
 
@@ -118,7 +119,7 @@ class List_Route extends Route {
 		);
 		$past_events_query = new WP_Query( $past_events_args );
 
-		$user_attending_events      = get_user_meta( get_current_user_id(), Translation_Events::USER_META_KEY_ATTENDING, true ) ?: array( 0 );
+		$user_attending_events      = get_user_meta( get_current_user_id(), Attendee_Repository::USER_META_KEY, true ) ?: array( 0 );
 		$user_attending_events_args = array(
 			'post_type'      => Translation_Events::CPT,
 			'post__in'       => array_keys( $user_attending_events ),

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -2,8 +2,8 @@
 
 namespace Wporg\TranslationEvents\Routes\User;
 
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
-use Wporg\TranslationEvents\Translation_Events;
 
 /**
  * Toggle whether the current user is attending an event.
@@ -23,7 +23,7 @@ class Attend_Event_Route extends Route {
 			$this->die_with_404();
 		}
 
-		$event_ids = get_user_meta( $user->ID, Translation_Events::USER_META_KEY_ATTENDING, true ) ?? array();
+		$event_ids = get_user_meta( $user->ID, Attendee_Repository::USER_META_KEY, true ) ?? array();
 		if ( ! $event_ids ) {
 			$event_ids = array();
 		}
@@ -36,7 +36,7 @@ class Attend_Event_Route extends Route {
 			unset( $event_ids[ $event_id ] );
 		}
 
-		update_user_meta( $user->ID, Translation_Events::USER_META_KEY_ATTENDING, $event_ids );
+		update_user_meta( $user->ID, Attendee_Repository::USER_META_KEY, $event_ids );
 
 		wp_safe_redirect( gp_url( "/events/$event->post_name" ) );
 		exit;

--- a/includes/routes/user/my-events.php
+++ b/includes/routes/user/my-events.php
@@ -5,6 +5,7 @@ namespace Wporg\TranslationEvents\Routes\User;
 use DateTime;
 use DateTimeZone;
 use WP_Query;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Translation_Events;
 
@@ -39,7 +40,7 @@ class My_Events_Route extends Route {
 		// phpcs:enable
 
 		$user_id              = get_current_user_id();
-		$events               = get_user_meta( $user_id, Translation_Events::USER_META_KEY_ATTENDING, true ) ?: array();
+		$events               = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true ) ?: array();
 		$events               = array_keys( $events );
 		$current_datetime_utc = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
 		$args                 = array(

--- a/includes/routes/user/my-events.php
+++ b/includes/routes/user/my-events.php
@@ -13,6 +13,13 @@ use Wporg\TranslationEvents\Translation_Events;
  * Displays the My Events page for a user.
  */
 class My_Events_Route extends Route {
+	private Attendee_Repository $attendee_repository;
+
+	public function __construct() {
+		parent::__construct();
+		$this->attendee_repository = new Attendee_Repository();
+	}
+
 	public function handle(): void {
 		global $wp;
 		if ( ! is_user_logged_in() ) {
@@ -40,8 +47,6 @@ class My_Events_Route extends Route {
 		// phpcs:enable
 
 		$user_id              = get_current_user_id();
-		$events               = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true ) ?: array();
-		$events               = array_keys( $events );
 		$current_datetime_utc = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
 		$args                 = array(
 			'post_type'              => Translation_Events::CPT,
@@ -63,7 +68,6 @@ class My_Events_Route extends Route {
 			'events_i_attended_paged' => $_events_i_attended_paged,
 			'paged'                   => $_events_i_attended_paged,
 			'post_status'             => 'publish',
-			'post__in'                => $events,
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'              => array(
 				array(
@@ -78,8 +82,16 @@ class My_Events_Route extends Route {
 			'orderby'                 => 'meta_value',
 			'order'                   => 'DESC',
 		);
-		$events_i_attended_query = new WP_Query( $args );
 
+		$user_attending_event_ids = $this->attendee_repository->get_events_for_user( $user_id );
+		if ( empty( $user_attending_event_ids ) ) {
+			// Setting it to an array with a single 0 element will result in the query returning zero results,
+			// which is what we want, as the user is not attending any events.
+			$user_attending_event_ids = array( 0 );
+		}
+		$args['post__in'] = $user_attending_event_ids;
+
+		$events_i_attended_query = new WP_Query( $args );
 		$this->tmpl( 'events-my-events', get_defined_vars() );
 	}
 }

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -171,7 +171,7 @@ class Stats_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_event_ids = get_user_meta( $user_id, Translation_Events::USER_META_KEY_ATTENDING, true );
+		$attending_event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
 		return array_filter(
 			$events,
 			function ( Event $event ) use ( $attending_event_ids ) {

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -15,9 +15,11 @@ class Stats_Listener {
 	const ACTION_REQUEST_CHANGES = 'request_changes';
 
 	private Active_Events_Cache $active_events_cache;
+	private Attendee_Repository $attendee_repository;
 
-	public function __construct( Active_Events_Cache $active_events_cache ) {
+	public function __construct( Active_Events_Cache $active_events_cache, Attendee_Repository $attendee_repository ) {
 		$this->active_events_cache = $active_events_cache;
+		$this->attendee_repository = $attendee_repository;
 	}
 
 	public function start(): void {
@@ -171,11 +173,11 @@ class Stats_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
+		$attending_event_ids = $this->attendee_repository->get_events_for_user( $user_id );
 		return array_filter(
 			$events,
 			function ( Event $event ) use ( $attending_event_ids ) {
-				return isset( $attending_event_ids[ $event->id() ] );
+				return in_array( $event->id(), $attending_event_ids, true );
 			}
 		);
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,7 @@
         <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
         <exclude name="Squiz.Commenting.VariableComment.Missing"/>
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+        <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/>
         <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
         <exclude name="Generic.Files.OneObjectStructurePerFile.MultipleFound"/>
         <exclude name="Universal.Operators.DisallowShortTernary.Found"/>

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -75,4 +75,20 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertTrue( $this->repository->is_attending( $event1_id, $user_id ) );
 		$this->assertFalse( $this->repository->is_attending( $event2_id, $user_id ) );
 	}
+
+	public function test_get_event_ids() {
+		$event1_id    = 1;
+		$event2_id    = 2;
+		$event3_id    = 3;
+		$user_id      = 42;
+		$another_user = $user_id + 1;
+
+		$this->repository->add_attendee( $event1_id, $user_id );
+		$this->repository->add_attendee( $event2_id, $user_id );
+		$this->repository->add_attendee( $event3_id, $another_user );
+
+		$this->assertEquals( array( $event1_id, $event2_id ), $this->repository->get_events_for_user( $user_id ) );
+		$this->assertEquals( array( $event3_id ), $this->repository->get_events_for_user( $another_user ) );
+		$this->assertEmpty( $this->repository->get_events_for_user( $another_user + 1 ) );
+	}
 }

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Wporg\Tests;
+
+use WP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee_Repository;
+
+class Attendee_Repository_Test extends WP_UnitTestCase {
+	private Attendee_Repository $repository;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->repository = new Attendee_Repository();
+	}
+}

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -12,4 +12,31 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		parent::setUp();
 		$this->repository = new Attendee_Repository();
 	}
+
+	public function test_add_attendee_invalid_event_id() {
+		$this->expectExceptionMessage( 'invalid event id' );
+		$this->repository->add_attendee( 0, 1 );
+	}
+
+	public function test_add_attendee_invalid_user_id() {
+		$this->expectExceptionMessage( 'invalid user id' );
+		$this->repository->add_attendee( 1, 0 );
+	}
+
+	public function test_add_attendee() {
+		$event1_id = 1;
+		$event2_id = 2;
+		$user_id   = 42;
+
+		$this->repository->add_attendee( $event1_id, $user_id );
+		$this->repository->add_attendee( $event2_id, $user_id );
+
+		$event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
+		$this->assertCount( 2, $event_ids );
+		$this->assertTrue( $event_ids[ $event1_id ] );
+		$this->assertTrue( $event_ids[ $event2_id ] );
+
+		$event_ids_another_user = get_user_meta( $user_id + 1, Attendee_Repository::USER_META_KEY, true );
+		$this->assertEmpty( $event_ids_another_user );
+	}
 }

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -31,12 +31,12 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->repository->add_attendee( $event1_id, $user_id );
 		$this->repository->add_attendee( $event2_id, $user_id );
 
-		$event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
+		$event_ids = get_user_meta( $user_id, 'translation-events-attending', true );
 		$this->assertCount( 2, $event_ids );
 		$this->assertTrue( $event_ids[ $event1_id ] );
 		$this->assertTrue( $event_ids[ $event2_id ] );
 
-		$event_ids_another_user = get_user_meta( $user_id + 1, Attendee_Repository::USER_META_KEY, true );
+		$event_ids_another_user = get_user_meta( $user_id + 1, 'translation-events-attending', true );
 		$this->assertEmpty( $event_ids_another_user );
 	}
 
@@ -60,7 +60,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 
 		$this->repository->remove_attendee( $event1_id, $user_id );
 
-		$event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
+		$event_ids = get_user_meta( $user_id, 'translation-events-attending', true );
 		$this->assertCount( 1, $event_ids );
 		$this->assertTrue( $event_ids[ $event2_id ] );
 	}

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -64,4 +64,15 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertCount( 1, $event_ids );
 		$this->assertTrue( $event_ids[ $event2_id ] );
 	}
+
+	public function test_is_attending() {
+		$event1_id = 1;
+		$event2_id = 2;
+		$user_id   = 42;
+
+		$this->repository->add_attendee( $event1_id, $user_id );
+
+		$this->assertTrue( $this->repository->is_attending( $event1_id, $user_id ) );
+		$this->assertFalse( $this->repository->is_attending( $event2_id, $user_id ) );
+	}
 }

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -39,4 +39,29 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event_ids_another_user = get_user_meta( $user_id + 1, Attendee_Repository::USER_META_KEY, true );
 		$this->assertEmpty( $event_ids_another_user );
 	}
+
+	public function test_remove_attendee_invalid_event_id() {
+		$this->expectExceptionMessage( 'invalid event id' );
+		$this->repository->remove_attendee( 0, 1 );
+	}
+
+	public function test_remove_attendee_invalid_user_id() {
+		$this->expectExceptionMessage( 'invalid user id' );
+		$this->repository->remove_attendee( 1, 0 );
+	}
+
+	public function test_remove_attendee() {
+		$event1_id = 1;
+		$event2_id = 2;
+		$user_id   = 42;
+
+		$this->repository->add_attendee( $event1_id, $user_id );
+		$this->repository->add_attendee( $event2_id, $user_id );
+
+		$this->repository->remove_attendee( $event1_id, $user_id );
+
+		$event_ids = get_user_meta( $user_id, Attendee_Repository::USER_META_KEY, true );
+		$this->assertCount( 1, $event_ids );
+		$this->assertTrue( $event_ids[ $event2_id ] );
+	}
 }

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTest_Factory_For_Post;
 use WP_UnitTest_Generator_Sequence;
+use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Factory extends WP_UnitTest_Factory_For_Post {
@@ -68,7 +69,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 	private function create_event( DateTimeImmutable $start, DateTimeImmutable $end, array $attendee_ids ): int {
 		$event_id = $this->create();
-		$meta_key = Translation_Events::USER_META_KEY_ATTENDING;
+		$meta_key = Attendee_Repository::USER_META_KEY;
 
 		$user_id = get_current_user_id();
 		if ( ! in_array( $user_id, $attendee_ids, true ) ) {

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -69,7 +69,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 	private function create_event( DateTimeImmutable $start, DateTimeImmutable $end, array $attendee_ids ): int {
 		$event_id = $this->create();
-		$meta_key = Attendee_Repository::USER_META_KEY;
+		$meta_key = 'translation-events-attending';
 
 		$user_id = get_current_user_id();
 		if ( ! in_array( $user_id, $attendee_ids, true ) ) {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -63,6 +63,7 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
+		require_once __DIR__ . '/includes/attendee-repository.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
 		require_once __DIR__ . '/includes/stats-listener.php';
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -465,18 +465,19 @@ class Translation_Events {
 	/**
 	 * Add the active events for the current user before the translation table.
 	 *
-	 * @return void
+	 * @throws Exception
 	 */
 	public function add_active_events_current_user(): void {
-		$user_attending_events = get_user_meta( get_current_user_id(), Attendee_Repository::USER_META_KEY, true ) ?: array();
-		if ( empty( $user_attending_events ) ) {
+		$attendee_repository      = new Attendee_Repository();
+		$user_attending_event_ids = $attendee_repository->get_events_for_user( get_current_user_id() );
+		if ( empty( $user_attending_event_ids ) ) {
 			return;
 		}
 
 		$current_datetime_utc       = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
 		$user_attending_events_args = array(
 			'post_type'   => self::CPT,
-			'post__in'    => array_keys( $user_attending_events ),
+			'post__in'    => $user_attending_event_ids,
 			'post_status' => 'publish',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'  => array(
@@ -498,6 +499,7 @@ class Translation_Events {
 			'orderby'     => 'meta_value',
 			'order'       => 'ASC',
 		);
+
 		$user_attending_events_query = new WP_Query( $user_attending_events_args );
 		$number_of_events            = $user_attending_events_query->post_count;
 		if ( 0 === $number_of_events ) {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -74,7 +74,8 @@ class Translation_Events {
 		GP::$router->add( '/events/([a-z0-9_-]+)', array( 'Wporg\TranslationEvents\Routes\Event\Details_Route', 'handle' ) );
 
 		$active_events_cache = new Active_Events_Cache();
-		$stats_listener      = new Stats_Listener( $active_events_cache );
+		$attendee_repository = new Attendee_Repository();
+		$stats_listener      = new Stats_Listener( $active_events_cache, $attendee_repository );
 		$stats_listener->start();
 	}
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -399,19 +399,18 @@ class Translation_Events {
 	 * @param string  $new_status The new post status.
 	 * @param string  $old_status The old post status.
 	 * @param WP_Post $post       The post object.
+	 *
+	 * @throws Exception
 	 */
 	public function event_status_transition( string $new_status, string $old_status, WP_Post $post ): void {
 		if ( self::CPT !== $post->post_type ) {
 			return;
 		}
 		if ( 'publish' === $new_status && ( 'new' === $old_status || 'draft' === $old_status ) ) {
-			$current_user_id         = get_current_user_id();
-			$user_attending_events   = get_user_meta( $current_user_id, Attendee_Repository::USER_META_KEY, true ) ?: array();
-			$is_user_attending_event = in_array( $post->ID, $user_attending_events, true );
-			if ( ! $is_user_attending_event ) {
-				$new_user_attending_events              = $user_attending_events;
-				$new_user_attending_events[ $post->ID ] = true;
-				update_user_meta( $current_user_id, Attendee_Repository::USER_META_KEY, $new_user_attending_events, $user_attending_events );
+			$attendee_repository = new Attendee_Repository();
+			$current_user_id     = get_current_user_id();
+			if ( ! $attendee_repository->is_attending( $post->ID, $current_user_id ) ) {
+				$attendee_repository->add_attendee( $post->ID, $current_user_id );
 			}
 		}
 	}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -26,8 +26,7 @@ use WP_Post;
 use WP_Query;
 
 class Translation_Events {
-	public const CPT                     = 'translation_event';
-	public const USER_META_KEY_ATTENDING = 'translation-events-attending';
+	public const CPT = 'translation_event';
 
 	public static function get_instance() {
 		static $instance = null;
@@ -407,12 +406,12 @@ class Translation_Events {
 		}
 		if ( 'publish' === $new_status && ( 'new' === $old_status || 'draft' === $old_status ) ) {
 			$current_user_id         = get_current_user_id();
-			$user_attending_events   = get_user_meta( $current_user_id, self::USER_META_KEY_ATTENDING, true ) ?: array();
+			$user_attending_events   = get_user_meta( $current_user_id, Attendee_Repository::USER_META_KEY, true ) ?: array();
 			$is_user_attending_event = in_array( $post->ID, $user_attending_events, true );
 			if ( ! $is_user_attending_event ) {
 				$new_user_attending_events              = $user_attending_events;
 				$new_user_attending_events[ $post->ID ] = true;
-				update_user_meta( $current_user_id, self::USER_META_KEY_ATTENDING, $new_user_attending_events, $user_attending_events );
+				update_user_meta( $current_user_id, Attendee_Repository::USER_META_KEY, $new_user_attending_events, $user_attending_events );
 			}
 		}
 	}
@@ -469,7 +468,7 @@ class Translation_Events {
 	 * @return void
 	 */
 	public function add_active_events_current_user(): void {
-		$user_attending_events = get_user_meta( get_current_user_id(), self::USER_META_KEY_ATTENDING, true ) ?: array();
+		$user_attending_events = get_user_meta( get_current_user_id(), Attendee_Repository::USER_META_KEY, true ) ?: array();
 		if ( empty( $user_attending_events ) ) {
 			return;
 		}


### PR DESCRIPTION
This PR is the first step to tackle #167.

It makes it so that the fact that attendance is stored as user meta is not exposed to the codebase. This is achieved through an `Attendee_Repository`.

This will make it possible to change how attendance is stored without impacting the rest of the codebase. Only the internals of `Attendee_Repository` will need to change. I will be doing that in a follow-up PR.