### PR TITLE
Count contributions prior to user joining event

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -17,5 +17,5 @@ require_once __DIR__ . '/includes/event/event-repository-interface.php';
 require_once __DIR__ . '/includes/event/event-repository.php';
 require_once __DIR__ . '/includes/event/event-repository-cached.php';
 require_once __DIR__ . '/includes/event/event-form-handler.php';
-require_once __DIR__ . '/includes/stats-calculator.php';
-require_once __DIR__ . '/includes/stats-listener.php';
+require_once __DIR__ . '/includes/stats/stats-calculator.php';
+require_once __DIR__ . '/includes/stats/stats-listener.php';

--- a/autoload.php
+++ b/autoload.php
@@ -18,4 +18,5 @@ require_once __DIR__ . '/includes/event/event-repository.php';
 require_once __DIR__ . '/includes/event/event-repository-cached.php';
 require_once __DIR__ . '/includes/event/event-form-handler.php';
 require_once __DIR__ . '/includes/stats/stats-calculator.php';
+require_once __DIR__ . '/includes/stats/stats-importer.php';
 require_once __DIR__ . '/includes/stats/stats-listener.php';

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -7,7 +7,7 @@ use DateTimeZone;
 use Exception;
 use GP;
 use WP_Error;
-use Wporg\TranslationEvents\Stats_Calculator;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 class Event_Form_Handler {
 	private Event_Repository_Interface $event_repository;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -2,6 +2,7 @@
 
 namespace Wporg\TranslationEvents\Event;
 
+use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use Throwable;
@@ -84,6 +85,11 @@ class Event {
 
 	public function end(): Event_End_Date {
 		return $this->end;
+	}
+
+	public function is_active(): bool {
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		return $now >= $this->start->utc() && $now < $this->end->utc();
 	}
 
 	public function timezone(): DateTimeZone {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -93,8 +93,7 @@ class Event {
 	}
 
 	public function is_past(): bool {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return $this->end->utc() < $now;
+		return $this->end->is_in_the_past();
 	}
 
 	public function timezone(): DateTimeZone {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -92,6 +92,11 @@ class Event {
 		return $now >= $this->start->utc() && $now < $this->end->utc();
 	}
 
+	public function is_past(): bool {
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		return $this->end->utc() < $now;
+	}
+
 	public function timezone(): DateTimeZone {
 		return $this->timezone;
 	}

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -8,7 +8,7 @@ use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
-use Wporg\TranslationEvents\Stats_Calculator;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 /**

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -4,7 +4,7 @@ namespace Wporg\TranslationEvents\Routes\Event;
 
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
-use Wporg\TranslationEvents\Stats_Calculator;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 /**

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -28,17 +28,18 @@ class Attend_Event_Route extends Route {
 		if ( ! $user ) {
 			$this->die_with_error( esc_html__( 'Only logged-in users can attend events', 'gp-translation-events' ), 403 );
 		}
+		$user_id = $user->ID;
 
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user_id );
 		if ( $attendee instanceof Attendee ) {
-			$this->attendee_repository->remove_attendee( $event->id(), $user->ID );
+			$this->attendee_repository->remove_attendee( $event->id(), $user_id );
 		} else {
-			$attendee = new Attendee( $event->id(), $user->ID );
+			$attendee = new Attendee( $event->id(), $user_id );
 			$this->attendee_repository->insert_attendee( $attendee );
 		}
 

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -13,6 +13,9 @@ use Wporg\TranslationEvents\Translation_Events;
  * Toggle whether the current user is attending an event.
  * If the user is not currently marked as attending, they will be marked as attending.
  * If the user is currently marked as attending, they will be marked as not attending.
+ *
+ * If the user is marked as attending, and the event is active at that moment, stats for the translations the user
+ * created since the event started are imported.
  */
 class Attend_Event_Route extends Route {
 	private Event_Repository_Interface $event_repository;

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -38,6 +38,10 @@ class Attend_Event_Route extends Route {
 			$this->die_with_404();
 		}
 
+		if ( $event->is_past() ) {
+			$this->die_with_error( esc_html__( 'Cannot attend or un-attend a past event', 'gp-translation-events' ), 403 );
+		}
+
 		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user_id );
 		if ( $attendee instanceof Attendee ) {
 			$this->attendee_repository->remove_attendee( $event->id(), $user_id );

--- a/includes/stats/stats-calculator.php
+++ b/includes/stats/stats-calculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Stats;
 
 use Exception;
 use WP_Post;

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -2,11 +2,40 @@
 
 namespace Wporg\TranslationEvents\Stats;
 
+use Wporg\TranslationEvents\Event\Event;
+
 class Stats_Importer {
 	/**
 	 * Imports the contributions a user made while a given event was active.
 	 */
-	public function import_for_user_and_event( int $user_id, int $event_id ): void {
-		// TODO.
+	public function import_for_user_and_event( int $user_id, Event $event ): void {
+		global $wpdb, $gp_table_prefix;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"
+				insert ignore into {$gp_table_prefix}event_actions
+				    (event_id, user_id, original_id, locale, action, happened_at)
+				select %d, t.user_id, t.original_id, ts.slug, %s, t.date_added
+				from {$gp_table_prefix}translations t,
+				     {$gp_table_prefix}translation_sets ts
+				where t.user_id = %d
+				  and t.translation_set_id = ts.id
+				  AND date_added >= %s
+				  AND date_added <= %s
+				",
+				array(
+					'event_id'          => $event->id(),
+					'action'            => Stats_Listener::ACTION_CREATE,
+					'user_id'           => $user_id,
+					'date_added_after'  => $event->start()->utc()->format( 'Y-m-d H:i:s' ),
+					'date_added_before' => $event->end()->utc()->format( 'Y-m-d H:i:s' ),
+				),
+			),
+		);
+		// phpcs:enable
 	}
 }

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -24,7 +24,7 @@ class Stats_Importer {
 				     {$gp_table_prefix}translation_sets ts
 				where t.user_id = %d
 				  and t.translation_set_id = ts.id
-				  and t.status in ('current', 'waiting', 'changesrequested', 'fuzzy' )
+				  and t.status in ( 'current', 'waiting', 'changesrequested', 'fuzzy' )
 				  and date_added between %s and %s
 				",
 				array(

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -19,7 +19,7 @@ class Stats_Importer {
 				"
 				insert ignore into {$gp_table_prefix}event_actions
 				    (event_id, user_id, original_id, locale, action, happened_at)
-				select %d, t.user_id, t.original_id, ts.slug, %s, t.date_added
+				select %d, t.user_id, t.original_id, ts.locale, %s, t.date_added
 				from {$gp_table_prefix}translations t,
 				     {$gp_table_prefix}translation_sets ts
 				where t.user_id = %d

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Wporg\TranslationEvents\Stats;
+
+class Stats_Importer {
+	/**
+	 * Imports the contributions a user made while a given event was active.
+	 */
+	public function import_for_user_and_event( int $user_id, int $event_id ): void {
+		// TODO.
+	}
+}

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -24,7 +24,7 @@ class Stats_Importer {
 				     {$gp_table_prefix}translation_sets ts
 				where t.user_id = %d
 				  and t.translation_set_id = ts.id
-				  and ( t.status = 'current' or t.status = 'waiting' or t.status = 'changesrequested' or status = 'fuzzy' )
+				  and t.status in ('current', 'waiting', 'changesrequested', 'fuzzy' )
 				  and date_added >= %s
 				  AND date_added <= %s
 				",

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -25,8 +25,7 @@ class Stats_Importer {
 				where t.user_id = %d
 				  and t.translation_set_id = ts.id
 				  and t.status in ('current', 'waiting', 'changesrequested', 'fuzzy' )
-				  and date_added >= %s
-				  AND date_added <= %s
+				  and date_added between %s and %s
 				",
 				array(
 					'event_id'          => $event->id(),

--- a/includes/stats/stats-importer.php
+++ b/includes/stats/stats-importer.php
@@ -24,7 +24,8 @@ class Stats_Importer {
 				     {$gp_table_prefix}translation_sets ts
 				where t.user_id = %d
 				  and t.translation_set_id = ts.id
-				  AND date_added >= %s
+				  and ( t.status = 'current' or t.status = 'waiting' or t.status = 'changesrequested' or status = 'fuzzy' )
+				  and date_added >= %s
 				  AND date_added <= %s
 				",
 				array(

--- a/includes/stats/stats-listener.php
+++ b/includes/stats/stats-listener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Stats;
 
 use DateTimeImmutable;
 use DateTimeZone;

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -5,6 +5,7 @@ namespace Wporg\TranslationEvents;
 use Exception;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee\Attendee;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 class Upgrade {
 	private const VERSION        = 2;

--- a/templates/event.php
+++ b/templates/event.php
@@ -7,6 +7,8 @@ namespace Wporg\TranslationEvents;
 
 use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
+use Wporg\TranslationEvents\Stats\Event_Stats;
+use Wporg\TranslationEvents\Stats\Stats_Row;
 
 /** @var int $event_id */
 /** @var string $event_title */

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -6,6 +6,7 @@
 namespace Wporg\TranslationEvents;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 /** @var Events_Query_Result $events_i_created_query */
 /** @var Events_Query_Result $events_i_attended_query */

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -14,6 +14,7 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 
 class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	private Event_Repository_Cached $repository;
+	private Event_Factory $event_factory;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -72,4 +72,44 @@ class Event_Test extends WP_UnitTestCase {
 			'',
 		);
 	}
+
+	public function test_is_active() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$start    = new Event_Start_Date( 'now' );
+		$end      = new Event_End_Date( 'now' );
+
+		$past_event = new Event(
+			0,
+			$start->modify( '-1 hour' ),
+			$end,
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$active_event = new Event(
+			0,
+			$start,
+			$end->modify( '+1 hour' ),
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$future_event = new Event(
+			0,
+			$start->modify( '+1 hour' ),
+			$end->modify( '+2 hours' ),
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$this->assertFalse( $past_event->is_active() );
+		$this->assertTrue( $active_event->is_active() );
+		$this->assertFalse( $future_event->is_active() );
+	}
 }

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -112,4 +112,44 @@ class Event_Test extends WP_UnitTestCase {
 		$this->assertTrue( $active_event->is_active() );
 		$this->assertFalse( $future_event->is_active() );
 	}
+
+	public function test_is_past() {
+		$timezone = new DateTimeZone( 'Europe/Lisbon' );
+		$start    = new Event_Start_Date( 'now' );
+		$end      = new Event_End_Date( 'now' );
+
+		$past_event = new Event(
+			0,
+			$start->modify( '-1 hour' ),
+			$end->modify( '-30 minutes' ),
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$active_event = new Event(
+			0,
+			$start,
+			$end->modify( '+1 hour' ),
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$future_event = new Event(
+			0,
+			$start->modify( '+1 hour' ),
+			$end->modify( '+2 hours' ),
+			$timezone,
+			'publish',
+			'Foo title',
+			'',
+		);
+
+		$this->assertTrue( $past_event->is_past() );
+		$this->assertFalse( $active_event->is_past() );
+		$this->assertFalse( $future_event->is_past() );
+	}
 }

--- a/tests/lib/stats-factory.php
+++ b/tests/lib/stats-factory.php
@@ -45,7 +45,7 @@ class Stats_Factory {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $wpdb->get_row( $wpdb->prepare( "select * from {$gp_table_prefix}event_actions where event_id = %s", $event_id ), ARRAY_A );
+		return $wpdb->get_results( $wpdb->prepare( "select * from {$gp_table_prefix}event_actions where event_id = %s", $event_id ), ARRAY_A );
 		// phpcs:enable
 	}
 }

--- a/tests/lib/translation-factory.php
+++ b/tests/lib/translation-factory.php
@@ -13,7 +13,7 @@ class Translation_Factory {
 		$this->set        = $this->gp_factory->translation_set->create_with_project_and_locale();
 	}
 
-	public function create( int $user_id ) {
+	public function create( int $user_id, $date_added = null ) {
 		$original = $this->gp_factory->original->create(
 			array(
 				'project_id' => $this->set->project->id,
@@ -21,8 +21,11 @@ class Translation_Factory {
 				'singular'   => 'foo',
 			)
 		);
+		if ( $date_added ) {
+			$original->update( array( 'date_added' => $date_added ) );
+		}
 
-		return $this->gp_factory->translation->create(
+		$translation = $this->gp_factory->translation->create(
 			array(
 				'user_id'            => $user_id,
 				'translation_set_id' => $this->set->id,
@@ -30,5 +33,9 @@ class Translation_Factory {
 				'status'             => 'waiting',
 			)
 		);
+		if ( $date_added ) {
+			$translation->update( array( 'date_added' => $date_added ) );
+		}
+		return $translation;
 	}
 }

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Wporg\Tests;
+namespace Wporg\Tests\Stats;
 
 use GP_UnitTestCase;
-use Wporg\TranslationEvents\Stats_Calculator;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -39,7 +39,7 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		$event    = $this->event_repository->get_event( $event_id );
 
 		// Create translations while the event is active.
-		$translation0 = $this->translation_factory->create( $user_id, date( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
+		$translation0 = $this->translation_factory->create( $user_id, gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
 		$translation1 = $this->translation_factory->create( $user_id );
 		$translation2 = $this->translation_factory->create( $user_id );
 

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -39,6 +39,7 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		$event    = $this->event_repository->get_event( $event_id );
 
 		// Create translations while the event is active.
+		$translation0 = $this->translation_factory->create( $user_id, date( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
 		$translation1 = $this->translation_factory->create( $user_id );
 		$translation2 = $this->translation_factory->create( $user_id );
 

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -2,7 +2,11 @@
 
 namespace Wporg\Tests\Stats;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Stats\Stats_Importer;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
@@ -13,17 +17,58 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Stats_Importer $importer;
+	private Event_Repository $event_repository;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->translation_factory = new Translation_Factory( $this->factory );
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
+		$this->event_repository    = new Event_Repository( new Attendee_Repository() );
 		$this->importer            = new Stats_Importer();
 	}
 
 	public function test_import_for_user_and_event() {
-		// TODO.
-		$this->markTestSkipped();
+		$this->set_normal_user_as_current();
+		$user_id = wp_get_current_user()->ID;
+
+		// Create a translation before the event starts, which should not be imported.
+		$this->translation_factory->create( $user_id );
+
+		// Wait for the event to start.
+		// It needs to be 2 seconds because the event starts at "now -1 second".
+		// TODO: This makes test runs take longer, we should find another way.
+		sleep( 2 );
+
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->event_repository->get_event( $event_id );
+
+		// Create translations while the event is active.
+		$translation1 = $this->translation_factory->create( $user_id );
+		$translation2 = $this->translation_factory->create( $user_id );
+
+		// Make sure no stats were created yet.
+		$this->assertEquals( 0, $this->stats_factory->get_count() );
+
+		$this->importer->import_for_user_and_event( $user_id, $event );
+
+		$stats = $this->stats_factory->get_by_event_id( $event_id );
+		$this->assertCount( 2, $stats );
+
+		$stats1 = $stats[0];
+		$this->assertEquals( $event_id, $stats1['event_id'] );
+		$this->assertEquals( $user_id, $stats1['user_id'] );
+		$this->assertEquals( $translation1->original_id, $stats1['original_id'] );
+		$this->assertEquals( 'create', $stats1['action'] );
+		$this->assertEquals( 'default', $stats1['locale'] );
+		$this->assertEquals( $translation1->date_added, $stats1['happened_at'] );
+
+		$stats2 = $stats[1];
+		$this->assertEquals( $event_id, $stats2['event_id'] );
+		$this->assertEquals( $user_id, $stats2['user_id'] );
+		$this->assertEquals( $translation2->original_id, $stats2['original_id'] );
+		$this->assertEquals( 'create', $stats2['action'] );
+		$this->assertEquals( 'default', $stats2['locale'] );
+		$this->assertEquals( $translation2->date_added, $stats1['happened_at'] );
 	}
 }

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wporg\Tests\Stats;
+
+use GP_UnitTestCase;
+use Wporg\TranslationEvents\Stats\Stats_Importer;
+use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Tests\Stats_Factory;
+use Wporg\TranslationEvents\Tests\Translation_Factory;
+
+class Stats_Importer_Test extends GP_UnitTestCase {
+	private Translation_Factory $translation_factory;
+	private Event_Factory $event_factory;
+	private Stats_Factory $stats_factory;
+	private Stats_Importer $importer;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->translation_factory = new Translation_Factory( $this->factory );
+		$this->event_factory       = new Event_Factory();
+		$this->stats_factory       = new Stats_Factory();
+		$this->importer            = new Stats_Importer();
+	}
+
+	public function test_import_for_user_and_event() {
+		// TODO.
+		$this->markTestSkipped();
+	}
+}

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -33,13 +33,12 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		$user_id = wp_get_current_user()->ID;
 
 		// Create a translation before the event starts, which should not be imported.
-		$this->translation_factory->create( $user_id );
+		$this->translation_factory->create( $user_id, gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
 
 		$event_id = $this->event_factory->create_active( array(), new DateTimeImmutable( '5 minutes ago', new DateTimeZone( 'UTC' ) ) );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		// Create translations while the event is active.
-		$translation0 = $this->translation_factory->create( $user_id, gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS ) );
 		$translation1 = $this->translation_factory->create( $user_id );
 		$translation2 = $this->translation_factory->create( $user_id );
 

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -4,6 +4,7 @@ namespace Wporg\Tests\Stats;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use GP_Translation;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -41,6 +42,14 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		// Create translations while the event is active.
 		$translation1 = $this->translation_factory->create( $user_id );
 		$translation2 = $this->translation_factory->create( $user_id );
+
+		/** @var GP_Translation $translation_rejected  */
+		/** @var GP_Translation $translation_old  */
+		$translation_rejected = $this->translation_factory->create( $user_id );
+		$translation_old      = $this->translation_factory->create( $user_id );
+
+		$translation_rejected->update( array( 'status' => 'rejected' ) );
+		$translation_old->update( array( 'status' => 'old' ) );
 
 		// Make sure no stats were created yet.
 		$this->assertEquals( 0, $this->stats_factory->get_count() );

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -35,12 +35,7 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		// Create a translation before the event starts, which should not be imported.
 		$this->translation_factory->create( $user_id );
 
-		// Wait for the event to start.
-		// It needs to be 2 seconds because the event starts at "now -1 second".
-		// TODO: This makes test runs take longer, we should find another way.
-		sleep( 2 );
-
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( array(), new DateTimeImmutable( '5 minutes ago', new DateTimeZone( 'UTC' ) ) );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		// Create translations while the event is active.

--- a/tests/stats/stats-importer.php
+++ b/tests/stats/stats-importer.php
@@ -55,7 +55,7 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		$this->assertEquals( $user_id, $stats1['user_id'] );
 		$this->assertEquals( $translation1->original_id, $stats1['original_id'] );
 		$this->assertEquals( 'create', $stats1['action'] );
-		$this->assertEquals( 'default', $stats1['locale'] );
+		$this->assertEquals( 'aa', $stats1['locale'] );
 		$this->assertEquals( $translation1->date_added, $stats1['happened_at'] );
 
 		$stats2 = $stats[1];
@@ -63,7 +63,7 @@ class Stats_Importer_Test extends GP_UnitTestCase {
 		$this->assertEquals( $user_id, $stats2['user_id'] );
 		$this->assertEquals( $translation2->original_id, $stats2['original_id'] );
 		$this->assertEquals( 'create', $stats2['action'] );
-		$this->assertEquals( 'default', $stats2['locale'] );
+		$this->assertEquals( 'aa', $stats2['locale'] );
 		$this->assertEquals( $translation2->date_added, $stats1['happened_at'] );
 	}
 }

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -83,14 +83,14 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$stats_count = $this->stats_factory->get_count();
 		$this->assertEquals( 2, $stats_count );
 
-		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id );
+		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id )[0];
 		$this->assertEquals( $event1_id, $event1_stats['event_id'] );
 		$this->assertEquals( $user_id, $event1_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event1_stats['original_id'] );
 		$this->assertEquals( 'create', $event1_stats['action'] );
 		$this->assertEquals( 'aa', $event1_stats['locale'] );
 
-		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id );
+		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id )[0];
 		$this->assertEquals( $event2_id, $event2_stats['event_id'] );
 		$this->assertEquals( $user_id, $event2_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event2_stats['original_id'] );
@@ -117,14 +117,14 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$stats_count = $this->stats_factory->get_count();
 		$this->assertEquals( 2, $stats_count );
 
-		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id );
+		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id )[0];
 		$this->assertEquals( $event1_id, $event1_stats['event_id'] );
 		$this->assertEquals( $user_id, $event1_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event1_stats['original_id'] );
 		$this->assertEquals( 'approve', $event1_stats['action'] );
 		$this->assertEquals( 'aa', $event1_stats['locale'] );
 
-		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id );
+		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id )[0];
 		$this->assertEquals( $event2_id, $event2_stats['event_id'] );
 		$this->assertEquals( $user_id, $event2_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event2_stats['original_id'] );
@@ -151,14 +151,14 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$stats_count = $this->stats_factory->get_count();
 		$this->assertEquals( 2, $stats_count );
 
-		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id );
+		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id )[0];
 		$this->assertEquals( $event1_id, $event1_stats['event_id'] );
 		$this->assertEquals( $user_id, $event1_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event1_stats['original_id'] );
 		$this->assertEquals( 'reject', $event1_stats['action'] );
 		$this->assertEquals( 'aa', $event1_stats['locale'] );
 
-		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id );
+		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id )[0];
 		$this->assertEquals( $event2_id, $event2_stats['event_id'] );
 		$this->assertEquals( $user_id, $event2_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event2_stats['original_id'] );
@@ -185,14 +185,14 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$stats_count = $this->stats_factory->get_count();
 		$this->assertEquals( 2, $stats_count );
 
-		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id );
+		$event1_stats = $this->stats_factory->get_by_event_id( $event1_id )[0];
 		$this->assertEquals( $event1_id, $event1_stats['event_id'] );
 		$this->assertEquals( $user_id, $event1_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event1_stats['original_id'] );
 		$this->assertEquals( 'request_changes', $event1_stats['action'] );
 		$this->assertEquals( 'aa', $event1_stats['locale'] );
 
-		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id );
+		$event2_stats = $this->stats_factory->get_by_event_id( $event2_id )[0];
 		$this->assertEquals( $event2_id, $event2_stats['event_id'] );
 		$this->assertEquals( $user_id, $event2_stats['user_id'] );
 		$this->assertEquals( $translation->original_id, $event2_stats['original_id'] );

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Wporg\Tests;
+namespace Wporg\Tests\Stats;
 
 use GP_Translation;
 use GP_UnitTestCase;

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -29,6 +29,7 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
+use Wporg\TranslationEvents\Stats\Stats_Listener;
 
 class Translation_Events {
 	public const CPT = 'translation_event';


### PR DESCRIPTION
Fix #161 

## Summary of changes

- Move stats-related code to a `Stats` namespace
- Add `is_active()` and `is_past()` methods to `Event`
- Add a `Stats_Importer` for importing stats
- Add `Stats_Importer::import_for_user_and_event( $user_id, $event_id )`
- When a user attends an event that is active at that moment, call `import_for_user_and_event()`
- Make sure it's not possible to attend/un-attend past events

## Testing instructions

1. Login as User A
2. Create a translation
1. Login as User B
3. Create an event and make it start now
4. Login as User A
6. Navigate to the page of the event you created above, and click the "Attend" button
7. Create a translation
8. You should now be listed as a contributor, and the stats table should show **a single translation** (it should not count the first translation, created above in 2., as the event hadn't started yet)
