### PR TITLE
Small cleanup of handling ajax submit

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -218,7 +218,11 @@ class Translation_Events {
 			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
 		}
 
-		$action = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
+		if ( ! isset( $_POST['form_name'] ) ) {
+			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
+		}
+
+		$action = sanitize_text_field( wp_unslash( $_POST['form_name'] ) );
 		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
@@ -281,10 +285,6 @@ class Translation_Events {
 			$event_status = sanitize_text_field( wp_unslash( $_POST['event_form_action'] ) );
 		}
 
-		if ( ! isset( $_POST['form_name'] ) ) {
-			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
-		}
-
 		if ( 'create_event' === $action ) {
 			$event_id         = wp_insert_post(
 				array(
@@ -334,7 +334,7 @@ class Translation_Events {
 		if ( ! $event_id ) {
 			wp_send_json_error( esc_html__( 'Event could not be created or updated.', 'gp-translation-events' ), 422 );
 		}
-		if ( 'delete_event' !== $_POST['form_name'] ) {
+		if ( 'delete_event' !== $action ) {
 			try {
 				update_post_meta( $event_id, '_event_start', $this->convert_to_utc( $event_start, $event_timezone ) );
 				update_post_meta( $event_id, '_event_end', $this->convert_to_utc( $event_end, $event_timezone ) );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -297,7 +297,6 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
 		}
 		if ( 'edit_event' === $action ) {
-			$event = get_post( $event_id );
 			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
@@ -312,7 +311,6 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
 		}
 		if ( 'delete_event' === $action ) {
-			$event = get_post( $event_id );
 			if ( ! $event || self::CPT !== $event->post_type ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -264,17 +264,19 @@ class Translation_Events {
 			}
 		}
 
+		$title = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
+
 		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
 		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
-		$title         = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
+		if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
+			wp_send_json_error( esc_html__( 'Invalid slug.', 'gp-translation-events' ), 422 );
+		}
+
 		// This will be sanitized by santitize_post which is called in wp_insert_post.
 		$description    = isset( $_POST['event_description'] ) ? force_balance_tags( wp_unslash( $_POST['event_description'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$event_start    = isset( $_POST['event_start'] ) ? sanitize_text_field( wp_unslash( $_POST['event_start'] ) ) : '';
 		$event_end      = isset( $_POST['event_end'] ) ? sanitize_text_field( wp_unslash( $_POST['event_end'] ) ) : '';
 		$event_timezone = isset( $_POST['event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['event_timezone'] ) ) : '';
-		if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
-			wp_send_json_error( esc_html__( 'Invalid slug.', 'gp-translation-events' ), 422 );
-		}
 
 		$is_valid_event_date = false;
 		try {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -247,23 +247,20 @@ class Translation_Events {
 		}
 		if ( 'edit_event' === $action ) {
 			$event = get_post( $event_id );
+			if ( ! $event || self::CPT !== $event->post_type ) {
+				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
+			}
 			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
-			}
-			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
 		}
 		if ( 'delete_event' === $action ) {
 			$event = get_post( $event_id );
-			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
-			}
 			if ( ! $event || self::CPT !== $event->post_type ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
-			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( 'You do not have permission to delete this event' );
+			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
+				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
 			}
 		}
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -250,11 +250,20 @@ class Translation_Events {
 			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
 			}
+			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
+				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
+			}
 		}
 		if ( 'delete_event' === $action ) {
 			$event = get_post( $event_id );
 			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
 				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
+			}
+			if ( ! $event || self::CPT !== $event->post_type ) {
+				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
+			}
+			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
+				wp_send_json_error( 'You do not have permission to delete this event' );
 			}
 		}
 
@@ -297,9 +306,6 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
 		}
 		if ( 'edit_event' === $action ) {
-			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
-			}
 			wp_update_post(
 				array(
 					'ID'           => $event_id,
@@ -311,12 +317,6 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
 		}
 		if ( 'delete_event' === $action ) {
-			if ( ! $event || self::CPT !== $event->post_type ) {
-				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
-			}
-			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( 'You do not have permission to delete this event' );
-			}
 			$stats_calculator = new Stats_Calculator();
 			try {
 				$event_stats = $stats_calculator->for_event( $event );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -205,16 +205,19 @@ class Translation_Events {
 		if ( ! is_user_logged_in() ) {
 			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
 		}
-		$action           = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
+
+		$action = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
+		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
+			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
+		}
+
 		$event_id         = null;
 		$event            = null;
 		$response_message = '';
 		$form_actions     = array( 'draft', 'publish', 'delete' );
 		$is_nonce_valid   = false;
 		$nonce_name       = '_event_nonce';
-		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
-			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
-		}
+
 		/**
 		 * Filter the ability to create, edit, or delete an event.
 		 *

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -206,6 +206,18 @@ class Translation_Events {
 			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
 		}
 
+		$nonce_name     = '_event_nonce';
+		$is_nonce_valid = false;
+		if ( isset( $_POST[ $nonce_name ] ) ) {
+			$nonce_value = sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) );
+			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
+				$is_nonce_valid = true;
+			}
+		}
+		if ( ! $is_nonce_valid ) {
+			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
+		}
+
 		$action = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
 		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
@@ -219,8 +231,6 @@ class Translation_Events {
 		$event            = null;
 		$response_message = '';
 		$form_actions     = array( 'draft', 'publish', 'delete' );
-		$is_nonce_valid   = false;
-		$nonce_name       = '_event_nonce';
 
 		/**
 		 * Filter the ability to create, edit, or delete an event.
@@ -243,15 +253,7 @@ class Translation_Events {
 				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
 			}
 		}
-		if ( isset( $_POST[ $nonce_name ] ) ) {
-			$nonce_value = sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) );
-			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
-				$is_nonce_valid = true;
-			}
-		}
-		if ( ! $is_nonce_valid ) {
-			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
-		}
+
 		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
 		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
 		$title         = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -211,7 +211,11 @@ class Translation_Events {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
 
-		$event_id         = null;
+		if ( 'create_event' !== $action && ! isset( $_POST['event_id'] ) ) {
+			wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 404 );
+		}
+
+		$event_id         = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
 		$event            = null;
 		$response_message = '';
 		$form_actions     = array( 'draft', 'publish', 'delete' );
@@ -228,15 +232,13 @@ class Translation_Events {
 			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
 		}
 		if ( 'edit_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
-			$event    = get_post( $event_id );
+			$event = get_post( $event_id );
 			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
 			}
 		}
 		if ( 'delete_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
-			$event    = get_post( $event_id );
+			$event = get_post( $event_id );
 			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
 				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
 			}
@@ -293,11 +295,7 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
 		}
 		if ( 'edit_event' === $action ) {
-			if ( ! isset( $_POST['event_id'] ) ) {
-				wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 422 );
-			}
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
-			$event    = get_post( $event_id );
+			$event = get_post( $event_id );
 			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
@@ -312,8 +310,7 @@ class Translation_Events {
 			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
 		}
 		if ( 'delete_event' === $action ) {
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
-			$event    = get_post( $event_id );
+			$event = get_post( $event_id );
 			if ( ! $event || self::CPT !== $event->post_type ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
@@ -365,9 +362,6 @@ class Translation_Events {
 			)
 		);
 	}
-
-
-
 
 	/**
 	 * Convert a date time in a time zone to UTC.


### PR DESCRIPTION
This PR cleans up the `submit_event_ajax()` function:

1. Move validation to the top of the function
2. Remove duplicated validation checks
3. Only parse the event id from the `$_POST` once
4. Only call `get_post()` once

This is in preparation for using the event repository to insert, update and delete an event.