### PR TITLE
Disable edit event with stats

### DIFF
--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
+use DateTime;
+use DateTimeZone;
 use Exception;
 use GP;
 use Wporg\TranslationEvents\Attendee_Repository;
@@ -53,6 +55,13 @@ class Details_Route extends Route {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $e );
 			$this->die_with_error( esc_html__( 'Failed to calculate event stats', 'gp-translation-events' ) );
+		}
+
+		$is_editable_event = true;
+		$event_end_utc     = new DateTime( get_post_meta( $event_id, '_event_end', true ), new DateTimeZone( 'UTC' ) );
+		$now_utc           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		if ( $now_utc > $event_end_utc || $stats_calculator->event_has_stats( $event ) ) {
+			$is_editable_event = false;
 		}
 
 		$this->tmpl( 'event', get_defined_vars() );

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -59,6 +59,11 @@ class Edit_Route extends Route {
 		}
 
 		$stats_calculator = new Stats_Calculator();
+
+		if ( $stats_calculator->event_has_stats( $event ) ) {
+			$this->die_with_error( esc_html__( 'You cannot edit an event with translations.', 'gp-translation-events' ), 403 );
+		}
+
 		if ( ! $stats_calculator->event_has_stats( $event ) ) {
 			$current_user = wp_get_current_user();
 			if ( ( $current_user->ID === $event->post_author || current_user_can( 'manage_options' ) ) && ( $now < $event_end_utc ) ) {

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -7,7 +7,7 @@ namespace Wporg\TranslationEvents;
 
 /** @var string $event_page_title */
 /** @var string $event_form_name */
-/** @var int $event_id */
+/** @var int    $event_id */
 /** @var string $event_title */
 /** @var string $event_description */
 /** @var string $event_start */

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -33,7 +33,7 @@ use GP;
 	<?php if ( isset( $event_id ) && ! isset( $event_form_name ) ) : ?>
 	<p class="event-sub-head">
 			<span class="event-host">Host: <a href="<?php echo esc_attr( get_author_posts_url( $event->post_author ) ); ?>"><?php echo esc_html( get_the_author_meta( 'display_name', $event->post_author ) ); ?></a></span>
-			<?php if ( current_user_can( 'edit_post', $event_id ) && ( true === $is_editable_event ) ) : ?>
+			<?php if ( current_user_can( 'edit_post', $event_id ) && ( $is_editable_event ) ) : ?>
 				<a class="event-page-edit-link" href="<?php echo esc_url( gp_url( 'events/edit/' . $event_id ) ); ?>"><span class="dashicons dashicons-edit"></span>Edit event</a>
 			<?php endif ?>
 		</p>

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -1,6 +1,9 @@
 <?php
 namespace Wporg\TranslationEvents;
 
+/** @var string $event_page_title */
+/** @var bool   $is_editable_event */
+
 use GP;
 ?>
 
@@ -30,7 +33,7 @@ use GP;
 	<?php if ( isset( $event_id ) && ! isset( $event_form_name ) ) : ?>
 	<p class="event-sub-head">
 			<span class="event-host">Host: <a href="<?php echo esc_attr( get_author_posts_url( $event->post_author ) ); ?>"><?php echo esc_html( get_the_author_meta( 'display_name', $event->post_author ) ); ?></a></span>
-			<?php if ( current_user_can( 'edit_post', $event_id ) ) : ?>
+			<?php if ( current_user_can( 'edit_post', $event_id ) && ( true === $is_editable_event ) ) : ?>
 				<a class="event-page-edit-link" href="<?php echo esc_url( gp_url( 'events/edit/' . $event_id ) ); ?>"><span class="dashicons dashicons-edit"></span>Edit event</a>
 			<?php endif ?>
 		</p>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -37,12 +37,14 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_end                     = ( new DateTime( get_post_meta( get_the_ID(), '_event_end', true ) ) )->format( 'M j, Y' );
 			$envent_end_utc                = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
 			$now                           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$stats_calculator              = new Stats_Calculator();
+			$has_translations              = $stats_calculator->event_has_stats( get_post() );
 
 			$now > $envent_end_utc ? $past_event = true : $past_event = false;
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<?php if ( ! $past_event ) : ?>
+				<?php if ( ! $past_event && ! $has_translations ) : ?>
 					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -38,12 +38,12 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 			$event_end_utc                 = new DateTime( get_post_meta( get_the_ID(), '_event_end', true ), new DateTimeZone( 'UTC' ) );
 			$now                           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 			$stats_calculator              = new Stats_Calculator();
-			$has_translations              = $stats_calculator->event_has_stats( get_post() );
+			$has_stats                     = $stats_calculator->event_has_stats( get_post() );
 
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event_status ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php the_title(); ?></a>
-				<?php if ( $event_end_utc > $now && ! $has_translations ) : ?>
+				<?php if ( $event_end_utc > $now && ! $has_stats ) : ?>
 					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event_status ) : ?>


### PR DESCRIPTION
This PR depends on https://github.com/WordPress/wporg-gp-translation-events/pull/181, so we need to merge it before.

This PR disable the edit action in the `Edit_Route` if the event has translations and disable the `Edit` buttons in the:

**Show view for an event**

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/53cb7f15-c88f-4018-ac64-bc133f6a0755)

**"My events" template**

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f153adc1-dd3f-43a5-9e33-0acd92bef992)


Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/115