### PR TITLE
Add form handler

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -38,6 +38,10 @@
 		 * @param isDraft	  Whether the current event status is a draft or not
 		 */
 		function handleSubmit( eventStatus, isDraft ) {
+			if ( '' === $( '#event-title' ).val() ) {
+				$gp.notices.error( 'Event title must be set.' );
+				return;
+			}
 			if ( '' === $( '#event-start' ).val() ) {
 				$gp.notices.error( 'Event start date and time must be set.' );
 				return;

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -38,6 +38,11 @@
 		 * @param isDraft	  Whether the current event status is a draft or not
 		 */
 		function handleSubmit( eventStatus, isDraft ) {
+			const $form = $( '.translation-event-form' );
+			if ( ! $form[0].reportValidity() ) {
+				return;
+			}
+
 			if ( '' === $( '#event-title' ).val() ) {
 				$gp.notices.error( 'Event title must be set.' );
 				return;
@@ -61,7 +66,6 @@
 				}
 			}
 			$( '#event-form-action' ).val( eventStatus );
-			const $form        = $( '.translation-event-form' );
 			const $is_creation = $( '#form-name' ).val() === 'create_event';
 
 			$.ajax(

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -15,7 +15,7 @@ class Event_Form_Handler {
 		if ( ! is_user_logged_in() ) {
 			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
 		}
-		$action           = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
+		$action           = isset( $form_data['form_name'] ) ? sanitize_text_field( wp_unslash( $form_data['form_name'] ) ) : '';
 		$event_id         = null;
 		$event            = null;
 		$response_message = '';
@@ -35,21 +35,21 @@ class Event_Form_Handler {
 			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
 		}
 		if ( 'edit_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
+			$event_id = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : '';
 			$event    = get_post( $event_id );
 			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
 			}
 		}
 		if ( 'delete_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
+			$event_id = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : '';
 			$event    = get_post( $event_id );
 			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
 				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
 			}
 		}
-		if ( isset( $_POST[ $nonce_name ] ) ) {
-			$nonce_value = sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) );
+		if ( isset( $form_data[ $nonce_name ] ) ) {
+			$nonce_value = sanitize_text_field( wp_unslash( $form_data[ $nonce_name ] ) );
 			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
 				$is_nonce_valid = true;
 			}
@@ -59,12 +59,12 @@ class Event_Form_Handler {
 		}
 		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
 		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
-		$title         = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
+		$title         = isset( $form_data['event_title'] ) ? sanitize_text_field( wp_unslash( $form_data['event_title'] ) ) : '';
 		// This will be sanitized by santitize_post which is called in wp_insert_post.
-		$description    = isset( $_POST['event_description'] ) ? force_balance_tags( wp_unslash( $_POST['event_description'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$event_start    = isset( $_POST['event_start'] ) ? sanitize_text_field( wp_unslash( $_POST['event_start'] ) ) : '';
-		$event_end      = isset( $_POST['event_end'] ) ? sanitize_text_field( wp_unslash( $_POST['event_end'] ) ) : '';
-		$event_timezone = isset( $_POST['event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['event_timezone'] ) ) : '';
+		$description    = isset( $form_data['event_description'] ) ? force_balance_tags( wp_unslash( $form_data['event_description'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$event_start    = isset( $form_data['event_start'] ) ? sanitize_text_field( wp_unslash( $form_data['event_start'] ) ) : '';
+		$event_end      = isset( $form_data['event_end'] ) ? sanitize_text_field( wp_unslash( $form_data['event_end'] ) ) : '';
+		$event_timezone = isset( $form_data['event_timezone'] ) ? sanitize_text_field( wp_unslash( $form_data['event_timezone'] ) ) : '';
 		if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
 			wp_send_json_error( esc_html__( 'Invalid slug.', 'gp-translation-events' ), 422 );
 		}
@@ -80,11 +80,11 @@ class Event_Form_Handler {
 		}
 
 		$event_status = '';
-		if ( isset( $_POST['event_form_action'] ) && in_array( $_POST['event_form_action'], $form_actions, true ) ) {
-			$event_status = sanitize_text_field( wp_unslash( $_POST['event_form_action'] ) );
+		if ( isset( $form_data['event_form_action'] ) && in_array( $form_data['event_form_action'], $form_actions, true ) ) {
+			$event_status = sanitize_text_field( wp_unslash( $form_data['event_form_action'] ) );
 		}
 
-		if ( ! isset( $_POST['form_name'] ) ) {
+		if ( ! isset( $form_data['form_name'] ) ) {
 			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
 		}
 
@@ -100,10 +100,10 @@ class Event_Form_Handler {
 			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
 		}
 		if ( 'edit_event' === $action ) {
-			if ( ! isset( $_POST['event_id'] ) ) {
+			if ( ! isset( $form_data['event_id'] ) ) {
 				wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 422 );
 			}
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
+			$event_id = sanitize_text_field( wp_unslash( $form_data['event_id'] ) );
 			$event    = get_post( $event_id );
 			if ( ! $event || Translation_Events::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
@@ -119,7 +119,7 @@ class Event_Form_Handler {
 			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
 		}
 		if ( 'delete_event' === $action ) {
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
+			$event_id = sanitize_text_field( wp_unslash( $form_data['event_id'] ) );
 			$event    = get_post( $event_id );
 			if ( ! $event || Translation_Events::CPT !== $event->post_type ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
@@ -142,7 +142,7 @@ class Event_Form_Handler {
 		if ( ! $event_id ) {
 			wp_send_json_error( esc_html__( 'Event could not be created or updated.', 'gp-translation-events' ), 422 );
 		}
-		if ( 'delete_event' !== $_POST['form_name'] ) {
+		if ( 'delete_event' !== $form_data['form_name'] ) {
 			try {
 				update_post_meta( $event_id, '_event_start', $this->convert_to_utc( $event_start, $event_timezone ) );
 				update_post_meta( $event_id, '_event_end', $this->convert_to_utc( $event_end, $event_timezone ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -84,10 +84,6 @@ class Event_Form_Handler {
 			$event_status = sanitize_text_field( wp_unslash( $form_data['event_form_action'] ) );
 		}
 
-		if ( ! isset( $form_data['form_name'] ) ) {
-			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
-		}
-
 		if ( 'create_event' === $action ) {
 			$event_id         = wp_insert_post(
 				array(

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -19,7 +19,6 @@ class Event_Form_Handler {
 		$event_id         = null;
 		$event            = null;
 		$response_message = '';
-		$form_actions     = array( 'draft', 'publish', 'delete' );
 		$is_nonce_valid   = false;
 		$nonce_name       = '_event_nonce';
 		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
@@ -57,6 +56,7 @@ class Event_Form_Handler {
 		if ( ! $is_nonce_valid ) {
 			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
 		}
+
 		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
 		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
 		$title         = isset( $form_data['event_title'] ) ? sanitize_text_field( wp_unslash( $form_data['event_title'] ) ) : '';
@@ -80,7 +80,7 @@ class Event_Form_Handler {
 		}
 
 		$event_status = '';
-		if ( isset( $form_data['event_form_action'] ) && in_array( $form_data['event_form_action'], $form_actions, true ) ) {
+		if ( isset( $form_data['event_form_action'] ) && in_array( $form_data['event_form_action'], array( 'draft', 'publish', 'delete' ), true ) ) {
 			$event_status = sanitize_text_field( wp_unslash( $form_data['event_form_action'] ) );
 		}
 

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Wporg\TranslationEvents\Event;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use GP;
+use Wporg\TranslationEvents\Active_Events_Cache;
+use Wporg\TranslationEvents\Stats_Calculator;
+use Wporg\TranslationEvents\Translation_Events;
+
+class Event_Form_Handler {
+	public function handle( array $form_data ): void {
+		if ( ! is_user_logged_in() ) {
+			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
+		}
+		$action           = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
+		$event_id         = null;
+		$event            = null;
+		$response_message = '';
+		$form_actions     = array( 'draft', 'publish', 'delete' );
+		$is_nonce_valid   = false;
+		$nonce_name       = '_event_nonce';
+		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
+			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
+		}
+		/**
+		 * Filter the ability to create, edit, or delete an event.
+		 *
+		 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
+		 */
+		$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
+		if ( 'create_event' === $action && ( ! $can_crud_event ) ) {
+			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
+		}
+		if ( 'edit_event' === $action ) {
+			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
+			$event    = get_post( $event_id );
+			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
+				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
+			}
+		}
+		if ( 'delete_event' === $action ) {
+			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
+			$event    = get_post( $event_id );
+			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
+				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
+			}
+		}
+		if ( isset( $_POST[ $nonce_name ] ) ) {
+			$nonce_value = sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) );
+			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
+				$is_nonce_valid = true;
+			}
+		}
+		if ( ! $is_nonce_valid ) {
+			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
+		}
+		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
+		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
+		$title         = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
+		// This will be sanitized by santitize_post which is called in wp_insert_post.
+		$description    = isset( $_POST['event_description'] ) ? force_balance_tags( wp_unslash( $_POST['event_description'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$event_start    = isset( $_POST['event_start'] ) ? sanitize_text_field( wp_unslash( $_POST['event_start'] ) ) : '';
+		$event_end      = isset( $_POST['event_end'] ) ? sanitize_text_field( wp_unslash( $_POST['event_end'] ) ) : '';
+		$event_timezone = isset( $_POST['event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['event_timezone'] ) ) : '';
+		if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
+			wp_send_json_error( esc_html__( 'Invalid slug.', 'gp-translation-events' ), 422 );
+		}
+
+		$is_valid_event_date = false;
+		try {
+			$is_valid_event_date = $this->validate_event_dates( $event_start, $event_end, $event_timezone );
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Deliberately ignored, handled below.
+		}
+		if ( ! $is_valid_event_date ) {
+			wp_send_json_error( esc_html__( 'Invalid event dates or the event end date is a past value.', 'gp-translation-events' ), 422 );
+		}
+
+		$event_status = '';
+		if ( isset( $_POST['event_form_action'] ) && in_array( $_POST['event_form_action'], $form_actions, true ) ) {
+			$event_status = sanitize_text_field( wp_unslash( $_POST['event_form_action'] ) );
+		}
+
+		if ( ! isset( $_POST['form_name'] ) ) {
+			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
+		}
+
+		if ( 'create_event' === $action ) {
+			$event_id         = wp_insert_post(
+				array(
+					'post_type'    => Translation_Events::CPT,
+					'post_title'   => $title,
+					'post_content' => $description,
+					'post_status'  => $event_status,
+				)
+			);
+			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
+		}
+		if ( 'edit_event' === $action ) {
+			if ( ! isset( $_POST['event_id'] ) ) {
+				wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 422 );
+			}
+			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
+			$event    = get_post( $event_id );
+			if ( ! $event || Translation_Events::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
+				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
+			}
+			wp_update_post(
+				array(
+					'ID'           => $event_id,
+					'post_title'   => $title,
+					'post_content' => $description,
+					'post_status'  => $event_status,
+				)
+			);
+			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
+		}
+		if ( 'delete_event' === $action ) {
+			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
+			$event    = get_post( $event_id );
+			if ( ! $event || Translation_Events::CPT !== $event->post_type ) {
+				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
+			}
+			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
+				wp_send_json_error( 'You do not have permission to delete this event' );
+			}
+			$stats_calculator = new Stats_Calculator();
+			try {
+				$event_stats = $stats_calculator->for_event( $event );
+			} catch ( Exception $e ) {
+				wp_send_json_error( esc_html__( 'Failed to calculate event stats.', 'gp-translation-events' ), 500 );
+			}
+			if ( ! empty( $event_stats->rows() ) ) {
+				wp_send_json_error( esc_html__( 'Event has translations and cannot be deleted.', 'gp-translation-events' ), 422 );
+			}
+			wp_trash_post( $event_id );
+			$response_message = esc_html__( 'Event deleted successfully!', 'gp-translation-events' );
+		}
+		if ( ! $event_id ) {
+			wp_send_json_error( esc_html__( 'Event could not be created or updated.', 'gp-translation-events' ), 422 );
+		}
+		if ( 'delete_event' !== $_POST['form_name'] ) {
+			try {
+				update_post_meta( $event_id, '_event_start', $this->convert_to_utc( $event_start, $event_timezone ) );
+				update_post_meta( $event_id, '_event_end', $this->convert_to_utc( $event_end, $event_timezone ) );
+			} catch ( Exception $e ) {
+				wp_send_json_error( esc_html__( 'Invalid start or end', 'gp-translation-events' ), 422 );
+			}
+
+			update_post_meta( $event_id, '_event_timezone', $event_timezone );
+		}
+		try {
+			Active_Events_Cache::invalidate();
+		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( $e );
+		}
+
+		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
+		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
+		wp_send_json_success(
+			array(
+				'message'        => $response_message,
+				'eventId'        => $event_id,
+				'eventUrl'       => str_replace( '%pagename%', $post_name, $permalink ),
+				'eventStatus'    => $event_status,
+				'eventEditUrl'   => esc_url( gp_url( '/events/edit/' . $event_id ) ),
+				'eventDeleteUrl' => esc_url( gp_url( '/events/my-events/' ) ),
+			)
+		);
+	}
+
+	/**
+	 * Convert a date time in a time zone to UTC.
+	 *
+	 * @param string $date_time The date time in the time zone.
+	 * @param string $time_zone The time zone.
+	 * @return string The date time in UTC.
+	 * @throws Exception When dates are invalid.
+	 */
+	private function convert_to_utc( string $date_time, string $time_zone ): string {
+		$date_time = new DateTime( $date_time, new DateTimeZone( $time_zone ) );
+		$date_time->setTimezone( new DateTimeZone( 'UTC' ) );
+		return $date_time->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Validate the event dates.
+	 *
+	 * @param string $event_start The event start date.
+	 * @param string $event_end The event end date.
+	 * @param string $event_timezone The event timezone.
+	 * @return bool Whether the event dates are valid.
+	 * @throws Exception When dates are invalid.
+	 */
+	private function validate_event_dates( string $event_start, string $event_end, string $event_timezone ): bool {
+		if ( ! $event_start || ! $event_end ) {
+			return false;
+		}
+		$event_start = new DateTime( $event_start, new DateTimeZone( $event_timezone ) );
+		$event_end   = new DateTime( $event_end, new DateTimeZone( $event_timezone ) );
+		$now         = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		if ( ( $event_start < $event_end ) && ( $event_end > $now ) ) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -128,7 +128,7 @@ class Event {
 	}
 
 	/**
-	 * @throws InvalidStartOrEnd
+	 * @throws InvalidStart|InvalidEnd
 	 */
 	public function set_times( DateTimeImmutable $start, DateTimeImmutable $end ): void {
 		$this->validate_times( $start, $end );
@@ -162,32 +162,6 @@ class Event {
 
 	public function set_description( string $description ): void {
 		$this->description = $description;
-	}
-
-	/**
-	 * Generate text for the end date.
-	 *
-	 * @param string $event_end The end date.
-	 *
-	 * @return string The end date text.
-	 */
-	public static function get_end_date_text( string $event_end ): string {
-		$end_date_time     = new DateTimeImmutable( $event_end );
-		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
-		$interval       = $end_date_time->diff( $current_date_time );
-		$hours_left     = ( $interval->d * 24 ) + $interval->h;
-		$hours_in_a_day = 24;
-
-		if ( 0 === $hours_left ) {
-			/* translators: %s: Number of minutes left. */
-			return sprintf( _n( 'ends in %s minute', 'ends in %s minutes', $interval->i ), $interval->i );
-		} elseif ( $hours_left <= $hours_in_a_day ) {
-			/* translators: %s: Number of hours left. */
-			return sprintf( _n( 'ends in %s hour', 'ends in %s hours', $hours_left ), $hours_left );
-		}
-
-		return sprintf( 'until %s', $end_date_time->format( 'M j, Y' ) );
 	}
 
 	/**

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -9,6 +9,12 @@ use Wporg\TranslationEvents\Event_End_Date;
 use Exception;
 use Throwable;
 
+class InvalidTimeZone extends Exception {
+	public function __construct( Throwable $previous = null ) {
+		parent::__construct( 'Event time zone is invalid', 0, $previous );
+	}
+}
+
 class InvalidStart extends Exception {
 	public function __construct( Throwable $previous = null ) {
 		parent::__construct( 'Event start is invalid', 0, $previous );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -24,6 +24,7 @@ use Exception;
 use GP;
 use WP_Post;
 use WP_Query;
+use Wporg\TranslationEvents\Event\Event_Form_Handler;
 
 class Translation_Events {
 	public const CPT = 'translation_event';
@@ -65,6 +66,7 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/event/event-repository-interface.php';
 		require_once __DIR__ . '/includes/event/event-repository.php';
 		require_once __DIR__ . '/includes/event/event-repository-cached.php';
+		require_once __DIR__ . '/includes/event/event-form-handler.php';
 		require_once __DIR__ . '/includes/active-events-cache.php';
 		require_once __DIR__ . '/includes/attendee-repository.php';
 		require_once __DIR__ . '/includes/stats-calculator.php';
@@ -180,207 +182,13 @@ class Translation_Events {
 	}
 
 	/**
-	 * Validate the event dates.
-	 *
-	 * @param string $event_start The event start date.
-	 * @param string $event_end The event end date.
-	 * @param string $event_timezone The event timezone.
-	 * @return bool Whether the event dates are valid.
-	 * @throws Exception When dates are invalid.
-	 */
-	public function validate_event_dates( string $event_start, string $event_end, string $event_timezone ): bool {
-		if ( ! $event_start || ! $event_end ) {
-			return false;
-		}
-		$event_start = new DateTime( $event_start, new DateTimeZone( $event_timezone ) );
-		$event_end   = new DateTime( $event_end, new DateTimeZone( $event_timezone ) );
-		$now         = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-		if ( ( $event_start < $event_end ) && ( $event_end > $now ) ) {
-			return true;
-		}
-		return false;
-	}
-
-	/**
 	 * Handle the event form submission for the creation, editing, and deletion of events. This function is called via AJAX.
 	 */
 	public function submit_event_ajax() {
-		if ( ! is_user_logged_in() ) {
-			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
-		}
-		$action           = isset( $_POST['form_name'] ) ? sanitize_text_field( wp_unslash( $_POST['form_name'] ) ) : '';
-		$event_id         = null;
-		$event            = null;
-		$response_message = '';
-		$form_actions     = array( 'draft', 'publish', 'delete' );
-		$is_nonce_valid   = false;
-		$nonce_name       = '_event_nonce';
-		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
-			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
-		}
-		/**
-		 * Filter the ability to create, edit, or delete an event.
-		 *
-		 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
-		 */
-		$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
-		if ( 'create_event' === $action && ( ! $can_crud_event ) ) {
-			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
-		}
-		if ( 'edit_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
-			$event    = get_post( $event_id );
-			if ( ! ( $can_crud_event || current_user_can( 'edit_post', $event_id ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
-			}
-		}
-		if ( 'delete_event' === $action ) {
-			$event_id = isset( $_POST['event_id'] ) ? sanitize_text_field( wp_unslash( $_POST['event_id'] ) ) : '';
-			$event    = get_post( $event_id );
-			if ( ! ( $can_crud_event || current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
-			}
-		}
-		if ( isset( $_POST[ $nonce_name ] ) ) {
-			$nonce_value = sanitize_text_field( wp_unslash( $_POST[ $nonce_name ] ) );
-			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
-				$is_nonce_valid = true;
-			}
-		}
-		if ( ! $is_nonce_valid ) {
-			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
-		}
-		// This is a list of slugs that are not allowed, as they conflict with the event URLs.
-		$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
-		$title         = isset( $_POST['event_title'] ) ? sanitize_text_field( wp_unslash( $_POST['event_title'] ) ) : '';
-		// This will be sanitized by santitize_post which is called in wp_insert_post.
-		$description    = isset( $_POST['event_description'] ) ? force_balance_tags( wp_unslash( $_POST['event_description'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$event_start    = isset( $_POST['event_start'] ) ? sanitize_text_field( wp_unslash( $_POST['event_start'] ) ) : '';
-		$event_end      = isset( $_POST['event_end'] ) ? sanitize_text_field( wp_unslash( $_POST['event_end'] ) ) : '';
-		$event_timezone = isset( $_POST['event_timezone'] ) ? sanitize_text_field( wp_unslash( $_POST['event_timezone'] ) ) : '';
-		if ( isset( $title ) && in_array( sanitize_title( $title ), $invalid_slugs, true ) ) {
-			wp_send_json_error( esc_html__( 'Invalid slug.', 'gp-translation-events' ), 422 );
-		}
-
-		$is_valid_event_date = false;
-		try {
-			$is_valid_event_date = $this->validate_event_dates( $event_start, $event_end, $event_timezone );
-		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Deliberately ignored, handled below.
-		}
-		if ( ! $is_valid_event_date ) {
-			wp_send_json_error( esc_html__( 'Invalid event dates or the event end date is a past value.', 'gp-translation-events' ), 422 );
-		}
-
-		$event_status = '';
-		if ( isset( $_POST['event_form_action'] ) && in_array( $_POST['event_form_action'], $form_actions, true ) ) {
-			$event_status = sanitize_text_field( wp_unslash( $_POST['event_form_action'] ) );
-		}
-
-		if ( ! isset( $_POST['form_name'] ) ) {
-			wp_send_json_error( esc_html__( 'Form name must be set.', 'gp-translation-events' ), 422 );
-		}
-
-		if ( 'create_event' === $action ) {
-			$event_id         = wp_insert_post(
-				array(
-					'post_type'    => self::CPT,
-					'post_title'   => $title,
-					'post_content' => $description,
-					'post_status'  => $event_status,
-				)
-			);
-			$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
-		}
-		if ( 'edit_event' === $action ) {
-			if ( ! isset( $_POST['event_id'] ) ) {
-				wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 422 );
-			}
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
-			$event    = get_post( $event_id );
-			if ( ! $event || self::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
-				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
-			}
-			wp_update_post(
-				array(
-					'ID'           => $event_id,
-					'post_title'   => $title,
-					'post_content' => $description,
-					'post_status'  => $event_status,
-				)
-			);
-			$response_message = esc_html__( 'Event updated successfully!', 'gp-translation-events' );
-		}
-		if ( 'delete_event' === $action ) {
-			$event_id = sanitize_text_field( wp_unslash( $_POST['event_id'] ) );
-			$event    = get_post( $event_id );
-			if ( ! $event || self::CPT !== $event->post_type ) {
-				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
-			}
-			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( 'You do not have permission to delete this event' );
-			}
-			$stats_calculator = new Stats_Calculator();
-			try {
-				$event_stats = $stats_calculator->for_event( $event );
-			} catch ( Exception $e ) {
-				wp_send_json_error( esc_html__( 'Failed to calculate event stats.', 'gp-translation-events' ), 500 );
-			}
-			if ( ! empty( $event_stats->rows() ) ) {
-				wp_send_json_error( esc_html__( 'Event has translations and cannot be deleted.', 'gp-translation-events' ), 422 );
-			}
-			wp_trash_post( $event_id );
-			$response_message = esc_html__( 'Event deleted successfully!', 'gp-translation-events' );
-		}
-		if ( ! $event_id ) {
-			wp_send_json_error( esc_html__( 'Event could not be created or updated.', 'gp-translation-events' ), 422 );
-		}
-		if ( 'delete_event' !== $_POST['form_name'] ) {
-			try {
-				update_post_meta( $event_id, '_event_start', $this->convert_to_utc( $event_start, $event_timezone ) );
-				update_post_meta( $event_id, '_event_end', $this->convert_to_utc( $event_end, $event_timezone ) );
-			} catch ( Exception $e ) {
-				wp_send_json_error( esc_html__( 'Invalid start or end', 'gp-translation-events' ), 422 );
-			}
-
-			update_post_meta( $event_id, '_event_timezone', $event_timezone );
-		}
-		try {
-			Active_Events_Cache::invalidate();
-		} catch ( Exception $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $e );
-		}
-
-		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
-		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-		wp_send_json_success(
-			array(
-				'message'        => $response_message,
-				'eventId'        => $event_id,
-				'eventUrl'       => str_replace( '%pagename%', $post_name, $permalink ),
-				'eventStatus'    => $event_status,
-				'eventEditUrl'   => esc_url( gp_url( '/events/edit/' . $event_id ) ),
-				'eventDeleteUrl' => esc_url( gp_url( '/events/my-events/' ) ),
-			)
-		);
-	}
-
-
-
-
-	/**
-	 * Convert a date time in a time zone to UTC.
-	 *
-	 * @param string $date_time The date time in the time zone.
-	 * @param string $time_zone The time zone.
-	 * @return string The date time in UTC.
-	 * @throws Exception When dates are invalid.
-	 */
-	public function convert_to_utc( string $date_time, string $time_zone ): string {
-		$date_time = new DateTime( $date_time, new DateTimeZone( $time_zone ) );
-		$date_time->setTimezone( new DateTimeZone( 'UTC' ) );
-		return $date_time->format( 'Y-m-d H:i:s' );
+		$form_handler = new Event_Form_Handler();
+		// Nonce verification is done by the form handler.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$form_handler->handle( $_POST );
 	}
 
 	public function register_translation_event_js() {


### PR DESCRIPTION
> Should be easy to review commit by commit

This PR extracts the form handling logic out of the main plugin file into a separate class.

The only changes in behaviour concern validation, we're now checking that the title is set, and that the time zone is valid. No other changes were made.

## Summary of changes

- Extract form handling code out of the main plugin and into an `Event_Form_Handler` class.
- Extract form parsing/validation out of the `handle()` function into a dedicated private function that takes the form data as argument and returns an instance of `Event`. The goal is to have a valid instance of `Event` as early as possible, so that validation happens early, and so that the `Event` instance can be used in the rest of the code. (If you're interested in some theory about this see [Parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)).
- Use the `Event` instance instead of declaring a variable for each event property.

## Screen captures

<img width="552" alt="Screenshot 2024-03-21 at 16 33 40" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/9e3423a0-de84-467d-aa7a-2f63c2a91c05">

## Test instructions
Test creating, editing and deleting events. The behaviour should be the same as before, except that you now see an error if the title is empty.