### PR TITLE
Store attendance in an attendees table

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once __DIR__ . '/templates/helper-functions.php';
+require_once __DIR__ . '/includes/routes/route.php';
+require_once __DIR__ . '/includes/routes/event/create.php';
+require_once __DIR__ . '/includes/routes/event/details.php';
+require_once __DIR__ . '/includes/routes/event/edit.php';
+require_once __DIR__ . '/includes/routes/event/list.php';
+require_once __DIR__ . '/includes/routes/user/attend-event.php';
+require_once __DIR__ . '/includes/routes/user/my-events.php';
+require_once __DIR__ . '/includes/attendee/attendee.php';
+require_once __DIR__ . '/includes/attendee/attendee-repository.php';
+require_once __DIR__ . '/includes/event/event-date.php';
+require_once __DIR__ . '/includes/event/event.php';
+require_once __DIR__ . '/includes/event/event-repository-interface.php';
+require_once __DIR__ . '/includes/event/event-repository.php';
+require_once __DIR__ . '/includes/event/event-repository-cached.php';
+require_once __DIR__ . '/includes/event/event-form-handler.php';
+require_once __DIR__ . '/includes/stats-calculator.php';
+require_once __DIR__ . '/includes/stats-listener.php';

--- a/autoload.php
+++ b/autoload.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/includes/database.php';
 require_once __DIR__ . '/templates/helper-functions.php';
 require_once __DIR__ . '/includes/routes/route.php';
 require_once __DIR__ . '/includes/routes/event/create.php';

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -104,11 +104,30 @@ class Attendee_Repository {
 	 * @return int[] Event ids.
 	 */
 	public function get_events_for_user( int $user_id ): array {
-		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
-		if ( ! $event_ids ) {
-			$event_ids = array();
-		}
+		global $wpdb, $gp_table_prefix;
 
-		return array_keys( $event_ids );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+				select event_id
+				from {$gp_table_prefix}event_attendees
+				where user_id = %d
+			",
+				array(
+					$user_id,
+				)
+			)
+		);
+		// phpcs:enable
+
+		return array_map(
+			function ( object $row ) {
+				return intval( $row->event_id );
+			},
+			$rows
+		);
 	}
 }

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -69,7 +69,7 @@ class Attendee_Repository {
 	/**
 	 * @deprecated
 	 * TODO: This method should be moved out of this class because it's not about attendance,
-	 *       it returns events that match a condition (belong to a user), so it belongs in an event repository.
+	 *       it returns events that match a condition (have a user as attendee), so it belongs in an event repository.
 	 *       However, since we don't have an event repository yet, the method is placed here for now.
 	 *       When the method is moved to an event repository, it should return Event instances instead of event ids.
 	 *

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -5,8 +5,6 @@ namespace Wporg\TranslationEvents;
 use Exception;
 
 class Attendee_Repository {
-	private const USER_META_KEY = 'translation-events-attending';
-
 	/**
 	 * @throws Exception
 	 */

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -45,16 +45,20 @@ class Attendee_Repository {
 			throw new Exception( 'invalid user id' );
 		}
 
-		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
-		if ( ! $event_ids ) {
-			$event_ids = array();
-		}
-
-		if ( isset( $event_ids[ $event_id ] ) ) {
-			unset( $event_ids[ $event_id ] );
-		}
-
-		update_user_meta( $user_id, self::USER_META_KEY, $event_ids );
+		global $wpdb, $gp_table_prefix;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"delete from {$gp_table_prefix}event_attendees where event_id = %d and user_id = %d",
+				array(
+					'event_id' => $event_id,
+					'user_id'  => $user_id,
+				),
+			),
+		);
+		// phpcs:enable
 	}
 
 	public function is_attending( int $event_id, int $user_id ): bool {

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -50,12 +50,28 @@ class Attendee_Repository {
 	}
 
 	public function is_attending( int $event_id, int $user_id ): bool {
-		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
-		if ( ! $event_ids ) {
-			$event_ids = array();
-		}
+		global $wpdb, $gp_table_prefix;
 
-		return isset( $event_ids[ $event_id ] );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"
+				select count(*) as cnt
+				from {$gp_table_prefix}event_attendees
+				where event_id = %d
+				  and user_id = %d
+			",
+				array(
+					$event_id,
+					$user_id,
+				)
+			)
+		);
+		// phpcs:enable
+
+		return 1 === intval( $row->cnt );
 	}
 
 	/**

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -44,16 +44,17 @@ class Attendee_Repository {
 		}
 
 		global $wpdb, $gp_table_prefix;
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query(
-			$wpdb->prepare(
-				"delete from {$gp_table_prefix}event_attendees where event_id = %d and user_id = %d",
-				array(
-					'event_id' => $event_id,
-					'user_id'  => $user_id,
-				),
+		$wpdb->delete(
+			"{$gp_table_prefix}event_attendees",
+			array(
+				'event_id' => $event_id,
+				'user_id'  => $user_id,
+			),
+			array(
+				'%d',
+				'%d',
 			),
 		);
 		// phpcs:enable

--- a/includes/attendee-repository.php
+++ b/includes/attendee-repository.php
@@ -18,12 +18,20 @@ class Attendee_Repository {
 			throw new Exception( 'invalid user id' );
 		}
 
-		$event_ids = get_user_meta( $user_id, self::USER_META_KEY, true );
-		if ( ! $event_ids ) {
-			$event_ids = array();
-		}
-		$event_ids[ $event_id ] = true;
-		update_user_meta( $user_id, self::USER_META_KEY, $event_ids );
+		global $wpdb, $gp_table_prefix;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id) values (%d, %d)",
+				array(
+					'event_id' => $event_id,
+					'user_id'  => $user_id,
+				),
+			),
+		);
+		// phpcs:enable
 	}
 
 	/**

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -88,31 +88,6 @@ class Attendee_Repository {
 		return $attendee;
 	}
 
-	public function is_attending( Attendee $attendee ): bool {
-		global $wpdb, $gp_table_prefix;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		$row = $wpdb->get_row(
-			$wpdb->prepare(
-				"
-				select count(*) as cnt
-				from {$gp_table_prefix}event_attendees
-				where event_id = %d
-				  and user_id = %d
-			",
-				array(
-					$attendee->event_id(),
-					$attendee->user_id(),
-				)
-			)
-		);
-		// phpcs:enable
-
-		return 1 === intval( $row->cnt );
-	}
-
 	/**
 	 * @return Attendee[] Attendees of the event.
 	 */

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -15,10 +15,12 @@ class Attendee_Repository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query(
 			$wpdb->prepare(
-				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id) values (%d, %d)",
+				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id, is_host, is_contributor) values (%d, %d, %d, %d)",
 				array(
-					'event_id' => $attendee->event_id(),
-					'user_id'  => $attendee->user_id(),
+					'event_id'       => $attendee->event_id(),
+					'user_id'        => $attendee->user_id(),
+					'is_host'        => $attendee->is_host() ? 1 : 0,
+					'is_contributor' => $attendee->is_contributor() ? 1 : 0,
 				),
 			),
 		);

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -8,7 +8,7 @@ class Attendee_Repository {
 	/**
 	 * @throws Exception
 	 */
-	public function add_attendee( Attendee $attendee ): void {
+	public function insert_attendee( Attendee $attendee ): void {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -15,12 +15,11 @@ class Attendee_Repository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query(
 			$wpdb->prepare(
-				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id, is_host, is_contributor) values (%d, %d, %d, %d)",
+				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id, is_host) values (%d, %d, %d)",
 				array(
-					'event_id'       => $attendee->event_id(),
-					'user_id'        => $attendee->user_id(),
-					'is_host'        => $attendee->is_host() ? 1 : 0,
-					'is_contributor' => $attendee->is_contributor() ? 1 : 0,
+					'event_id' => $attendee->event_id(),
+					'user_id'  => $attendee->user_id(),
+					'is_host'  => $attendee->is_host() ? 1 : 0,
 				),
 			),
 		);
@@ -80,9 +79,6 @@ class Attendee_Repository {
 		$attendee = new Attendee( $row->event_id, $row->user_id );
 		if ( '1' === $row->is_host ) {
 			$attendee->mark_as_host();
-		}
-		if ( '1' === $row->is_contributor ) {
-			$attendee->mark_as_contributor();
 		}
 
 		return $attendee;

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -30,15 +30,15 @@ class Attendee_Repository {
 	/**
 	 * @throws Exception
 	 */
-	public function remove_attendee( Attendee $attendee ): void {
+	public function remove_attendee( int $event_id, int $user_id ): void {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->delete(
 			"{$gp_table_prefix}event_attendees",
 			array(
-				'event_id' => $attendee->event_id(),
-				'user_id'  => $attendee->user_id(),
+				'event_id' => $event_id,
+				'user_id'  => $user_id,
 			),
 			array(
 				'%d',

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -48,6 +48,46 @@ class Attendee_Repository {
 		// phpcs:enable
 	}
 
+	/**
+	 * @throws Exception
+	 */
+	public function get_attendee( int $event_id, int $user_id ): ?Attendee {
+		global $wpdb, $gp_table_prefix;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"
+				select *
+				from {$gp_table_prefix}event_attendees
+				where event_id = %d
+				  and user_id = %d
+			",
+				array(
+					$event_id,
+					$user_id,
+				),
+			)
+		);
+		// phpcs:enable
+
+		if ( ! $row ) {
+			return null;
+		}
+
+		$attendee = new Attendee( $row->event_id, $row->user_id );
+		if ( '1' === $row->is_host ) {
+			$attendee->mark_as_host();
+		}
+		if ( '1' === $row->is_contributor ) {
+			$attendee->mark_as_contributor();
+		}
+
+		return $attendee;
+	}
+
 	public function is_attending( Attendee $attendee ): bool {
 		global $wpdb, $gp_table_prefix;
 

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -72,7 +72,7 @@ class Attendee_Repository {
 	}
 
 	/**
-	 * @return int[] User ids.
+	 * @return Attendee[] Attendees of the event.
 	 */
 	public function get_attendees( int $event_id ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		// TODO.

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -46,7 +46,7 @@ class Attendee_Repository {
 		// phpcs:enable
 	}
 
-	public function is_attending( int $event_id, int $user_id ): bool {
+	public function is_attending( Attendee $attendee ): bool {
 		global $wpdb, $gp_table_prefix;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -61,8 +61,8 @@ class Attendee_Repository {
 				  and user_id = %d
 			",
 				array(
-					$event_id,
-					$user_id,
+					$attendee->event_id(),
+					$attendee->user_id(),
 				)
 			)
 		);

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Attendee;
 
 use Exception;
 

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -8,14 +8,7 @@ class Attendee_Repository {
 	/**
 	 * @throws Exception
 	 */
-	public function add_attendee( int $event_id, int $user_id ): void {
-		if ( $event_id < 1 ) {
-			throw new Exception( 'invalid event id' );
-		}
-		if ( $user_id < 1 ) {
-			throw new Exception( 'invalid user id' );
-		}
-
+	public function add_attendee( Attendee $attendee ): void {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -24,8 +17,8 @@ class Attendee_Repository {
 			$wpdb->prepare(
 				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id) values (%d, %d)",
 				array(
-					'event_id' => $event_id,
-					'user_id'  => $user_id,
+					'event_id' => $attendee->event_id(),
+					'user_id'  => $attendee->user_id(),
 				),
 			),
 		);

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -28,22 +28,15 @@ class Attendee_Repository {
 	/**
 	 * @throws Exception
 	 */
-	public function remove_attendee( int $event_id, int $user_id ): void {
-		if ( $event_id < 1 ) {
-			throw new Exception( 'invalid event id' );
-		}
-		if ( $user_id < 1 ) {
-			throw new Exception( 'invalid user id' );
-		}
-
+	public function remove_attendee( Attendee $attendee ): void {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->delete(
 			"{$gp_table_prefix}event_attendees",
 			array(
-				'event_id' => $event_id,
-				'user_id'  => $user_id,
+				'event_id' => $attendee->event_id(),
+				'user_id'  => $attendee->user_id(),
 			),
 			array(
 				'%d',

--- a/includes/attendee/attendee.php
+++ b/includes/attendee/attendee.php
@@ -8,7 +8,6 @@ class Attendee {
 	private int $event_id;
 	private int $user_id;
 	private bool $is_host;
-	private bool $is_contributor;
 
 	/**
 	 * @throws Exception
@@ -21,10 +20,9 @@ class Attendee {
 			throw new Exception( 'invalid user id' );
 		}
 
-		$this->event_id       = $event_id;
-		$this->user_id        = $user_id;
-		$this->is_host        = false;
-		$this->is_contributor = false;
+		$this->event_id = $event_id;
+		$this->user_id  = $user_id;
+		$this->is_host  = false;
 	}
 
 	public function event_id(): int {
@@ -41,13 +39,5 @@ class Attendee {
 
 	public function mark_as_host(): void {
 		$this->is_host = true;
-	}
-
-	public function is_contributor(): bool {
-		return $this->is_contributor;
-	}
-
-	public function mark_as_contributor(): void {
-		$this->is_contributor = true;
 	}
 }

--- a/includes/attendee/attendee.php
+++ b/includes/attendee/attendee.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Wporg\TranslationEvents\Attendee;
+
+use Exception;
+
+class Attendee {
+	private int $event_id;
+	private int $user_id;
+
+	/**
+	 * @throws Exception
+	 */
+	public function __construct( int $event_id, int $user_id ) {
+		if ( $event_id < 1 ) {
+			throw new Exception( 'invalid event id' );
+		}
+		if ( $user_id < 1 ) {
+			throw new Exception( 'invalid user id' );
+		}
+
+		$this->event_id = $event_id;
+		$this->user_id  = $user_id;
+	}
+
+	public function event_id(): int {
+		return $this->event_id;
+	}
+
+	public function user_id(): int {
+		return $this->user_id;
+	}
+}

--- a/includes/attendee/attendee.php
+++ b/includes/attendee/attendee.php
@@ -7,6 +7,8 @@ use Exception;
 class Attendee {
 	private int $event_id;
 	private int $user_id;
+	private bool $is_host;
+	private bool $is_contributor;
 
 	/**
 	 * @throws Exception
@@ -19,8 +21,10 @@ class Attendee {
 			throw new Exception( 'invalid user id' );
 		}
 
-		$this->event_id = $event_id;
-		$this->user_id  = $user_id;
+		$this->event_id       = $event_id;
+		$this->user_id        = $user_id;
+		$this->is_host        = false;
+		$this->is_contributor = false;
 	}
 
 	public function event_id(): int {
@@ -29,5 +33,21 @@ class Attendee {
 
 	public function user_id(): int {
 		return $this->user_id;
+	}
+
+	public function is_host(): bool {
+		return $this->is_host;
+	}
+
+	public function mark_as_host(): void {
+		$this->is_host = true;
+	}
+
+	public function is_contributor(): bool {
+		return $this->is_contributor;
+	}
+
+	public function mark_as_contributor(): void {
+		$this->is_contributor = true;
 	}
 }

--- a/includes/database.php
+++ b/includes/database.php
@@ -75,7 +75,7 @@ class Database {
 		foreach ( $events as $event ) {
 			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
 				$attendee = new Attendee( $event->ID, $user->ID );
-				$attendee_repository->add_attendee( $attendee );
+				$attendee_repository->insert_attendee( $attendee );
 			}
 		}
 	}

--- a/includes/database.php
+++ b/includes/database.php
@@ -74,7 +74,6 @@ class Database {
 		foreach ( $events as $event ) {
 			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
 				$attendee = new Attendee( $event->ID, $user->ID );
-				$attendee->mark_as_host();
 				$attendee_repository->insert_attendee( $attendee );
 			}
 		}

--- a/includes/database.php
+++ b/includes/database.php
@@ -74,6 +74,7 @@ class Database {
 		foreach ( $events as $event ) {
 			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
 				$attendee = new Attendee( $event->ID, $user->ID );
+				$attendee->mark_as_host();
 				$attendee_repository->insert_attendee( $attendee );
 			}
 		}

--- a/includes/database.php
+++ b/includes/database.php
@@ -32,6 +32,8 @@ class Database {
 			`translate_event_attendees_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
 			`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
+			`is_host` tinyint(1) default 0 not null comment 'Whether the user is a host of the event',
+			`is_contributor` tinyint(1) default 0 not null comment 'Whether the user created or reviewed translations during the event',
 		PRIMARY KEY (`translate_event_attendees_id`),
 		UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
 		INDEX `user` (`user_id`)

--- a/includes/database.php
+++ b/includes/database.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wporg\TranslationEvents;
+
+use Exception;
+use WP_Query;
+use Wporg\TranslationEvents\Attendee\Attendee;
+
+class Database {
+	public static function upgrade(): void {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		global $gp_table_prefix;
+
+		// Create actions table.
+		$create_actions_table = "
+		CREATE TABLE `{$gp_table_prefix}event_actions` (
+			`translate_event_actions_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
+			`original_id` int(10) NOT NULL COMMENT 'ID of the translation',
+			`user_id` int(10) NOT NULL COMMENT 'ID of the user who made the action',
+			`action` enum('approve','create','reject','request_changes') NOT NULL COMMENT 'The action that the user made (create, reject, etc)',
+			`locale` varchar(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL COMMENT 'Locale of the translation',
+			`happened_at` datetime NOT NULL COMMENT 'When the action happened, in UTC',
+		PRIMARY KEY (`translate_event_actions_id`),
+		UNIQUE KEY `event_per_translated_original_per_user` (`event_id`,`locale`,`original_id`,`user_id`)
+		) COMMENT='Tracks translation actions that happened during a translation event'";
+		dbDelta( $create_actions_table );
+
+		// Create attendees table.
+		$create_attendees_table = "
+		CREATE TABLE `{$gp_table_prefix}event_attendees` (
+			`translate_event_attendees_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
+			`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
+		PRIMARY KEY (`translate_event_attendees_id`),
+		UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
+		INDEX `user` (`user_id`)
+		) COMMENT='Attendees of events'";
+		dbDelta( $create_attendees_table );
+
+		// TODO: Remove this once it has been run in production.
+		try {
+			// Don't run it during tests.
+			$is_running_tests = 'yes' === getenv( 'WPORG_TRANSLATION_EVENTS_TESTS' );
+			if ( ! $is_running_tests ) {
+				self::import_legacy_attendees();
+			}
+		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( $e );
+		}
+	}
+
+	/**
+	 * Previously, event attendance was tracked through user_meta.
+	 * This function imports this legacy attendance information into the attendees table.
+	 *
+	 * Instead of looping through all users, we consider only users who have contributed to an event.
+	 *
+	 * @deprecated TODO: Remove this function once this has been run in production.
+	 * @throws Exception
+	 */
+	private static function import_legacy_attendees(): void {
+		$query = new WP_Query(
+			array(
+				'post_type' => Translation_Events::CPT,
+			)
+		);
+
+		$events              = $query->get_posts();
+		$stats_calculator    = new Stats_Calculator();
+		$attendee_repository = Translation_Events::get_attendee_repository();
+		foreach ( $events as $event ) {
+			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
+				$attendee = new Attendee( $event->ID, $user->ID );
+				$attendee_repository->add_attendee( $attendee );
+			}
+		}
+	}
+}

--- a/includes/database.php
+++ b/includes/database.php
@@ -33,7 +33,6 @@ class Database {
 			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
 			`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
 			`is_host` tinyint(1) default 0 not null comment 'Whether the user is a host of the event',
-			`is_contributor` tinyint(1) default 0 not null comment 'Whether the user created or reviewed translations during the event',
 		PRIMARY KEY (`translate_event_attendees_id`),
 		UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
 		INDEX `user` (`user_id`)

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -8,7 +8,7 @@ use Exception;
 use WP_Error;
 use WP_Post;
 use WP_Query;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -50,7 +50,9 @@ class Details_Route extends Route {
 		$event_description = $event->description();
 		$event_start       = $event->start();
 		$event_end         = $event->end();
-		$user_is_attending = $this->attendee_repository->is_attending( new Attendee( $event->id(), $user->ID ) );
+
+		$attendee          = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		$user_is_attending = $attendee instanceof Attendee;
 
 		$stats_calculator = new Stats_Calculator();
 		try {

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -4,7 +4,7 @@ namespace Wporg\TranslationEvents\Routes\Event;
 
 use Exception;
 use GP;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats_Calculator;

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -4,6 +4,7 @@ namespace Wporg\TranslationEvents\Routes\Event;
 
 use Exception;
 use GP;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
@@ -49,7 +50,7 @@ class Details_Route extends Route {
 		$event_description = $event->description();
 		$event_start       = $event->start();
 		$event_end         = $event->end();
-		$user_is_attending = $this->attendee_repository->is_attending( $event->id(), $user->ID );
+		$user_is_attending = $this->attendee_repository->is_attending( new Attendee( $event->id(), $user->ID ) );
 
 		$stats_calculator = new Stats_Calculator();
 		try {

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -3,7 +3,9 @@
 namespace Wporg\TranslationEvents\Routes\User;
 
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
+use Wporg\TranslationEvents\Translation_Events;
 
 /**
  * Toggle whether the current user is attending an event.
@@ -11,11 +13,13 @@ use Wporg\TranslationEvents\Routes\Route;
  * If the user is currently marked as attending, they will be marked as not attending.
  */
 class Attend_Event_Route extends Route {
+	private Event_Repository_Interface $event_repository;
 	private Attendee_Repository $attendee_repository;
 
 	public function __construct() {
 		parent::__construct();
-		$this->attendee_repository = new Attendee_Repository();
+		$this->event_repository    = Translation_Events::get_event_repository();
+		$this->attendee_repository = Translation_Events::get_attendee_repository();
 	}
 
 	public function handle( int $event_id ): void {
@@ -24,18 +28,18 @@ class Attend_Event_Route extends Route {
 			$this->die_with_error( esc_html__( 'Only logged-in users can attend events', 'gp-translation-events' ), 403 );
 		}
 
-		$event = get_post( $event_id );
+		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();
 		}
 
-		if ( $this->attendee_repository->is_attending( $event_id, $user->ID ) ) {
-			$this->attendee_repository->remove_attendee( $event_id, $user->ID );
+		if ( $this->attendee_repository->is_attending( $event->id(), $user->ID ) ) {
+			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
 		} else {
-			$this->attendee_repository->add_attendee( $event_id, $user->ID );
+			$this->attendee_repository->add_attendee( $event->id(), $user->ID );
 		}
 
-		wp_safe_redirect( gp_url( "/events/$event->post_name" ) );
+		wp_safe_redirect( gp_url( "/events/{$event->slug()}" ) );
 		exit;
 	}
 }

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -37,7 +37,7 @@ class Attend_Event_Route extends Route {
 		$attendee = new Attendee( $event->id(), $user->ID );
 
 		if ( $this->attendee_repository->is_attending( $event->id(), $user->ID ) ) {
-			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
+			$this->attendee_repository->remove_attendee( $attendee );
 		} else {
 			$this->attendee_repository->add_attendee( $attendee );
 		}

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -37,7 +37,7 @@ class Attend_Event_Route extends Route {
 		$attendee = new Attendee( $event->id(), $user->ID );
 
 		if ( $this->attendee_repository->is_attending( $attendee ) ) {
-			$this->attendee_repository->remove_attendee( $attendee );
+			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
 		} else {
 			$this->attendee_repository->insert_attendee( $attendee );
 		}

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -36,7 +36,7 @@ class Attend_Event_Route extends Route {
 
 		$attendee = new Attendee( $event->id(), $user->ID );
 
-		if ( $this->attendee_repository->is_attending( $event->id(), $user->ID ) ) {
+		if ( $this->attendee_repository->is_attending( $attendee ) ) {
 			$this->attendee_repository->remove_attendee( $attendee );
 		} else {
 			$this->attendee_repository->add_attendee( $attendee );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -39,7 +39,7 @@ class Attend_Event_Route extends Route {
 		if ( $this->attendee_repository->is_attending( $attendee ) ) {
 			$this->attendee_repository->remove_attendee( $attendee );
 		} else {
-			$this->attendee_repository->add_attendee( $attendee );
+			$this->attendee_repository->insert_attendee( $attendee );
 		}
 
 		wp_safe_redirect( gp_url( "/events/{$event->slug()}" ) );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -34,11 +34,11 @@ class Attend_Event_Route extends Route {
 			$this->die_with_404();
 		}
 
-		$attendee = new Attendee( $event->id(), $user->ID );
-
-		if ( $this->attendee_repository->is_attending( $attendee ) ) {
+		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		if ( $attendee instanceof Attendee ) {
 			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
 		} else {
+			$attendee = new Attendee( $event->id(), $user->ID );
 			$this->attendee_repository->insert_attendee( $attendee );
 		}
 

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -2,6 +2,7 @@
 
 namespace Wporg\TranslationEvents\Routes\User;
 
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
@@ -33,10 +34,12 @@ class Attend_Event_Route extends Route {
 			$this->die_with_404();
 		}
 
+		$attendee = new Attendee( $event->id(), $user->ID );
+
 		if ( $this->attendee_repository->is_attending( $event->id(), $user->ID ) ) {
 			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
 		} else {
-			$this->attendee_repository->add_attendee( $event->id(), $user->ID );
+			$this->attendee_repository->add_attendee( $attendee );
 		}
 
 		wp_safe_redirect( gp_url( "/events/{$event->slug()}" ) );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -2,7 +2,7 @@
 
 namespace Wporg\TranslationEvents\Routes\User;
 
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Routes\Route;
 
 /**

--- a/includes/stats-listener.php
+++ b/includes/stats-listener.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Exception;
 use GP_Translation;
 use GP_Translation_Set;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,7 @@
 			<directory suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<php>
+		<env name="TRANSLATION_EVENTS_NO_IMPORT_LEGACY_ATTENDEES" value="true" force="true" />
+	</php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,6 @@
 		</testsuite>
 	</testsuites>
 	<php>
-		<env name="TRANSLATION_EVENTS_NO_IMPORT_LEGACY_ATTENDEES" value="true" force="true" />
+		<env name="WPORG_TRANSLATION_EVENTS_TESTS" value="yes" force="true" />
 	</php>
 </phpunit>

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -57,9 +57,9 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 
 		$this->repository->remove_attendee( $event1_id, $user_id );
 
-		$event_ids = get_user_meta( $user_id, 'translation-events-attending', true );
-		$this->assertCount( 1, $event_ids );
-		$this->assertTrue( $event_ids[ $event2_id ] );
+		$rows = $this->all_table_rows();
+		$this->assertCount( 1, $rows );
+		$this->assertEquals( $event2_id, $rows[0]->event_id );
 	}
 
 	public function test_is_attending() {

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -31,13 +31,10 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->repository->add_attendee( $event1_id, $user_id );
 		$this->repository->add_attendee( $event2_id, $user_id );
 
-		$event_ids = get_user_meta( $user_id, 'translation-events-attending', true );
-		$this->assertCount( 2, $event_ids );
-		$this->assertTrue( $event_ids[ $event1_id ] );
-		$this->assertTrue( $event_ids[ $event2_id ] );
-
-		$event_ids_another_user = get_user_meta( $user_id + 1, 'translation-events-attending', true );
-		$this->assertEmpty( $event_ids_another_user );
+		$rows = $this->all_table_rows();
+		$this->assertCount( 2, $rows );
+		$this->assertEquals( $event1_id, $rows[0]->event_id );
+		$this->assertEquals( $event2_id, $rows[1]->event_id );
 	}
 
 	public function test_remove_attendee_invalid_event_id() {

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -91,4 +91,13 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( $event3_id ), $this->repository->get_events_for_user( $another_user ) );
 		$this->assertEmpty( $this->repository->get_events_for_user( $another_user + 1 ) );
 	}
+
+	private function all_table_rows(): array {
+		global $wpdb, $gp_table_prefix;
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_results( "select * from {$gp_table_prefix}event_attendees order by event_id, user_id" );
+		// phpcs:enable
+	}
 }

--- a/tests/attendee-repository.php
+++ b/tests/attendee-repository.php
@@ -73,7 +73,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->repository->is_attending( $event2_id, $user_id ) );
 	}
 
-	public function test_get_event_ids() {
+	public function test_get_events_for_user() {
 		$event1_id    = 1;
 		$event2_id    = 2;
 		$event3_id    = 3;

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -46,7 +46,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
 		$this->repository->insert_attendee( new Attendee( $event2_id, $user_id ) );
 
-		$this->repository->remove_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->remove_attendee( $event1_id, $user_id );
 
 		$rows = $this->all_table_rows();
 		$this->assertCount( 1, $rows );

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -85,17 +85,6 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertNull( $this->repository->get_attendee( $event2_id, $user2_id ) );
 	}
 
-	public function test_is_attending() {
-		$event1_id = 1;
-		$event2_id = 2;
-		$user_id   = 42;
-
-		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
-
-		$this->assertTrue( $this->repository->is_attending( new Attendee( $event1_id, $user_id ) ) );
-		$this->assertFalse( $this->repository->is_attending( new Attendee( $event2_id, $user_id ) ) );
-	}
-
 	public function test_get_events_for_user() {
 		$event1_id    = 1;
 		$event2_id    = 2;

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -38,16 +38,6 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $event2_id, $rows[1]->event_id );
 	}
 
-	public function test_remove_attendee_invalid_event_id() {
-		$this->expectExceptionMessage( 'invalid event id' );
-		$this->repository->remove_attendee( 0, 1 );
-	}
-
-	public function test_remove_attendee_invalid_user_id() {
-		$this->expectExceptionMessage( 'invalid user id' );
-		$this->repository->remove_attendee( 1, 0 );
-	}
-
 	public function test_remove_attendee() {
 		$event1_id = 1;
 		$event2_id = 2;
@@ -56,7 +46,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
 		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
 
-		$this->repository->remove_attendee( $event1_id, $user_id );
+		$this->repository->remove_attendee( new Attendee( $event1_id, $user_id ) );
 
 		$rows = $this->all_table_rows();
 		$this->assertCount( 1, $rows );

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -3,6 +3,7 @@
 namespace Wporg\Tests\Attendee;
 
 use WP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 
 class Attendee_Repository_Test extends WP_UnitTestCase {
@@ -15,12 +16,12 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 
 	public function test_add_attendee_invalid_event_id() {
 		$this->expectExceptionMessage( 'invalid event id' );
-		$this->repository->add_attendee( 0, 1 );
+		$this->repository->add_attendee( new Attendee( 0, 1 ) );
 	}
 
 	public function test_add_attendee_invalid_user_id() {
 		$this->expectExceptionMessage( 'invalid user id' );
-		$this->repository->add_attendee( 1, 0 );
+		$this->repository->add_attendee( new Attendee( 1, 0 ) );
 	}
 
 	public function test_add_attendee() {
@@ -28,8 +29,8 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( $event1_id, $user_id );
-		$this->repository->add_attendee( $event2_id, $user_id );
+		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
 
 		$rows = $this->all_table_rows();
 		$this->assertCount( 2, $rows );
@@ -52,8 +53,8 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( $event1_id, $user_id );
-		$this->repository->add_attendee( $event2_id, $user_id );
+		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
 
 		$this->repository->remove_attendee( $event1_id, $user_id );
 
@@ -67,7 +68,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( $event1_id, $user_id );
+		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
 
 		$this->assertTrue( $this->repository->is_attending( $event1_id, $user_id ) );
 		$this->assertFalse( $this->repository->is_attending( $event2_id, $user_id ) );
@@ -80,9 +81,9 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$user_id      = 42;
 		$another_user = $user_id + 1;
 
-		$this->repository->add_attendee( $event1_id, $user_id );
-		$this->repository->add_attendee( $event2_id, $user_id );
-		$this->repository->add_attendee( $event3_id, $another_user );
+		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
+		$this->repository->add_attendee( new Attendee( $event3_id, $another_user ) );
 
 		$this->assertEquals( array( $event1_id, $event2_id ), $this->repository->get_events_for_user( $user_id ) );
 		$this->assertEquals( array( $event3_id ), $this->repository->get_events_for_user( $another_user ) );

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -64,7 +64,6 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->repository->insert_attendee( $attendee11 );
 
 		$attendee12 = new Attendee( $event1_id, $user2_id );
-		$attendee12->mark_as_contributor();
 		$this->repository->insert_attendee( $attendee12 );
 
 		// Add some more attendees to make sure we get the right ones.
@@ -75,12 +74,10 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$retrieved_attendee_11 = $this->repository->get_attendee( $event1_id, $user1_id );
 		$this->assertEquals( $attendee11, $retrieved_attendee_11 );
 		$this->assertTrue( $retrieved_attendee_11->is_host() );
-		$this->assertFalse( $retrieved_attendee_11->is_contributor() );
 
 		$retrieved_attendee_12 = $this->repository->get_attendee( $event1_id, $user2_id );
 		$this->assertEquals( $attendee12, $retrieved_attendee_12 );
 		$this->assertFalse( $retrieved_attendee_12->is_host() );
-		$this->assertTrue( $retrieved_attendee_12->is_contributor() );
 
 		$this->assertNull( $this->repository->get_attendee( $event2_id, $user2_id ) );
 	}

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -16,21 +16,21 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 
 	public function test_add_attendee_invalid_event_id() {
 		$this->expectExceptionMessage( 'invalid event id' );
-		$this->repository->add_attendee( new Attendee( 0, 1 ) );
+		$this->repository->insert_attendee( new Attendee( 0, 1 ) );
 	}
 
 	public function test_add_attendee_invalid_user_id() {
 		$this->expectExceptionMessage( 'invalid user id' );
-		$this->repository->add_attendee( new Attendee( 1, 0 ) );
+		$this->repository->insert_attendee( new Attendee( 1, 0 ) );
 	}
 
-	public function test_add_attendee() {
+	public function test_insert_attendee() {
 		$event1_id = 1;
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
-		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event2_id, $user_id ) );
 
 		$rows = $this->all_table_rows();
 		$this->assertCount( 2, $rows );
@@ -43,8 +43,8 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
-		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event2_id, $user_id ) );
 
 		$this->repository->remove_attendee( new Attendee( $event1_id, $user_id ) );
 
@@ -58,7 +58,7 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$event2_id = 2;
 		$user_id   = 42;
 
-		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
 
 		$this->assertTrue( $this->repository->is_attending( new Attendee( $event1_id, $user_id ) ) );
 		$this->assertFalse( $this->repository->is_attending( new Attendee( $event2_id, $user_id ) ) );
@@ -71,9 +71,9 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$user_id      = 42;
 		$another_user = $user_id + 1;
 
-		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
-		$this->repository->add_attendee( new Attendee( $event2_id, $user_id ) );
-		$this->repository->add_attendee( new Attendee( $event3_id, $another_user ) );
+		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event2_id, $user_id ) );
+		$this->repository->insert_attendee( new Attendee( $event3_id, $another_user ) );
 
 		$this->assertEquals( array( $event1_id, $event2_id ), $this->repository->get_events_for_user( $user_id ) );
 		$this->assertEquals( array( $event3_id ), $this->repository->get_events_for_user( $another_user ) );

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -53,6 +53,38 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 		$this->assertEquals( $event2_id, $rows[0]->event_id );
 	}
 
+	public function test_get_attendee() {
+		$event1_id = 1;
+		$event2_id = 2;
+		$user1_id  = 42;
+		$user2_id  = 43;
+
+		$attendee11 = new Attendee( $event1_id, $user1_id );
+		$attendee11->mark_as_host();
+		$this->repository->insert_attendee( $attendee11 );
+
+		$attendee12 = new Attendee( $event1_id, $user2_id );
+		$attendee12->mark_as_contributor();
+		$this->repository->insert_attendee( $attendee12 );
+
+		// Add some more attendees to make sure we get the right ones.
+		$this->repository->insert_attendee( new Attendee( $event1_id, 84 ) );
+		$this->repository->insert_attendee( new Attendee( $event2_id, 84 ) );
+		$this->repository->insert_attendee( new Attendee( $event2_id, $user1_id ) );
+
+		$retrieved_attendee_11 = $this->repository->get_attendee( $event1_id, $user1_id );
+		$this->assertEquals( $attendee11, $retrieved_attendee_11 );
+		$this->assertTrue( $retrieved_attendee_11->is_host() );
+		$this->assertFalse( $retrieved_attendee_11->is_contributor() );
+
+		$retrieved_attendee_12 = $this->repository->get_attendee( $event1_id, $user2_id );
+		$this->assertEquals( $attendee12, $retrieved_attendee_12 );
+		$this->assertFalse( $retrieved_attendee_12->is_host() );
+		$this->assertTrue( $retrieved_attendee_12->is_contributor() );
+
+		$this->assertNull( $this->repository->get_attendee( $event2_id, $user2_id ) );
+	}
+
 	public function test_is_attending() {
 		$event1_id = 1;
 		$event2_id = 2;

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -60,8 +60,8 @@ class Attendee_Repository_Test extends WP_UnitTestCase {
 
 		$this->repository->add_attendee( new Attendee( $event1_id, $user_id ) );
 
-		$this->assertTrue( $this->repository->is_attending( $event1_id, $user_id ) );
-		$this->assertFalse( $this->repository->is_attending( $event2_id, $user_id ) );
+		$this->assertTrue( $this->repository->is_attending( new Attendee( $event1_id, $user_id ) ) );
+		$this->assertFalse( $this->repository->is_attending( new Attendee( $event2_id, $user_id ) ) );
 	}
 
 	public function test_get_events_for_user() {

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Wporg\Tests;
+namespace Wporg\Tests\Attendee;
 
 use WP_UnitTestCase;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 
 class Attendee_Repository_Test extends WP_UnitTestCase {
 	private Attendee_Repository $repository;

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -5,7 +5,7 @@ namespace Wporg\Tests\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use GP_UnitTestCase;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_End_Date;

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -5,7 +5,7 @@ namespace Wporg\Tests\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use GP_UnitTestCase;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Event\Event_End_Date;

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -86,7 +86,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		if ( ! in_array( $user_id, $attendee_ids, true ) ) {
 			// The current user will have been added as attending the event, but it was not specified as an attendee by
 			// the caller of this function. So we remove the current user as attendee.
-			$attendee_repository->remove_attendee( new Attendee( $event_id, $user_id ) );
+			$attendee_repository->remove_attendee( $event_id, $user_id );
 		}
 
 		update_post_meta( $event_id, '_event_start', $start->format( 'Y-m-d H:i:s' ) );

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -94,7 +94,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		update_post_meta( $event_id, '_event_timezone', $timezone->getName() );
 
 		foreach ( $attendee_ids as $attendee_id ) {
-			$attendee_repository->add_attendee( new Attendee( $event_id, $attendee_id ) );
+			$attendee_repository->insert_attendee( new Attendee( $event_id, $attendee_id ) );
 		}
 
 		return $event_id;

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTest_Factory_For_Post;
 use WP_UnitTest_Generator_Sequence;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Translation_Events;
 
@@ -93,7 +94,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		update_post_meta( $event_id, '_event_timezone', $timezone->getName() );
 
 		foreach ( $attendee_ids as $attendee_id ) {
-			$attendee_repository->add_attendee( $event_id, $attendee_id );
+			$attendee_repository->add_attendee( new Attendee( $event_id, $attendee_id ) );
 		}
 
 		return $event_id;

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -78,26 +78,22 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 	}
 
 	public function create_event( DateTimeImmutable $start, DateTimeImmutable $end, DateTimeZone $timezone, array $attendee_ids ): int {
-		$event_id = $this->create();
-		$meta_key = 'translation-events-attending';
+		$attendee_repository = new Attendee_Repository();
+		$event_id            = $this->create();
 
 		$user_id = get_current_user_id();
 		if ( ! in_array( $user_id, $attendee_ids, true ) ) {
 			// The current user will have been added as attending the event, but it was not specified as an attendee by
 			// the caller of this function. So we remove the current user as attendee.
-			$event_ids = get_user_meta( $user_id, $meta_key, true );
-			unset( $event_ids[ $event_id ] );
-			update_user_meta( $user_id, $meta_key, $event_ids );
+			$attendee_repository->remove_attendee( $event_id, $user_id );
 		}
 
 		update_post_meta( $event_id, '_event_start', $start->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event_id, '_event_end', $end->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event_id, '_event_timezone', $timezone->getName() );
 
-		foreach ( $attendee_ids as $user_id ) {
-			$event_ids   = get_user_meta( $user_id, $meta_key, true ) ?: array();
-			$event_ids[] = $event_id;
-			update_user_meta( $user_id, $meta_key, $event_ids );
+		foreach ( $attendee_ids as $attendee_id ) {
+			$attendee_repository->add_attendee( $event_id, $attendee_id );
 		}
 
 		return $event_id;

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTest_Factory_For_Post;
 use WP_UnitTest_Generator_Sequence;
-use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Factory extends WP_UnitTest_Factory_For_Post {

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -86,7 +86,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		if ( ! in_array( $user_id, $attendee_ids, true ) ) {
 			// The current user will have been added as attending the event, but it was not specified as an attendee by
 			// the caller of this function. So we remove the current user as attendee.
-			$attendee_repository->remove_attendee( $event_id, $user_id );
+			$attendee_repository->remove_attendee( new Attendee( $event_id, $user_id ) );
 		}
 
 		update_post_meta( $event_id, '_event_start', $start->format( 'Y-m-d H:i:s' ) );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -36,6 +36,7 @@ class Translation_Events {
 	public static function get_instance() {
 		static $instance = null;
 		if ( null === $instance ) {
+			require_once __DIR__ . '/autoload.php';
 			$instance = new self();
 		}
 		return $instance;
@@ -73,25 +74,6 @@ class Translation_Events {
 	}
 
 	public function gp_init() {
-		require_once __DIR__ . '/templates/helper-functions.php';
-		require_once __DIR__ . '/includes/routes/route.php';
-		require_once __DIR__ . '/includes/routes/event/create.php';
-		require_once __DIR__ . '/includes/routes/event/details.php';
-		require_once __DIR__ . '/includes/routes/event/edit.php';
-		require_once __DIR__ . '/includes/routes/event/list.php';
-		require_once __DIR__ . '/includes/routes/user/attend-event.php';
-		require_once __DIR__ . '/includes/routes/user/my-events.php';
-		require_once __DIR__ . '/includes/attendee/attendee.php';
-		require_once __DIR__ . '/includes/attendee/attendee-repository.php';
-		require_once __DIR__ . '/includes/event/event-date.php';
-		require_once __DIR__ . '/includes/event/event.php';
-		require_once __DIR__ . '/includes/event/event-repository-interface.php';
-		require_once __DIR__ . '/includes/event/event-repository.php';
-		require_once __DIR__ . '/includes/event/event-repository-cached.php';
-		require_once __DIR__ . '/includes/event/event-form-handler.php';
-		require_once __DIR__ . '/includes/stats-calculator.php';
-		require_once __DIR__ . '/includes/stats-listener.php';
-
 		GP::$router->add( '/events?', array( 'Wporg\TranslationEvents\Routes\Event\List_Route', 'handle' ) );
 		GP::$router->add( '/events/new', array( 'Wporg\TranslationEvents\Routes\Event\Create_Route', 'handle' ) );
 		GP::$router->add( '/events/edit/(\d+)', array( 'Wporg\TranslationEvents\Routes\Event\Edit_Route', 'handle' ) );
@@ -160,9 +142,6 @@ class Translation_Events {
 	 * @throws Exception
 	 */
 	private function import_legacy_attendees(): void {
-		require_once __DIR__ . '/includes/attendee-repository.php';
-		require_once __DIR__ . '/includes/stats-calculator.php';
-
 		$query = new WP_Query(
 			array(
 				'post_type' => self::CPT,

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -89,74 +89,7 @@ class Translation_Events {
 	}
 
 	public function activate(): void {
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		global $gp_table_prefix;
-
-		// Create actions table.
-		$create_actions_table = "
-		CREATE TABLE `{$gp_table_prefix}event_actions` (
-			`translate_event_actions_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
-			`original_id` int(10) NOT NULL COMMENT 'ID of the translation',
-			`user_id` int(10) NOT NULL COMMENT 'ID of the user who made the action',
-			`action` enum('approve','create','reject','request_changes') NOT NULL COMMENT 'The action that the user made (create, reject, etc)',
-			`locale` varchar(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL COMMENT 'Locale of the translation',
-			`happened_at` datetime NOT NULL COMMENT 'When the action happened, in UTC',
-		PRIMARY KEY (`translate_event_actions_id`),
-		UNIQUE KEY `event_per_translated_original_per_user` (`event_id`,`locale`,`original_id`,`user_id`)
-		) COMMENT='Tracks translation actions that happened during a translation event'";
-		dbDelta( $create_actions_table );
-
-		// Create attendees table.
-		$create_attendees_table = "
-		CREATE TABLE `{$gp_table_prefix}event_attendees` (
-			`translate_event_attendees_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
-			`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
-		PRIMARY KEY (`translate_event_attendees_id`),
-		UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
-		INDEX `user` (`user_id`)
-		) COMMENT='Attendees of events'";
-		dbDelta( $create_attendees_table );
-
-		// TODO: Remove this once it has been run in production.
-		try {
-			// Don't run it during tests.
-			$is_running_tests = 'yes' === getenv( 'WPORG_TRANSLATION_EVENTS_TESTS' );
-			if ( ! $is_running_tests ) {
-				$this->import_legacy_attendees();
-			}
-		} catch ( Exception $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $e );
-		}
-	}
-
-	/**
-	 * Previously, event attendance was tracked through user_meta.
-	 * This function imports this legacy attendance information into the attendees table.
-	 *
-	 * Instead of looping through all users, we consider only users who have contributed to an event.
-	 *
-	 * @deprecated TODO: Remove this function once this has been run in production.
-	 * @throws Exception
-	 */
-	private function import_legacy_attendees(): void {
-		$query = new WP_Query(
-			array(
-				'post_type' => self::CPT,
-			)
-		);
-
-		$events              = $query->get_posts();
-		$stats_calculator    = new Stats_Calculator();
-		$attendee_repository = self::get_attendee_repository();
-		foreach ( $events as $event ) {
-			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
-				$attendee = new Attendee( $event->ID, $user->ID );
-				$attendee_repository->add_attendee( $attendee );
-			}
-		}
+		Database::upgrade();
 	}
 
 	/**

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -80,6 +80,7 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
+		require_once __DIR__ . '/includes/attendee/attendee.php';
 		require_once __DIR__ . '/includes/attendee/attendee-repository.php';
 		require_once __DIR__ . '/includes/event/event-date.php';
 		require_once __DIR__ . '/includes/event/event.php';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -103,9 +103,12 @@ class Translation_Events {
 		$stats_listener->start();
 	}
 
-	public function activate() {
+	public function activate(): void {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		global $gp_table_prefix;
-		$create_table = "
+
+		// Create actions table.
+		$create_actions_table = "
 		CREATE TABLE `{$gp_table_prefix}event_actions` (
 			`translate_event_actions_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
@@ -117,8 +120,7 @@ class Translation_Events {
 		PRIMARY KEY (`translate_event_actions_id`),
 		UNIQUE KEY `event_per_translated_original_per_user` (`event_id`,`locale`,`original_id`,`user_id`)
 		) COMMENT='Tracks translation actions that happened during a translation event'";
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		dbDelta( $create_table );
+		dbDelta( $create_actions_table );
 	}
 
 	/**

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -24,6 +24,7 @@ use Exception;
 use GP;
 use WP_Post;
 use WP_Query;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
@@ -170,10 +171,11 @@ class Translation_Events {
 
 		$events              = $query->get_posts();
 		$stats_calculator    = new Stats_Calculator();
-		$attendee_repository = new Attendee_Repository();
+		$attendee_repository = self::get_attendee_repository();
 		foreach ( $events as $event ) {
 			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
-				$attendee_repository->add_attendee( $event->ID, $user->ID );
+				$attendee = new Attendee( $event->ID, $user->ID );
+				$attendee_repository->add_attendee( $attendee );
 			}
 		}
 	}
@@ -297,10 +299,11 @@ class Translation_Events {
 			return;
 		}
 		if ( 'publish' === $new_status && ( 'new' === $old_status || 'draft' === $old_status ) ) {
-			$attendee_repository = new Attendee_Repository();
-			$current_user_id     = get_current_user_id();
-			if ( ! $attendee_repository->is_attending( $post->ID, $current_user_id ) ) {
-				$attendee_repository->add_attendee( $post->ID, $current_user_id );
+			$attendee_repository = self::get_attendee_repository();
+			$attendee            = new Attendee( $post->ID, get_current_user_id() );
+
+			if ( ! $attendee_repository->is_attending( $attendee->event_id(), $attendee->user_id() ) ) {
+				$attendee_repository->add_attendee( $attendee );
 			}
 		}
 	}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -302,7 +302,7 @@ class Translation_Events {
 			$attendee_repository = self::get_attendee_repository();
 			$attendee            = new Attendee( $post->ID, get_current_user_id() );
 
-			if ( ! $attendee_repository->is_attending( $attendee->event_id(), $attendee->user_id() ) ) {
+			if ( ! $attendee_repository->is_attending( $attendee ) ) {
 				$attendee_repository->add_attendee( $attendee );
 			}
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -211,10 +211,14 @@ class Translation_Events {
 			return;
 		}
 		if ( 'publish' === $new_status && ( 'new' === $old_status || 'draft' === $old_status ) ) {
+			$event_id            = $post->ID;
+			$user_id             = get_current_user_id();
 			$attendee_repository = self::get_attendee_repository();
-			$attendee            = new Attendee( $post->ID, get_current_user_id() );
+			$attendee            = $attendee_repository->get_attendee( $event_id, $user_id );
 
-			if ( ! $attendee_repository->is_attending( $attendee ) ) {
+			if ( null === $attendee ) {
+				$attendee = new Attendee( $event_id, $user_id );
+				$attendee->mark_as_host();
 				$attendee_repository->insert_attendee( $attendee );
 			}
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -137,7 +137,8 @@ class Translation_Events {
 		// TODO: Remove this once it has been run in production.
 		try {
 			// Don't run it during tests.
-			if ( 'true' === getenv( 'TRANSLATION_EVENTS_NO_IMPORT_LEGACY_ATTENDEES' ) ) {
+			$is_running_tests = 'yes' === getenv( 'WPORG_TRANSLATION_EVENTS_TESTS' );
+			if ( ! $is_running_tests ) {
 				$this->import_legacy_attendees();
 			}
 		} catch ( Exception $e ) {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -215,7 +215,7 @@ class Translation_Events {
 			$attendee            = new Attendee( $post->ID, get_current_user_id() );
 
 			if ( ! $attendee_repository->is_attending( $attendee ) ) {
-				$attendee_repository->add_attendee( $attendee );
+				$attendee_repository->insert_attendee( $attendee );
 			}
 		}
 	}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -136,7 +136,10 @@ class Translation_Events {
 
 		// TODO: Remove this once it has been run in production.
 		try {
-			$this->import_legacy_attendees();
+			// Don't run it during tests.
+			if ( 'true' === getenv( 'TRANSLATION_EVENTS_NO_IMPORT_LEGACY_ATTENDEES' ) ) {
+				$this->import_legacy_attendees();
+			}
 		} catch ( Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $e );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -169,7 +169,7 @@ class Translation_Events {
 		$stats_calculator    = new Stats_Calculator();
 		$attendee_repository = new Attendee_Repository();
 		foreach ( $events as $event ) {
-			foreach ( $stats_calculator->get_contributors( $event ) as $user ) {
+			foreach ( $stats_calculator->get_contributors( $event->ID ) as $user ) {
 				$attendee_repository->add_attendee( $event->ID, $user->ID );
 			}
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -121,6 +121,18 @@ class Translation_Events {
 		UNIQUE KEY `event_per_translated_original_per_user` (`event_id`,`locale`,`original_id`,`user_id`)
 		) COMMENT='Tracks translation actions that happened during a translation event'";
 		dbDelta( $create_actions_table );
+
+		// Create attendees table.
+		$create_attendees_table = "
+		CREATE TABLE `{$gp_table_prefix}event_attendees` (
+			`translate_event_attendees_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+			`event_id` int(10) NOT NULL COMMENT 'Post_ID of the translation_event post in the wp_posts table',
+			`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
+		PRIMARY KEY (`translate_event_attendees_id`),
+		UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
+		INDEX `user` (`user_id`)
+		) COMMENT='Attendees of events'";
+		dbDelta( $create_attendees_table );
 	}
 
 	/**

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -165,7 +165,6 @@ class Translation_Events {
 			)
 		);
 
-		// Import legacy attendance to attendees table.
 		$events              = $query->get_posts();
 		$stats_calculator    = new Stats_Calculator();
 		$attendee_repository = new Attendee_Repository();
@@ -174,22 +173,6 @@ class Translation_Events {
 				$attendee_repository->add_attendee( $event->ID, $user->ID );
 			}
 		}
-
-		// Delete legacy attendance information.
-		global $wpdb, $wp_table_prefix;
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		$wpdb->query(
-			$wpdb->prepare(
-				"delete from {$wp_table_prefix}usermeta where meta_key = %s",
-				array(
-					'meta_key' => 'translation-events-attending',
-				),
-			),
-		);
-		// phpcs:enable
 	}
 
 	/**

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -24,6 +24,7 @@ use Exception;
 use GP;
 use WP_Post;
 use WP_Query;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
@@ -79,13 +80,13 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
+		require_once __DIR__ . '/includes/attendee/attendee-repository.php';
 		require_once __DIR__ . '/includes/event/event-date.php';
 		require_once __DIR__ . '/includes/event/event.php';
 		require_once __DIR__ . '/includes/event/event-repository-interface.php';
 		require_once __DIR__ . '/includes/event/event-repository.php';
 		require_once __DIR__ . '/includes/event/event-repository-cached.php';
 		require_once __DIR__ . '/includes/event/event-form-handler.php';
-		require_once __DIR__ . '/includes/attendee-repository.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
 		require_once __DIR__ . '/includes/stats-listener.php';
 


### PR DESCRIPTION
Fixes #167 

I would recommend reviewing the final result instead of individual commits, as some iteration was required.

## Summary of changes

- Extract all `require_once` calls to an `autoload.php` file
    - And load it early instead of in `gp_init()`, to guarantee required files are always loaded
- Extract database upgrade logic to a separate file
- Move `Attendee_Repository` to an `Attendee` namespace
- Create `Attendee` class which represents a user attending an event
- Adapt `Attendee_Repository` so it uses `Attendee` class
- Add missing methods in `Attendee_Repository` (e.g. `get_attendee()`)
- Create `attendees` table, with the following fields
    - `translate_event_attendees_id` (primary key)
    - `event_id`: `int(10)`
    - `user_id`: `int(10)`
    - `is_host`: `tinyint(1)` (bool)
