### PR TITLE
Add  text snippets

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -330,7 +330,14 @@ a.event-page-edit-link:hover {
 	border-bottom: var(--gp-color-btn-primary-bg) thin solid;
 	text-decoration: none;
 }
-
+ul.text-snippets {
+	list-style-type: none;
+	padding: 0;
+	margin-left: 140px;
+}
+ul.text-snippets li {
+	display: inline;
+}
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {
 

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -331,9 +331,8 @@ a.event-page-edit-link:hover {
 	text-decoration: none;
 }
 ul.text-snippets {
-	list-style-type: none;
 	padding: 0;
-	margin-left: 140px;
+	margin-left: 160px;
 }
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -335,9 +335,6 @@ ul.text-snippets {
 	padding: 0;
 	margin-left: 140px;
 }
-ul.text-snippets li {
-	display: inline;
-}
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {
 

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -33,7 +33,9 @@
 					'click',
 					function ( e ) {
 						e.preventDefault();
-						$( this ).closest( 'div' ).find( 'textarea' ).append( $( this ).data( 'snippet' ) );
+						var textArea = $( this ).closest( 'div' ).find( 'textarea' );
+						var textAreaContent = textArea.val();
+						textArea.val( textAreaContent + $( this ).data( 'snippet' ) );
 					}
 				);
 			}

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -33,7 +33,7 @@
 					'click',
 					function ( e ) {
 						e.preventDefault();
-						$( this ).closest( 'div').find( 'textarea' ).append( $( this ).data( 'snippet' ) );
+						$( this ).closest( 'div' ).find( 'textarea' ).append( $( this ).data( 'snippet' ) );
 					}
 				);
 			}

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -33,7 +33,7 @@
 					'click',
 					function ( e ) {
 						e.preventDefault();
-						var textArea = $( this ).closest( 'div' ).find( 'textarea' );
+						var textArea        = $( this ).closest( 'div' ).find( 'textarea' );
 						var textAreaContent = textArea.val();
 						textArea.val( textAreaContent + $( this ).data( 'snippet' ) );
 					}

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -28,6 +28,14 @@
 						handleDelete()
 					}
 				);
+
+				$( '.text-snippet' ).on(
+					'click',
+					function ( e ) {
+						e.preventDefault();
+						$( this ).closest( 'div').find( 'textarea' ).append( $( this ).data( 'snippet' ) );
+					}
+				);
 			}
 		);
 

--- a/autoload.php
+++ b/autoload.php
@@ -19,3 +19,4 @@ require_once __DIR__ . '/includes/event/event-repository-cached.php';
 require_once __DIR__ . '/includes/event/event-form-handler.php';
 require_once __DIR__ . '/includes/stats-calculator.php';
 require_once __DIR__ . '/includes/stats-listener.php';
+require_once __DIR__ . '/includes/event-text-snippet.php';

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -13,7 +13,7 @@ class Events_Text_Snippet {
 	public static function generate_snippet_links( $snippets ) : string {
 		$links = '<ul class="text-snippets">';
 		foreach ( $snippets as $snippet ) {
-			$links .= sprintf( '<li><a href="#" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
+			$links .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
 		}
 		$links .= '</ul>';
 		return $links;

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -7,33 +7,15 @@ class Events_Text_Snippet {
 	/**
 	 * Generate links for text snippets.
 	 *
-	 * @param array $snippets The array of snippets.
-	 * @return string The generated snippet links.
+	 * @return string The snippet links in a list.
 	 */
-	public static function generate_snippet_links( $snippets ): string {
-		$links = '<ul class="text-snippets">';
+	public static function get_snippet_links(): string {
+		$snippets           = apply_filters( 'wporg_translation_events_snippets', array() );
+		$snippets_link_list = '<ul class="text-snippets">';
 		foreach ( $snippets as $snippet ) {
-			$links .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
+			$snippets_link_list .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
 		}
-		$links .= '</ul>';
-		return $links;
-	}
-
-	/**
-	 * Get the default snippets.
-	 *
-	 * @return array The default snippets.
-	 */
-	public static function get_default_snippets(): array {
-		return array(
-			array(
-				'title'   => 'General Instructions',
-				'snippet' => 'These are general instructions for anyone intending to contribute',
-			),
-			array(
-				'title'   => 'New Contributor Guidance',
-				'snippet' => 'Here is the snippet for new contributor guidance',
-			),
-		);
+		$snippets_link_list .= '</ul>';
+		return $snippets_link_list;
 	}
 }

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -10,7 +10,7 @@ class Events_Text_Snippet {
 	 * @param array $snippets The array of snippets.
 	 * @return string The generated snippet links.
 	 */
-	public static function generate_snippet_links( $snippets ) : string {
+	public static function generate_snippet_links( $snippets ): string {
 		$links = '<ul class="text-snippets">';
 		foreach ( $snippets as $snippet ) {
 			$links .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
@@ -37,4 +37,3 @@ class Events_Text_Snippet {
 		);
 	}
 }
-

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -13,7 +13,7 @@ class Event_Text_Snippet {
 		$snippets           = apply_filters( 'wporg_translation_events_snippets', array() );
 		$snippets_link_list = '<ul class="text-snippets">';
 		foreach ( $snippets as $snippet ) {
-			$snippets_link_list .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', esc_html( $snippet['snippet'] ), $snippet['title'] );
+			$snippets_link_list .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', esc_html( $snippet['snippet'] ), esc_html( $snippet['title'] ) );
 		}
 		$snippets_link_list .= '</ul>';
 		return $snippets_link_list;

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -2,7 +2,7 @@
 
 namespace Wporg\TranslationEvents;
 
-class Events_Text_Snippet {
+class Event_Text_Snippet {
 
 	/**
 	 * Generate links for text snippets.

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Wporg\TranslationEvents;
+
+class Events_Text_Snippet {
+
+	/**
+	 * Generate links for text snippets.
+	 *
+	 * @param array $snippets The array of snippets.
+	 * @return string The generated snippet links.
+	 */
+	public static function generate_snippet_links( $snippets ) : string {
+		$links = '<ul class="text-snippets">';
+		foreach ( $snippets as $snippet ) {
+			$links .= sprintf( '<li><a href="#" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
+		}
+		$links .= '</ul>';
+		return $links;
+	}
+
+	/**
+	 * Get the default snippets.
+	 *
+	 * @return array The default snippets.
+	 */
+	public static function get_default_snippets(): array {
+		return array(
+			array(
+				'title'   => 'General Instructions',
+				'snippet' => 'These are general instructions for anyone intending to contribute',
+			),
+			array(
+				'title'   => 'New Contributor Guidance',
+				'snippet' => 'Here is the snippet for new contributor guidance',
+			),
+		);
+	}
+}
+

--- a/includes/event-text-snippet.php
+++ b/includes/event-text-snippet.php
@@ -13,7 +13,7 @@ class Event_Text_Snippet {
 		$snippets           = apply_filters( 'wporg_translation_events_snippets', array() );
 		$snippets_link_list = '<ul class="text-snippets">';
 		foreach ( $snippets as $snippet ) {
-			$snippets_link_list .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', $snippet['snippet'], $snippet['title'] );
+			$snippets_link_list .= sprintf( '<li><a href="#" class="text-snippet" data-snippet="%s">%s</a></li>', esc_html( $snippet['snippet'] ), $snippet['title'] );
 		}
 		$snippets_link_list .= '</ul>';
 		return $snippets_link_list;

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -43,15 +43,20 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div>
 		<label for="event-description">Event Description</label>
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
-		<ul class="text-snippets">
-			<li>
-				<a href="#">New contributor guidance</a>
-			</li>
-			<li>
-				<a href="#">Generic Instructions</a>
-			</li>	
-		</ul>
-	<div>
+		<?php
+		echo wp_kses(
+			apply_filters( 'wporg_translation_events_snippets', Events_Text_Snippet::get_default_snippets() ),
+			array(
+				'a'  => array(
+					'href'         => array(),
+					'data-snippet' => array(),
+				),
+				'ul' => array( 'class' => array() ),
+				'li' => array(),
+			)
+		);
+		?>
+			<div>
 		<label for="event-start">Start Date</label>
 		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i' ) ); ?>" required>
 	</div>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -45,7 +45,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
 		<?php
 		echo wp_kses(
-			apply_filters( 'wporg_translation_events_snippets', Events_Text_Snippet::get_default_snippets() ),
+			Events_Text_Snippet::get_snippet_links(),
 			array(
 				'a'  => array(
 					'href'         => array(),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -45,7 +45,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
 		<?php
 		echo wp_kses(
-			Events_Text_Snippet::get_snippet_links(),
+			Event_Text_Snippet::get_snippet_links(),
 			array(
 				'a'  => array(
 					'href'         => array(),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -43,7 +43,14 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<div>
 		<label for="event-description">Event Description</label>
 		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
-	</div>
+		<ul class="text-snippets">
+			<li>
+				<a href="#">New contributor guidance</a>
+			</li>
+			<li>
+				<a href="#">Generic Instructions</a>
+			</li>	
+		</ul>
 	<div>
 		<label for="event-start">Start Date</label>
 		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i' ) ); ?>" required>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -50,6 +50,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 				'a'  => array(
 					'href'         => array(),
 					'data-snippet' => array(),
+					'class'        => array(),
 				),
 				'ul' => array( 'class' => array() ),
 				'li' => array(),

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -29,6 +29,7 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
+use Wporg\TranslationEvents\Events_Text_Snippet;
 
 class Translation_Events {
 	public const CPT = 'translation_event';
@@ -70,6 +71,8 @@ class Translation_Events {
 		add_filter( 'wp_insert_post_data', array( $this, 'generate_event_slug' ), 10, 2 );
 		add_action( 'gp_init', array( $this, 'gp_init' ) );
 		add_action( 'gp_before_translation_table', array( $this, 'add_active_events_current_user' ) );
+		add_filter( 'wporg_translation_events_snippets', array( Events_Text_Snippet::class, 'generate_snippet_links' ) );
+
 
 		if ( is_admin() ) {
 			Upgrade::upgrade_if_needed();

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -29,7 +29,6 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
-use Wporg\TranslationEvents\Events_Text_Snippet;
 
 class Translation_Events {
 	public const CPT = 'translation_event';
@@ -71,8 +70,6 @@ class Translation_Events {
 		add_filter( 'wp_insert_post_data', array( $this, 'generate_event_slug' ), 10, 2 );
 		add_action( 'gp_init', array( $this, 'gp_init' ) );
 		add_action( 'gp_before_translation_table', array( $this, 'add_active_events_current_user' ) );
-		add_filter( 'wporg_translation_events_snippets', array( Events_Text_Snippet::class, 'generate_snippet_links' ) );
-
 
 		if ( is_admin() ) {
 			Upgrade::upgrade_if_needed();


### PR DESCRIPTION
Fixes #96 

**Screen recording**
![eventsnippets](https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/365ccd85-b20d-46cd-ae13-ab12e4555d80)

**Testing Instructions**

Add the code block below to this [line](https://github.com/WordPress/wporg-gp-translation-events/blob/6c5218259f8ae0ddd05c95ea216fd257da2976fd/wporg-gp-translation-events.php#L73). Or you could add it to another plugin installed in the same environment. 

```		
add_filter( 'wporg_translation_events_snippets', function () {
			return array(
				array(
					'title'   => '1st snippet',
					'snippet' => 'This is the 1st snippet',
				),
				array(
					'title'   => '2nd snippet',
					'snippet' => 'This is the 2nd snippet',
				),
				array(
					'title'   => '3rd snippet',
					'snippet' => 'This is the 3rd snippet, with a <a href="https://example.com">link</a> on it.',
				),
			);
		} );
```
