### PR TITLE
Block the creation, editing or deletion of an event with a past end date

### DIFF
--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -47,21 +47,21 @@ class Edit_Route extends Route {
 			$event_end     = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone );
 			$now           = self::convertToTimezone( 'now', $event_timezone );
 			$event_end_utc = new DateTime( get_post_meta( $event_id, '_event_end', true ), new DateTimeZone( 'UTC' ) );
-			$now           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$now_utc       = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		} catch ( Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $e );
 			$this->die_with_error( esc_html__( 'Something is wrong.', 'gp-translation-events' ) );
 		}
 
-		if ( $now > $event_end_utc ) {
+		if ( $now_utc > $event_end_utc ) {
 			$this->die_with_error( esc_html__( 'You cannot edit a finished event.', 'gp-translation-events' ), 403 );
 		}
 
 		$stats_calculator = new Stats_Calculator();
 		if ( ! $stats_calculator->event_has_stats( $event ) ) {
 			$current_user = wp_get_current_user();
-			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ( $now < $event_end_utc ) ) {
+			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ( $now_utc < $event_end_utc ) ) {
 				$create_delete_button = true;
 			}
 		}

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -55,7 +55,7 @@ class Edit_Route extends Route {
 		}
 
 		if ( $now_utc > $event_end_utc ) {
-			$this->die_with_error( esc_html__( 'You cannot edit a finished event.', 'gp-translation-events' ), 403 );
+			$this->die_with_error( esc_html__( 'You cannot edit a past event.', 'gp-translation-events' ), 403 );
 		}
 
 		$stats_calculator = new Stats_Calculator();

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -54,6 +54,10 @@ class Edit_Route extends Route {
 			$this->die_with_error( esc_html__( 'Something is wrong.', 'gp-translation-events' ) );
 		}
 
+		if ( $now > $event_end_utc ) {
+			$this->die_with_error( esc_html__( 'You cannot edit a finished event.', 'gp-translation-events' ), 403 );
+		}
+
 		$stats_calculator = new Stats_Calculator();
 		if ( ! $stats_calculator->event_has_stats( $event ) ) {
 			$current_user = wp_get_current_user();

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -3,6 +3,7 @@
 namespace Wporg\TranslationEvents\Routes\Event;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use Wporg\TranslationEvents\Routes\Route;
@@ -41,21 +42,24 @@ class Edit_Route extends Route {
 		$create_delete_button          = false;
 		$visibility_delete_button      = 'inline-flex';
 
-		$stats_calculator = new Stats_Calculator();
-		if ( ! $stats_calculator->event_has_stats( $event ) ) {
-			$current_user = wp_get_current_user();
-			if ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) {
-				$create_delete_button = true;
-			}
-		}
-
 		try {
-			$event_start = self::convertToTimezone( get_post_meta( $event_id, '_event_start', true ), $event_timezone );
-			$event_end   = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone );
+			$event_start   = self::convertToTimezone( get_post_meta( $event_id, '_event_start', true ), $event_timezone );
+			$event_end     = self::convertToTimezone( get_post_meta( $event_id, '_event_end', true ), $event_timezone );
+			$now           = self::convertToTimezone( 'now', $event_timezone );
+			$event_end_utc = new DateTime( get_post_meta( $event_id, '_event_end', true ), new DateTimeZone( 'UTC' ) );
+			$now           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		} catch ( Exception $e ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $e );
 			$this->die_with_error( esc_html__( 'Something is wrong.', 'gp-translation-events' ) );
+		}
+
+		$stats_calculator = new Stats_Calculator();
+		if ( ! $stats_calculator->event_has_stats( $event ) ) {
+			$current_user = wp_get_current_user();
+			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ( $now < $event_end_utc ) ) {
+				$create_delete_button = true;
+			}
 		}
 
 		$this->tmpl( 'events-form', get_defined_vars() );

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -12,8 +12,6 @@ namespace Wporg\TranslationEvents;
 /** @var string $event_description */
 /** @var string $event_start */
 /** @var string $event_end */
-/** @var string $event_end_utc */
-/** @var string $now */
 /** @var string $event_timezone */
 /** @var string $event_url */
 /** @var string $css_show_url */
@@ -70,14 +68,12 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div class="submit-btn-group">
 		<label for="event-status"></label>
 	<?php if ( $event_id ) : ?>
-		<?php if ( isset( $event_status ) && 'draft' === $event_status && isset( $now ) && isset( $event_end_utc ) && ( $now < $event_end_utc ) ) : ?>
+		<?php if ( isset( $event_status ) && 'draft' === $event_status ) : ?>
 			<button class="button is-primary save-draft submit-event" type="submit" data-event-status="draft">Update Draft</button>
 		<?php endif; ?>
-		<?php if ( isset( $now ) && isset( $event_end_utc ) && ( $now < $event_end_utc ) ) : ?>
-			<button class="button is-primary submit-event" type="submit"  data-event-status="publish">
-				<?php echo ( isset( $event_status ) && 'publish' === $event_status ) ? esc_html( 'Update Event' ) : esc_html( 'Publish Event' ); ?>
-			</button>
-		<?php endif; ?>
+	<button class="button is-primary submit-event" type="submit"  data-event-status="publish">
+		<?php echo ( isset( $event_status ) && 'publish' === $event_status ) ? esc_html( 'Update Event' ) : esc_html( 'Publish Event' ); ?>
+	</button>
 	<?php else : ?>
 		<button class="button is-primary save-draft submit-event" type="submit" data-event-status="draft">Save Draft</button>
 		<button class="button is-primary submit-event" type="submit"  data-event-status="publish">Publish Event</button>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -12,6 +12,8 @@ namespace Wporg\TranslationEvents;
 /** @var string $event_description */
 /** @var string $event_start */
 /** @var string $event_end */
+/** @var string $event_end_utc */
+/** @var string $now */
 /** @var string $event_timezone */
 /** @var string $event_url */
 /** @var string $css_show_url */
@@ -68,12 +70,14 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div class="submit-btn-group">
 		<label for="event-status"></label>
 	<?php if ( $event_id ) : ?>
-		<?php if ( isset( $event_status ) && 'draft' === $event_status ) : ?>
+		<?php if ( isset( $event_status ) && 'draft' === $event_status && isset( $now ) && isset( $event_end_utc ) && ( $now < $event_end_utc ) ) : ?>
 			<button class="button is-primary save-draft submit-event" type="submit" data-event-status="draft">Update Draft</button>
 		<?php endif; ?>
-	<button class="button is-primary submit-event" type="submit"  data-event-status="publish">
-		<?php echo ( isset( $event_status ) && 'publish' === $event_status ) ? esc_html( 'Update Event' ) : esc_html( 'Publish Event' ); ?>
-	</button>
+		<?php if ( isset( $now ) && isset( $event_end_utc ) && ( $now < $event_end_utc ) ) : ?>
+			<button class="button is-primary submit-event" type="submit"  data-event-status="publish">
+				<?php echo ( isset( $event_status ) && 'publish' === $event_status ) ? esc_html( 'Update Event' ) : esc_html( 'Publish Event' ); ?>
+			</button>
+		<?php endif; ?>
 	<?php else : ?>
 		<button class="button is-primary save-draft submit-event" type="submit" data-event-status="draft">Save Draft</button>
 		<button class="button is-primary submit-event" type="submit"  data-event-status="publish">Publish Event</button>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -35,14 +35,13 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_status                  = get_post_status( $event_id );
 			$event_start                   = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
 			$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
-			$envent_end_utc                = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
+			$event_end_utc                 = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
 			$now                           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
-			$now > $envent_end_utc ? $past_event = true : $past_event = false;
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<?php if ( ! $past_event ) : ?>
+				<?php if ( $event_end_utc > $now ) : ?>
 					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -6,6 +6,7 @@
 namespace Wporg\TranslationEvents;
 
 use DateTime;
+use DateTimeZone;
 use WP_Query;
 
 /** @var WP_Query $events_i_created_query */
@@ -34,10 +35,16 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_status                  = get_post_status( $event_id );
 			$event_start                   = ( new DateTime( get_post_meta( get_the_ID(), '_event_start', true ) ) )->format( 'M j, Y' );
 			$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
+			$envent_end_utc                = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
+			$now                           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
+			$now > $envent_end_utc ? $past_event = true : $past_event = false;
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
+				<?php if ( ! $past_event ) : ?>
+					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
+				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>
 					<span class="event-label-<?php echo esc_attr( $event_status ); ?>"><?php echo esc_html( $event_status ); ?></span>
 				<?php endif; ?>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -190,9 +190,10 @@ class Translation_Events {
 		if ( ! $event_start || ! $event_end ) {
 			return false;
 		}
-		$event_start = new DateTime( $event_start );
-		$event_end   = new DateTime( $event_end );
-		if ( $event_start < $event_end ) {
+		$event_start = new DateTime( $event_start, new DateTimeZone( 'UTC' ) );
+		$event_end   = new DateTime( $event_end, new DateTimeZone( 'UTC' ) );
+		$now         = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		if ( ( $event_start < $event_end ) && ( $event_end > $now ) ) {
 			return true;
 		}
 		return false;
@@ -266,7 +267,7 @@ class Translation_Events {
 			// Deliberately ignored, handled below.
 		}
 		if ( ! $is_valid_event_date ) {
-			wp_send_json_error( esc_html__( 'Invalid event dates.', 'gp-translation-events' ), 422 );
+			wp_send_json_error( esc_html__( 'Invalid event dates or the event end date is a past value.', 'gp-translation-events' ), 422 );
 		}
 
 		$event_status = '';


### PR DESCRIPTION
This PR blocks the creation, editing or deletion of an event with a past end date.

Only shows the "Edit" button in the current of future events.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/ae15e4fe-9dcf-4f5c-aa7e-7aa059884faf)

The user can't create a past event.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/b98b73a6-308c-415a-8c1b-8a0f97d40d02)

If the user tries to edit a finished event, using the id, she will get an error:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/533d1716-5ad7-4c50-bacc-27fed54ab168)


Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/72