### PR TITLE
Fix tests

### DIFF
--- a/includes/event/event-date.php
+++ b/includes/event/event-date.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Event;
 
 use DateTime;
 use DateTimeImmutable;

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -8,6 +8,8 @@ use DateTimeZone;
 use Exception;
 use GP;
 use WP_Error;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Stats_Calculator;
 
 class Event_Form_Handler {
@@ -137,7 +139,7 @@ class Event_Form_Handler {
 					$event->set_title( $new_event->title() );
 					$event->set_description( $new_event->description() );
 					$event->set_timezone( $new_event->timezone() );
-					$event->set_times( $new_event->start()->utc(), $new_event->end()->utc() );
+					$event->set_times( $new_event->start(), $new_event->end() );
 				} catch ( Exception $e ) {
 					wp_send_json_error( esc_html__( 'Failed to update event.', 'gp-translation-events' ), 422 );
 					return;
@@ -202,13 +204,13 @@ class Event_Form_Handler {
 		}
 
 		try {
-			$start = new DateTimeImmutable( $event_start, $timezone );
+			$start = new Event_Start_Date( $event_start, $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidStart();
 		}
 
 		try {
-			$end = new DateTimeImmutable( $event_end, $timezone );
+			$end = new Event_End_Date( $event_end, $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidEnd();
 		}

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -3,13 +3,10 @@
 namespace Wporg\TranslationEvents\Event;
 
 use DateTime;
-use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use GP;
 use WP_Error;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Stats_Calculator;
 
 class Event_Form_Handler {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -9,6 +9,8 @@ use WP_Error;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee_Repository;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {
@@ -347,10 +349,11 @@ class Event_Repository implements Event_Repository_Interface {
 	 */
 	private function get_event_meta( int $event_id ): array {
 		$meta = get_post_meta( $event_id );
+		$utc  = new DateTimeZone( 'UTC' );
 
 		return array(
-			'start'    => self::parse_utc_datetime( $meta['_event_start'][0] ),
-			'end'      => self::parse_utc_datetime( $meta['_event_end'][0] ),
+			'start'    => new Event_Start_Date( $meta['_event_start'][0], $utc ),
+			'end'      => new Event_End_Date( $meta['_event_end'][0], $utc ),
 			'timezone' => new DateTimeZone( $meta['_event_timezone'][0] ),
 		);
 	}
@@ -359,9 +362,5 @@ class Event_Repository implements Event_Repository_Interface {
 		update_post_meta( $event->id(), '_event_start', $event->start()->utc()->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event->id(), '_event_end', $event->end()->utc()->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event->id(), '_event_timezone', $event->timezone()->getName() );
-	}
-
-	private function parse_utc_datetime( string $datetime ): DateTimeImmutable {
-		return DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $datetime, new DateTimeZone( 'UTC' ) );
 	}
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -9,8 +9,6 @@ use WP_Error;
 use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee_Repository;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository implements Event_Repository_Interface {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -51,29 +51,6 @@ class Event {
 	private string $description;
 
 	/**
-	 * Make an Event from post meta.
-	 *
-	 * @throws Exception When dates are invalid.
-	 */
-	public static function from_post_meta( int $id, array $meta ): Event {
-		if ( ! isset( $meta['_event_start'][0] ) || ! isset( $meta['_event_end'][0] ) || ! isset( $meta['_event_timezone'][0] ) ) {
-			throw new Exception( 'Invalid event meta' );
-		}
-
-		$event = new Event(
-			0,           // TODO: this function will be removed, this is here so tests pass.
-			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_start'][0], new DateTimeZone( 'UTC' ) ),
-			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $meta['_event_end'][0], new DateTimeZone( 'UTC' ) ),
-			new DateTimeZone( $meta['_event_timezone'][0] ),
-			'publish',   // TODO: this function will be removed, this is here so tests pass.
-			'Foo title', // TODO: this function will be removed, this is here so tests pass.
-			''
-		);
-		$event->set_id( $id );
-		return $event;
-	}
-
-	/**
 	 * @throws InvalidStart
 	 * @throws InvalidEnd
 	 * @throws InvalidStatus

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -42,8 +42,8 @@ class InvalidStatus extends Exception {
 class Event {
 	private int $id = 0;
 	private int $author_id;
-	private DateTimeImmutable $start;
-	private DateTimeImmutable $end;
+	private Event_Start_Date $start;
+	private Event_End_Date $end;
 	private DateTimeZone $timezone;
 	private string $slug = '';
 	private string $status;
@@ -58,8 +58,8 @@ class Event {
 	 */
 	public function __construct(
 		int $author_id,
-		DateTimeImmutable $start,
-		DateTimeImmutable $end,
+		Event_Start_Date $start,
+		Event_End_Date $end,
 		DateTimeZone $timezone,
 		string $status,
 		string $title,
@@ -82,11 +82,11 @@ class Event {
 	}
 
 	public function start(): Event_Start_Date {
-		return new Event_Start_Date( $this->start->format( 'Y-m-d H:i:s' ), $this->timezone() );
+		return $this->start;
 	}
 
 	public function end(): Event_End_Date {
-		return new Event_End_Date( $this->end->format( 'Y-m-d H:i:s' ), $this->timezone() );
+		return $this->end;
 	}
 
 	public function timezone(): DateTimeZone {
@@ -120,7 +120,7 @@ class Event {
 	/**
 	 * @throws InvalidStart|InvalidEnd
 	 */
-	public function set_times( DateTimeImmutable $start, DateTimeImmutable $end ): void {
+	public function set_times( Event_Start_Date $start, Event_End_Date $end ): void {
 		$this->validate_times( $start, $end );
 		$this->start = $start;
 		$this->end   = $end;
@@ -158,7 +158,7 @@ class Event {
 	 * @throws InvalidStart
 	 * @throws InvalidEnd
 	 */
-	private function validate_times( DateTimeImmutable $start, DateTimeImmutable $end ) {
+	private function validate_times( Event_Start_Date $start, Event_End_Date $end ) {
 		if ( $end <= $start ) {
 			throw new InvalidEnd();
 		}

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -2,10 +2,7 @@
 
 namespace Wporg\TranslationEvents\Event;
 
-use DateTimeImmutable;
 use DateTimeZone;
-use Wporg\TranslationEvents\Event_Start_Date;
-use Wporg\TranslationEvents\Event_End_Date;
 use Exception;
 use Throwable;
 

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -2,11 +2,10 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Routes\Route;
 
-use DateTimeZone;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
 /**
  * Displays the event create page.
  */

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -2,9 +2,6 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
 use Exception;
 use GP;
 use Wporg\TranslationEvents\Attendee_Repository;
@@ -12,8 +9,6 @@ use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
-use Wporg\TranslationEvents\Event_Start_Date;
-use Wporg\TranslationEvents\Event_End_Date;
 
 /**
  * Displays the event details page.

--- a/templates/event.php
+++ b/templates/event.php
@@ -5,6 +5,9 @@
 
 namespace Wporg\TranslationEvents;
 
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
+
 /** @var int $event_id */
 /** @var string $event_title */
 /** @var string $event_description */

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -6,6 +6,8 @@
 namespace Wporg\TranslationEvents;
 
 use DateTimeZone;
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 
 /** @var string $event_page_title */
 /** @var string $event_form_name */

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -5,6 +5,8 @@
 
 namespace Wporg\TranslationEvents;
 
+use DateTimeZone;
+
 /** @var string $event_page_title */
 /** @var string $event_form_name */
 /** @var int    $event_id */
@@ -12,7 +14,7 @@ namespace Wporg\TranslationEvents;
 /** @var string $event_description */
 /** @var Event_Start_Date $event_start */
 /** @var Event_End_Date $event_end */
-/** @var Datetime_Timezone|null $event_timezone */
+/** @var DateTimeZone|null $event_timezone */
 /** @var string $event_url */
 /** @var string $css_show_url */
 

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -44,11 +44,11 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 	<div>
 		<label for="event-start">Start Date</label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i:s' ) ); ?>" required>
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i' ) ); ?>" required>
 	</div>
 	<div>
 		<label for="event-end">End Date</label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i:s' ) ); ?>" required>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i' ) ); ?>" required>
 	</div>
 	<div>
 		<label for="event-timezone">Event Timezone</label>

--- a/tests/event-date.php
+++ b/tests/event-date.php
@@ -3,8 +3,7 @@
 namespace Wporg\Tests;
 
 use GP_UnitTestCase;
-use Wporg\TranslationEvents\Event_Start_Date;
-use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 
 class Event_Date_Test extends GP_UnitTestCase {
 	public function test_timezone() {

--- a/tests/event/event-date.php
+++ b/tests/event/event-date.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\Tests;
+namespace Wporg\Tests\Event;
 
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event_Start_Date;

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -8,8 +8,8 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Cached_Test extends GP_UnitTestCase {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -8,6 +8,8 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Cached_Test extends GP_UnitTestCase {
@@ -51,11 +53,10 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_created() {
-		$now   = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event = new Event(
 			0,
-			$now,
-			$now->modify( '+1 hour' ),
+			new Event_Start_Date( 'now' ),
+			( new Event_End_Date( 'now' ) )->modify( '+1 hour' ),
 			new DateTimeZone( 'Europe/Lisbon' ),
 			'draft',
 			'Foo',

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -8,6 +8,8 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Test extends GP_UnitTestCase {
@@ -59,9 +61,8 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_create_event() {
-		$now         = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$start       = $now->modify( '-1 hours' );
-		$end         = $now->modify( '+1 hours' );
+		$start       = ( new Event_Start_Date( 'now' ) )->modify( '-1 hours' );
+		$end         = ( new Event_End_Date( 'now' ) )->modify( '+1 hours' );
 		$timezone    = new DateTimeZone( 'Europe/Lisbon' );
 		$status      = 'publish';
 		$title       = 'Foo title';
@@ -95,9 +96,8 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->repository->get_event( $event_id );
 
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		// phpcs:disable Squiz.PHP.DisallowMultipleAssignments.Found
-		$event->set_times( $updated_start = $now->modify( '+1 days' ), $updated_end = $now->modify( '+2 days' ) );
+		$event->set_times( $updated_start = ( new Event_Start_Date( 'now' ) )->modify( '+1 days' ), $updated_end = ( new Event_End_Date( 'now' ) )->modify( '+2 days' ) );
 		$event->set_timezone( $updated_timezone = new DateTimeZone( 'Europe/Madrid' ) );
 		$event->set_status( $updated_status = 'draft' );
 		$event->set_title( $updated_title = 'Updated title' );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -8,8 +8,8 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Test extends GP_UnitTestCase {

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -9,8 +9,8 @@ use Wporg\TranslationEvents\Event\InvalidStart;
 use Wporg\TranslationEvents\Event\InvalidEnd;
 use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\InvalidTitle;
-use Wporg\TranslationEvents\Event_End_Date;
-use Wporg\TranslationEvents\Event_Start_Date;
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
 
 class Event_Test extends WP_UnitTestCase {
 	public function test_validates_start_and_end() {

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\Tests\Event;
 
-use DateTimeImmutable;
 use DateTimeZone;
 use WP_UnitTestCase;
 use Wporg\TranslationEvents\Event\Event;
@@ -10,17 +9,18 @@ use Wporg\TranslationEvents\Event\InvalidStart;
 use Wporg\TranslationEvents\Event\InvalidEnd;
 use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\InvalidTitle;
+use Wporg\TranslationEvents\Event_End_Date;
+use Wporg\TranslationEvents\Event_Start_Date;
 
 class Event_Test extends WP_UnitTestCase {
 	public function test_validates_start_and_end() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$this->expectException( InvalidEnd::class );
 		new Event(
 			0,
-			$now,
-			$now->modify( '-1 hours' ),
+			new Event_Start_Date( 'now' ),
+			( new Event_End_Date( 'now' ) )->modify( '-1 hour' ),
 			$timezone,
 			'publish',
 			'Foo title',
@@ -29,14 +29,13 @@ class Event_Test extends WP_UnitTestCase {
 	}
 
 	public function test_validates_start_and_end_timezone() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'Europe/Lisbon' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$this->expectException( InvalidStart::class );
 		new Event(
 			0,
-			$now,
-			$now->modify( '+1 hours' ),
+			new Event_Start_Date( 'now', $timezone ),
+			( new Event_End_Date( 'now', $timezone ) )->modify( '+1 hour' ),
 			$timezone,
 			'publish',
 			'Foo title',
@@ -45,14 +44,13 @@ class Event_Test extends WP_UnitTestCase {
 	}
 
 	public function test_validates_title() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$this->expectException( InvalidTitle::class );
 		new Event(
 			0,
-			$now,
-			$now->modify( '+1 hours' ),
+			new Event_Start_Date( 'now' ),
+			( new Event_End_Date( 'now' ) )->modify( '+1 hour' ),
 			$timezone,
 			'publish',
 			'',
@@ -61,14 +59,13 @@ class Event_Test extends WP_UnitTestCase {
 	}
 
 	public function test_validates_status() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		$this->expectException( InvalidStatus::class );
 		new Event(
 			0,
-			$now,
-			$now->modify( '+1 hours' ),
+			new Event_Start_Date( 'now' ),
+			( new Event_End_Date( 'now' ) )->modify( '+1 hour' ),
 			$timezone,
 			'',
 			'Foo title',

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -23,7 +23,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 	public function create_draft(): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		$event_id = $this->create_event(
 			$now->modify( '-1 hours' ),
@@ -42,7 +42,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 	public function create_active( array $attendee_ids = array(), $now = null ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 		if ( null === $now ) {
-			$now = new DateTimeImmutable( 'now', $timezone );
+			$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		}
 
 		return $this->create_event(
@@ -55,7 +55,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 	public function create_inactive_past( array $attendee_ids = array() ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->create_event(
 			$now->modify( '-2 month' ),
@@ -67,7 +67,7 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 
 	public function create_inactive_future( array $attendee_ids = array() ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', $timezone );
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->create_event(
 			$now->modify( '+1 month' ),

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -72,7 +72,6 @@ class Translation_Events {
 
 	public function gp_init() {
 		require_once __DIR__ . '/templates/helper-functions.php';
-		require_once __DIR__ . '/includes/event-date.php';
 		require_once __DIR__ . '/includes/routes/route.php';
 		require_once __DIR__ . '/includes/routes/event/create.php';
 		require_once __DIR__ . '/includes/routes/event/details.php';
@@ -80,6 +79,7 @@ class Translation_Events {
 		require_once __DIR__ . '/includes/routes/event/list.php';
 		require_once __DIR__ . '/includes/routes/user/attend-event.php';
 		require_once __DIR__ . '/includes/routes/user/my-events.php';
+		require_once __DIR__ . '/includes/event/event-date.php';
 		require_once __DIR__ . '/includes/event/event.php';
 		require_once __DIR__ . '/includes/event/event-repository-interface.php';
 		require_once __DIR__ . '/includes/event/event-repository.php';


### PR DESCRIPTION
Requires #190 

This PR makes tests pass again (they're failing on trunk).

## Summary of changes

-  Make it so that `Event` uses `Event_Start_Date` and `Event_End_Date` internally, instead of using `DateTimeImmutable`
- Don't show seconds in event create/edit form
- Fix tests
- Move `event-date.php` to `Event` namespace

## Testing instructions

There should be no functional changes, everything should work the same as before, except that seconds aren't shown in the event edit form.