### PR TITLE
New translation contributor

### DIFF
--- a/includes/stats/stats-calculator.php
+++ b/includes/stats/stats-calculator.php
@@ -311,15 +311,16 @@ class Stats_Calculator {
 	 */
 	public function is_first_time_contributor( $event_start, $user_id ) {
 		global $wpdb, $gp_table_prefix;
+		$new_contributor_max_translation_count = 10;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange
-		$users_first_translation_date = $wpdb->get_var(
+		$user_translations_count = $wpdb->get_var(
 			$wpdb->prepare(
 				"
-			select min(date_added) from {$gp_table_prefix}translations where user_id = %d
+			select count(*) from {$gp_table_prefix}translations where user_id = %d
 		",
 				array(
 					$user_id,
@@ -327,13 +328,9 @@ class Stats_Calculator {
 			)
 		);
 
-		if ( get_userdata( $user_id ) && ! $users_first_translation_date ) {
+		if ( get_userdata( $user_id ) && ! $user_translations_count ) {
 			return true;
 		}
-		$event_start_date_time  = new DateTimeImmutable( $event_start->__toString(), new DateTimeZone( 'UTC' ) );
-		$first_translation_date = new DateTimeImmutable( $users_first_translation_date, new DateTimeZone( 'UTC' ) );
-		// A first time contributor is someone whose first translation was made not earlier than 24 hours before the event.
-		$event_start_date_time = $event_start_date_time->modify( '-1 day' );
-		return $event_start_date_time <= $first_translation_date;
+		return $user_translations_count <= $new_contributor_max_translation_count;
 	}
 }

--- a/includes/stats/stats-calculator.php
+++ b/includes/stats/stats-calculator.php
@@ -302,14 +302,13 @@ class Stats_Calculator {
 	}
 
 	/**
-	 * Check if a user is a first time contributor.
+	 * Check if a user is a new translation contributor. A new contributor is a user who has made 10 or fewer translations.
 	 *
-	 * @param Event_Start_Date $event_start The event start date.
-	 * @param int              $user_id      The user ID.
+	 * @param int $user_id      The user ID.
 	 *
-	 * @return bool True if the user is a first time contributor, false otherwise.
+	 * @return bool True if the user is a new translation contributor, false otherwise.
 	 */
-	public function is_first_time_contributor( $event_start, $user_id ) {
+	public function is_new_translation_contributor( $user_id ) {
 		global $wpdb, $gp_table_prefix;
 		$new_contributor_max_translation_count = 10;
 

--- a/includes/stats/stats-calculator.php
+++ b/includes/stats/stats-calculator.php
@@ -302,16 +302,17 @@ class Stats_Calculator {
 	}
 
 	/**
-	 * Check if a user is a new translation contributor. A new contributor is a user who has made 10 or fewer translations.
+	 * Check if a user is a new translation contributor. A new contributor is a user who has made 10 or fewer translations before event start time.
 	 *
-	 * @param int $user_id      The user ID.
+	 * @param Event_Start_Date $event_start The event start date.
+	 * @param int              $user_id      The user ID.
 	 *
 	 * @return bool True if the user is a new translation contributor, false otherwise.
 	 */
-	public function is_new_translation_contributor( $user_id ) {
+	public function is_new_translation_contributor( $event_start, $user_id ) {
 		global $wpdb, $gp_table_prefix;
 		$new_contributor_max_translation_count = 10;
-
+		$event_start_date_time                 = $event_start->__toString();
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -319,10 +320,11 @@ class Stats_Calculator {
 		$user_translations_count = $wpdb->get_var(
 			$wpdb->prepare(
 				"
-			select count(*) from {$gp_table_prefix}translations where user_id = %d
+			select count(*) from {$gp_table_prefix}translations where user_id = %d and date_added < %s
 		",
 				array(
 					$user_id,
+					$event_start_date_time,
 				)
 			)
 		);

--- a/templates/event.php
+++ b/templates/event.php
@@ -49,7 +49,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 						<li class="event-contributor" title="<?php echo esc_html( implode( ', ', $contributor->locales ) ); ?>">
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->ID ) ); ?>" class="avatar"><?php echo get_avatar( $contributor->ID, 48 ); ?></a>
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->ID ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $contributor->ID ) ); ?></a>
-							<?php if ( $stats_calculator->is_first_time_contributor( $event_start, $contributor->ID ) ) : ?>
+							<?php if ( $stats_calculator->is_new_translation_contributor( $contributor->ID ) ) : ?>
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
@@ -83,7 +83,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 						<li class="event-attendee">
 							<a href="<?php echo esc_url( get_author_posts_url( $_user->ID ) ); ?>" class="avatar"><?php echo get_avatar( $_user->ID, 48 ); ?></a>
 							<a href="<?php echo esc_url( get_author_posts_url( $_user->ID ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $_user->ID ) ); ?></a>
-							<?php if ( $stats_calculator->is_first_time_contributor( $event_start, $_user->ID ) ) : ?>
+							<?php if ( $stats_calculator->is_new_translation_contributor( $_user->ID ) ) : ?>
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
@@ -199,7 +199,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								array_map(
 									function ( $contributor ) use ( $stats_calculator, $event_start ) {
 										$append_tada = '';
-										if ( $stats_calculator->is_first_time_contributor( $event_start, $contributor->ID ) ) {
+										if ( $stats_calculator->is_new_translation_contributor( $contributor->ID ) ) {
 											$append_tada = '<span class="first-time-contributor-tada" title="' . esc_html__( 'New Translation Contributor', 'gp-translation-events' ) . '"></span>';
 										}
 										return '@' . $contributor->user_login . $append_tada;

--- a/templates/event.php
+++ b/templates/event.php
@@ -49,7 +49,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 						<li class="event-contributor" title="<?php echo esc_html( implode( ', ', $contributor->locales ) ); ?>">
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->ID ) ); ?>" class="avatar"><?php echo get_avatar( $contributor->ID, 48 ); ?></a>
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->ID ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $contributor->ID ) ); ?></a>
-							<?php if ( $stats_calculator->is_new_translation_contributor( $contributor->ID ) ) : ?>
+							<?php if ( $stats_calculator->is_new_translation_contributor( $event_start, $contributor->ID ) ) : ?>
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
@@ -83,7 +83,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 						<li class="event-attendee">
 							<a href="<?php echo esc_url( get_author_posts_url( $_user->ID ) ); ?>" class="avatar"><?php echo get_avatar( $_user->ID, 48 ); ?></a>
 							<a href="<?php echo esc_url( get_author_posts_url( $_user->ID ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $_user->ID ) ); ?></a>
-							<?php if ( $stats_calculator->is_new_translation_contributor( $_user->ID ) ) : ?>
+							<?php if ( $stats_calculator->is_new_translation_contributor( $event_start, $_user->ID ) ) : ?>
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
@@ -199,7 +199,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								array_map(
 									function ( $contributor ) use ( $stats_calculator, $event_start ) {
 										$append_tada = '';
-										if ( $stats_calculator->is_new_translation_contributor( $contributor->ID ) ) {
+										if ( $stats_calculator->is_new_translation_contributor( $event_start, $contributor->ID ) ) {
 											$append_tada = '<span class="first-time-contributor-tada" title="' . esc_html__( 'New Translation Contributor', 'gp-translation-events' ) . '"></span>';
 										}
 										return '@' . $contributor->user_login . $append_tada;


### PR DESCRIPTION
Fixes #213 
In this PR, first time contributors will now be known as "new translation contributors". We have also updated the logic for determining who a new translation contributor is by checking if they have submitted only 10 or fewer translations before the start time of the event.

**Test 1**
- Create a new user and join an event, the tada emoji should show beside their name on the attendee list on the event page.

**Test 2**
- Create a new user
- Create event and set the start time to a few minutes or hours later
- Create 11 or more translations before the start time of that event, then join the event.
- The tada emoji should not show beside their name on the attendee list on the event page.
