### PR TITLE
Use event repository for creating/updating/deleting events

### DIFF
--- a/includes/active-events-cache.php
+++ b/includes/active-events-cache.php
@@ -40,15 +40,4 @@ class Active_Events_Cache {
 
 		return $result;
 	}
-
-	/**
-	 * Invalidates the active events cache.
-	 *
-	 * @throws Exception When it fails to invalidate the cache.
-	 */
-	public static function invalidate(): void {
-		if ( ! wp_cache_delete( self::KEY ) ) {
-			throw new Exception( 'Failed to invalidate cached events' );
-		}
-	}
 }

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -222,6 +222,7 @@ class Event_Form_Handler {
 
 		return new Event(
 			intval( $event_id ),
+			get_current_user_id(),
 			$start->setTimezone( new DateTimeZone( 'UTC' ) ),
 			$end->setTimezone( new DateTimeZone( 'UTC' ) ),
 			$timezone,

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -8,9 +8,7 @@ use DateTimeZone;
 use Exception;
 use GP;
 use WP_Error;
-use Wporg\TranslationEvents\Active_Events_Cache;
 use Wporg\TranslationEvents\Stats_Calculator;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Form_Handler {
 	private Event_Repository_Interface $event_repository;

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -69,7 +69,7 @@ class Event_Form_Handler {
 			}
 			$stats_calculator = new Stats_Calculator();
 			try {
-				$event_stats = $stats_calculator->for_event( $event );
+				$event_stats = $stats_calculator->for_event( $event->ID );
 			} catch ( Exception $e ) {
 				wp_send_json_error( esc_html__( 'Failed to calculate event stats.', 'gp-translation-events' ), 500 );
 			}

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -154,9 +154,7 @@ class Event_Form_Handler {
 				$response_message = esc_html__( 'Event updated successfully', 'gp-translation-events' );
 				$event_id         = $event->id();
 			}
-			if ( ! $event_id ) {
-				wp_send_json_error( esc_html__( 'Event could not be created or updated.', 'gp-translation-events' ), 422 );
-			}
+
 			try {
 				update_post_meta( $event_id, '_event_start', $new_event->start()->format( 'Y-m-d H:i:s' ) );
 				update_post_meta( $event_id, '_event_end', $new_event->end()->format( 'Y-m-d H:i:s' ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -12,6 +12,12 @@ use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Form_Handler {
+	private Event_Repository_Interface $event_repository;
+
+	public function __construct( Event_Repository_Interface $event_repository ) {
+		$this->event_repository = $event_repository;
+	}
+
 	public function handle( array $form_data ): void {
 		if ( ! is_user_logged_in() ) {
 			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -127,7 +127,6 @@ class Event_Form_Handler {
 					return;
 				}
 				$response_message = esc_html__( 'Event created successfully.', 'gp-translation-events' );
-				$event_id         = $new_event->id();
 			}
 			if ( 'edit_event' === $action ) {
 				$event = $this->event_repository->get_event( $new_event->id() );
@@ -152,9 +151,9 @@ class Event_Form_Handler {
 					return;
 				}
 				$response_message = esc_html__( 'Event updated successfully', 'gp-translation-events' );
-				$event_id         = $event->id();
 			}
 
+			$event_id     = $new_event->id();
 			$event_status = $new_event->status();
 		}
 

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -70,9 +70,7 @@ class Event_Form_Handler {
 			if ( ! $event || Translation_Events::CPT !== $event->post_type ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
-			if ( ! ( current_user_can( 'delete_post', $event->ID ) || get_current_user_id() === $event->post_author ) ) {
-				wp_send_json_error( 'You do not have permission to delete this event' );
-			}
+
 			$stats_calculator = new Stats_Calculator();
 			try {
 				$event_stats = $stats_calculator->for_event( $event->ID );
@@ -129,12 +127,9 @@ class Event_Form_Handler {
 				$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
 			}
 			if ( 'edit_event' === $action ) {
-				if ( ! isset( $form_data['event_id'] ) ) {
-					wp_send_json_error( esc_html__( 'Event id is required.', 'gp-translation-events' ), 422 );
-				}
 				$event_id = sanitize_text_field( wp_unslash( $form_data['event_id'] ) );
 				$event    = get_post( $event_id );
-				if ( ! $event || Translation_Events::CPT !== $event->post_type || ! ( current_user_can( 'edit_post', $event->ID ) || intval( $event->post_author ) === get_current_user_id() ) ) {
+				if ( ! $event || Translation_Events::CPT !== $event->post_type ) {
 					wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 				}
 				wp_update_post(

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -225,7 +225,6 @@ class Event_Form_Handler {
 			$description,
 		);
 		$event->set_id( intval( $event_id ) );
-		$event->set_slug( sanitize_title( $title ) );
 		return $event;
 	}
 }

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -220,16 +220,17 @@ class Event_Form_Handler {
 			throw new InvalidEnd();
 		}
 
-		return new Event(
-			intval( $event_id ),
+		$event = new Event(
 			get_current_user_id(),
 			$start->setTimezone( new DateTimeZone( 'UTC' ) ),
 			$end->setTimezone( new DateTimeZone( 'UTC' ) ),
 			$timezone,
-			sanitize_title( $title ),
 			$event_status,
 			$title,
 			$description,
 		);
+		$event->set_id( intval( $event_id ) );
+		$event->set_slug( sanitize_title( $title ) );
+		return $event;
 	}
 }

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -135,11 +135,16 @@ class Event_Form_Handler {
 					wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 				}
 
-				$event->set_status( $new_event->status() );
-				$event->set_title( $new_event->title() );
-				$event->set_description( $new_event->description() );
-				$event->set_timezone( $new_event->timezone() );
-				$event->set_times( $new_event->start()->utc(), $new_event->end()->utc() );
+				try {
+					$event->set_status( $new_event->status() );
+					$event->set_title( $new_event->title() );
+					$event->set_description( $new_event->description() );
+					$event->set_timezone( $new_event->timezone() );
+					$event->set_times( $new_event->start()->utc(), $new_event->end()->utc() );
+				} catch ( Exception $e ) {
+					wp_send_json_error( esc_html__( 'Failed to update event.', 'gp-translation-events' ), 422 );
+					return;
+				}
 
 				$result = $this->event_repository->update_event( $event );
 				if ( $result instanceof WP_Error ) {

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -158,13 +158,6 @@ class Event_Form_Handler {
 			$event_status = $new_event->status();
 		}
 
-		try {
-			Active_Events_Cache::invalidate();
-		} catch ( Exception $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $e );
-		}
-
 		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
 		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
 		wp_send_json_success(

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use GP;
+use WP_Error;
 use Wporg\TranslationEvents\Active_Events_Cache;
 use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
@@ -120,15 +121,13 @@ class Event_Form_Handler {
 			}
 
 			if ( 'create_event' === $action ) {
-				$event_id         = wp_insert_post(
-					array(
-						'post_type'    => Translation_Events::CPT,
-						'post_title'   => $new_event->title(),
-						'post_content' => $new_event->description(),
-						'post_status'  => $new_event->status(),
-					)
-				);
-				$response_message = esc_html__( 'Event created successfully!', 'gp-translation-events' );
+				$result = $this->event_repository->insert_event( $new_event );
+				if ( $result instanceof WP_Error ) {
+					wp_send_json_error( esc_html__( 'Failed to create event.', 'gp-translation-events' ), 422 );
+					return;
+				}
+				$response_message = esc_html__( 'Event created successfully.', 'gp-translation-events' );
+				$event_id         = $new_event->id();
 			}
 			if ( 'edit_event' === $action ) {
 				$event_id = sanitize_text_field( wp_unslash( $form_data['event_id'] ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -155,14 +155,6 @@ class Event_Form_Handler {
 				$event_id         = $event->id();
 			}
 
-			try {
-				update_post_meta( $event_id, '_event_start', $new_event->start()->format( 'Y-m-d H:i:s' ) );
-				update_post_meta( $event_id, '_event_end', $new_event->end()->format( 'Y-m-d H:i:s' ) );
-			} catch ( Exception $e ) {
-				wp_send_json_error( esc_html__( 'Invalid start or end', 'gp-translation-events' ), 422 );
-			}
-			update_post_meta( $event_id, '_event_timezone', $new_event->timezone()->getName() );
-
 			$event_status = $new_event->status();
 		}
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -75,6 +75,7 @@ class Event_Repository implements Event_Repository_Interface {
 			$meta = $this->get_event_meta( $id );
 			return new Event(
 				$post->ID,
+				intval( $post->post_author ),
 				$meta['start'],
 				$meta['end'],
 				$meta['timezone'],
@@ -261,6 +262,7 @@ class Event_Repository implements Event_Repository_Interface {
 			$meta     = $this->get_event_meta( $post->ID );
 			$events[] = new Event(
 				$post->ID,
+				intval( $post->post_author ),
 				$meta['start'],
 				$meta['end'],
 				$meta['timezone'],

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -72,18 +72,19 @@ class Event_Repository implements Event_Repository_Interface {
 		}
 
 		try {
-			$meta = $this->get_event_meta( $id );
-			return new Event(
-				$post->ID,
+			$meta  = $this->get_event_meta( $id );
+			$event = new Event(
 				intval( $post->post_author ),
 				$meta['start'],
 				$meta['end'],
 				$meta['timezone'],
-				$post->post_name,
 				$post->post_status,
 				$post->post_title,
 				$post->post_content,
 			);
+			$event->set_id( $post->ID );
+			$event->set_slug( $post->post_name );
+			return $event;
 		} catch ( Exception $e ) {
 			// This should not be possible as it means data in the database is invalid.
 			// So we consider an invalid event to be not found.
@@ -259,18 +260,19 @@ class Event_Repository implements Event_Repository_Interface {
 		$events = array();
 
 		foreach ( $posts as $post ) {
-			$meta     = $this->get_event_meta( $post->ID );
-			$events[] = new Event(
-				$post->ID,
+			$meta  = $this->get_event_meta( $post->ID );
+			$event = new Event(
 				intval( $post->post_author ),
 				$meta['start'],
 				$meta['end'],
 				$meta['timezone'],
-				$post->post_name,
 				$post->post_status,
 				$post->post_title,
 				$post->post_content,
 			);
+			$event->set_id( $post->ID );
+			$event->set_slug( $post->post_name );
+			$events[] = $event;
 		}
 
 		return new Events_Query_Result( $events, $query->max_num_pages );

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -67,6 +67,9 @@ class Event_Repository implements Event_Repository_Interface {
 
 	public function get_event( int $id ): ?Event {
 		$post = $this->get_event_post( $id );
+		if ( ! $post ) {
+			return null;
+		}
 
 		try {
 			$meta = $this->get_event_meta( $id );

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -40,12 +40,12 @@ class InvalidStatus extends Exception {
 }
 
 class Event {
-	private int $id;
+	private int $id = 0;
 	private int $author_id;
 	private DateTimeImmutable $start;
 	private DateTimeImmutable $end;
 	private DateTimeZone $timezone;
-	private string $slug;
+	private string $slug = '';
 	private string $status;
 	private string $title;
 	private string $description;
@@ -60,17 +60,17 @@ class Event {
 			throw new Exception( 'Invalid event meta' );
 		}
 
-		return new Event(
-			$id,
+		$event = new Event(
 			0,           // TODO: this function will be removed, this is here so tests pass.
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
-			'foo-slug',  // TODO: this function will be removed, this is here so tests pass.
 			'publish',   // TODO: this function will be removed, this is here so tests pass.
 			'Foo title', // TODO: this function will be removed, this is here so tests pass.
 			''
 		);
+		$event->set_id( $id );
+		return $event;
 	}
 
 	/**
@@ -80,19 +80,14 @@ class Event {
 	 * @throws InvalidTitle
 	 */
 	public function __construct(
-		int $id,
 		int $author_id,
 		DateTimeImmutable $start,
 		DateTimeImmutable $end,
 		DateTimeZone $timezone,
-		string $slug,
 		string $status,
 		string $title,
 		string $description
 	) {
-		$this->slug = $slug;
-
-		$this->set_id( $id );
 		$this->author_id = $author_id;
 		$this->set_times( $start, $end );
 		$this->set_timezone( $timezone );
@@ -139,6 +134,10 @@ class Event {
 
 	public function set_id( int $id ): void {
 		$this->id = $id;
+	}
+
+	public function set_slug( string $slug ): void {
+		$this->slug = $slug;
 	}
 
 	/**

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -41,6 +41,7 @@ class InvalidStatus extends Exception {
 
 class Event {
 	private int $id;
+	private int $author_id;
 	private DateTimeImmutable $start;
 	private DateTimeImmutable $end;
 	private DateTimeZone $timezone;
@@ -61,6 +62,7 @@ class Event {
 
 		return new Event(
 			$id,
+			0,           // TODO: this function will be removed, this is here so tests pass.
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
 			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
 			new DateTimeZone( $meta['_event_timezone'][0] ),
@@ -79,6 +81,7 @@ class Event {
 	 */
 	public function __construct(
 		int $id,
+		int $author_id,
 		DateTimeImmutable $start,
 		DateTimeImmutable $end,
 		DateTimeZone $timezone,
@@ -90,6 +93,7 @@ class Event {
 		$this->slug = $slug;
 
 		$this->set_id( $id );
+		$this->author_id = $author_id;
 		$this->set_times( $start, $end );
 		$this->set_timezone( $timezone );
 		$this->set_status( $status );
@@ -99,6 +103,10 @@ class Event {
 
 	public function id(): int {
 		return $this->id;
+	}
+
+	public function author_id(): int {
+		return $this->author_id;
 	}
 
 	public function start(): Event_Start_Date {

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -50,7 +50,7 @@ class Details_Route extends Route {
 
 		$stats_calculator = new Stats_Calculator();
 		try {
-			$event_stats  = $stats_calculator->for_event( $event );
+			$event_stats  = $stats_calculator->for_event( $event->ID );
 			$contributors = $stats_calculator->get_contributors( $event_id );
 			$projects     = $stats_calculator->get_projects( $event_id );
 		} catch ( Exception $e ) {

--- a/includes/stats-calculator.php
+++ b/includes/stats-calculator.php
@@ -86,7 +86,7 @@ class Stats_Calculator {
 	 *
 	 * @throws Exception When stats calculation failed.
 	 */
-	public function for_event( WP_Post $event ): Event_Stats {
+	public function for_event( int $event_id ): Event_Stats {
 		$stats = new Event_Stats();
 		global $wpdb, $gp_table_prefix;
 
@@ -107,7 +107,7 @@ class Stats_Calculator {
 				group by locale with rollup
 			",
 				array(
-					$event->ID,
+					$event_id,
 				)
 			)
 		);
@@ -246,7 +246,7 @@ class Stats_Calculator {
 	 */
 	public function event_has_stats( WP_Post $event ): bool {
 		try {
-			$stats = $this->for_event( $event );
+			$stats = $this->for_event( $event->ID );
 		} catch ( Exception $e ) {
 			return false;
 		}

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -54,6 +54,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 		$now   = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event = new Event(
 			0,
+			0,
 			$now,
 			$now->modify( '+1 hour' ),
 			new DateTimeZone( 'Europe/Lisbon' ),

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -54,11 +54,9 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 		$now   = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event = new Event(
 			0,
-			0,
 			$now,
 			$now->modify( '+1 hour' ),
 			new DateTimeZone( 'Europe/Lisbon' ),
-			'foo',
 			'draft',
 			'Foo',
 			'Foo.'

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -63,18 +63,15 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$start       = $now->modify( '-1 hours' );
 		$end         = $now->modify( '+1 hours' );
 		$timezone    = new DateTimeZone( 'Europe/Lisbon' );
-		$slug        = 'foo-slug';
 		$status      = 'publish';
 		$title       = 'Foo title';
 		$description = 'Foo Description';
 
 		$event = new Event(
 			0,
-			0,
 			$start,
 			$end,
 			$timezone,
-			$slug,
 			$status,
 			$title,
 			$description,
@@ -88,7 +85,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $start->getTimestamp(), $created_event->start()->getTimestamp() );
 		$this->assertEquals( $end->getTimestamp(), $created_event->end()->getTimestamp() );
 		$this->assertEquals( $timezone, $created_event->timezone() );
-		$this->assertEquals( $slug, $created_event->slug() );
+		$this->assertEquals( 'foo-title', $created_event->slug() );
 		$this->assertEquals( $status, $created_event->status() );
 		$this->assertEquals( $title, $created_event->title() );
 		$this->assertEquals( $description, $created_event->description() );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -70,6 +70,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 
 		$event = new Event(
 			0,
+			0,
 			$start,
 			$end,
 			$timezone,

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -22,6 +22,15 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 	}
 
+	public function test_get_event_returns_null_when_post_does_not_not_have_correct_type() {
+		$id = wp_insert_post(
+			array(
+				'post_type' => 'foo',
+			)
+		);
+		$this->assertNull( $this->repository->get_event( $id ) );
+	}
+
 	public function test_get_event_returns_null_when_event_does_not_exist() {
 		$this->assertNull( $this->repository->get_event( 42 ) );
 	}

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -18,12 +18,10 @@ class Event_Test extends WP_UnitTestCase {
 
 		$this->expectException( InvalidEnd::class );
 		new Event(
-			1,
 			0,
 			$now,
 			$now->modify( '-1 hours' ),
 			$timezone,
-			'foo-slug',
 			'publish',
 			'Foo title',
 			'',
@@ -36,12 +34,10 @@ class Event_Test extends WP_UnitTestCase {
 
 		$this->expectException( InvalidStart::class );
 		new Event(
-			1,
 			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,
-			'foo-slug',
 			'publish',
 			'Foo title',
 			'',
@@ -54,12 +50,10 @@ class Event_Test extends WP_UnitTestCase {
 
 		$this->expectException( InvalidTitle::class );
 		new Event(
-			1,
 			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,
-			'foo-slug',
 			'publish',
 			'',
 			'',
@@ -72,12 +66,10 @@ class Event_Test extends WP_UnitTestCase {
 
 		$this->expectException( InvalidStatus::class );
 		new Event(
-			1,
 			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,
-			'foo-slug',
 			'',
 			'Foo title',
 			'',

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -19,6 +19,7 @@ class Event_Test extends WP_UnitTestCase {
 		$this->expectException( InvalidEnd::class );
 		new Event(
 			1,
+			0,
 			$now,
 			$now->modify( '-1 hours' ),
 			$timezone,
@@ -36,6 +37,7 @@ class Event_Test extends WP_UnitTestCase {
 		$this->expectException( InvalidStart::class );
 		new Event(
 			1,
+			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,
@@ -53,6 +55,7 @@ class Event_Test extends WP_UnitTestCase {
 		$this->expectException( InvalidTitle::class );
 		new Event(
 			1,
+			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,
@@ -70,6 +73,7 @@ class Event_Test extends WP_UnitTestCase {
 		$this->expectException( InvalidStatus::class );
 		new Event(
 			1,
+			0,
 			$now,
 			$now->modify( '+1 hours' ),
 			$timezone,

--- a/tests/stats-calculator.php
+++ b/tests/stats-calculator.php
@@ -71,7 +71,7 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 		$this->stats_factory->create( $event2_id, $user2_id, 32, 'reject' );
 
 		$event1 = get_post( $event1_id );
-		$stats  = $this->calculator->for_event( $event1 );
+		$stats  = $this->calculator->for_event( $event1->ID );
 
 		$this->assertCount( 2, $stats->rows() );
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -25,6 +25,8 @@ use GP;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
+use Wporg\TranslationEvents\Event\Event_Repository_Cached;
+use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 
 class Translation_Events {
 	public const CPT = 'translation_event';
@@ -35,6 +37,22 @@ class Translation_Events {
 			$instance = new self();
 		}
 		return $instance;
+	}
+
+	public static function get_event_repository(): Event_Repository_Interface {
+		static $event_repository = null;
+		if ( null === $event_repository ) {
+			$event_repository = new Event_Repository_Cached( self::get_attendee_repository() );
+		}
+		return $event_repository;
+	}
+
+	public static function get_attendee_repository(): Attendee_Repository {
+		static $attendee_repository = null;
+		if ( null === $attendee_repository ) {
+			$attendee_repository = new Attendee_Repository();
+		}
+		return $attendee_repository;
 	}
 
 	public function __construct() {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -203,7 +203,7 @@ class Translation_Events {
 	 * Handle the event form submission for the creation, editing, and deletion of events. This function is called via AJAX.
 	 */
 	public function submit_event_ajax() {
-		$form_handler = new Event_Form_Handler();
+		$form_handler = new Event_Form_Handler( self::get_event_repository() );
 		// Nonce verification is done by the form handler.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$form_handler->handle( $_POST );


### PR DESCRIPTION
> Please don't be scared by the number of commits, they're small and should be self-explanatory with the commit message.

In previous PRs, we added an `Event_Repository` that acts as a layer between the database and the "business logic", but it wasn't being called anywhere yet.

In this PR, we change the form handling code so that creating/updating/deleting events uses the `Event_Repository`. There are no functional changes here, the behaviour should be the same as before.

I will tackle the reading side of things (calling the `get_*` methods of the repository) in another PR.

## Testing instructions
Test creating, editing and deleting events. If should behave as it did before.
