### PR TITLE
Event capabilities

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/includes/event/event-repository-interface.php';
 require_once __DIR__ . '/includes/event/event-repository.php';
 require_once __DIR__ . '/includes/event/event-repository-cached.php';
 require_once __DIR__ . '/includes/event/event-form-handler.php';
+require_once __DIR__ . '/includes/event/event-capabilities.php';
 require_once __DIR__ . '/includes/stats/stats-calculator.php';
 require_once __DIR__ . '/includes/stats/stats-importer.php';
 require_once __DIR__ . '/includes/stats/stats-listener.php';

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -130,7 +130,7 @@ class Event_Capabilities {
 			return false;
 		}
 
-		if ( user_can( $user->ID, 'manage_options' ) ) {
+		if ( user_can( $user->ID, 'delete_post', $event->id() ) ) {
 			return true;
 		}
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -4,6 +4,8 @@ namespace Wporg\TranslationEvents\Event;
 
 use GP;
 use WP_User;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 class Event_Capabilities {
 	private const CREATE = 'create_translation_event';
@@ -18,9 +20,17 @@ class Event_Capabilities {
 	);
 
 	private Event_Repository_Interface $event_repository;
+	private Attendee_Repository $attendee_repository;
+	private Stats_Calculator $stats_calculator;
 
-	public function __construct( Event_Repository_Interface $event_repository ) {
-		$this->event_repository = $event_repository;
+	public function __construct(
+		Event_Repository_Interface $event_repository,
+		Attendee_Repository $attendee_repository,
+		Stats_Calculator $stats_calculator
+	) {
+		$this->event_repository    = $event_repository;
+		$this->attendee_repository = $attendee_repository;
+		$this->stats_calculator    = $stats_calculator;
 	}
 
 	/**

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -10,6 +10,7 @@ use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 class Event_Capabilities {
 	private const CREATE = 'create_translation_event';
+	private const VIEW   = 'view_translation_event';
 	private const EDIT   = 'edit_translation_event';
 	private const DELETE = 'delete_translation_event';
 
@@ -18,6 +19,7 @@ class Event_Capabilities {
 	 */
 	private const CAPS = array(
 		self::CREATE,
+		self::VIEW,
 		self::EDIT,
 		self::DELETE,
 	);
@@ -48,6 +50,15 @@ class Event_Capabilities {
 		switch ( $cap ) {
 			case self::CREATE:
 				return $this->has_create( $user );
+			case self::VIEW:
+				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
+					return false;
+				}
+				$event = $this->event_repository->get_event( $args[2] );
+				if ( ! $event ) {
+					return false;
+				}
+				return $this->has_view( $user, $event );
 			case self::EDIT:
 				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
 					return false;
@@ -79,6 +90,21 @@ class Event_Capabilities {
 	 */
 	private function has_create( WP_User $user ): bool {
 		return $this->is_gp_admin( $user );
+	}
+
+	/**
+	 * Evaluate whether a user can view a specific event.
+	 *
+	 * @param WP_User $user  User for which we're evaluating the capability.
+	 * @param Event   $event Event for which we're evaluating the capability.
+	 * @return bool
+	 */
+	private function has_view( WP_User $user, Event $event ): bool {
+		if ( $this->is_gp_admin( $user ) ) {
+			return true;
+		}
+
+		return 'publish' === $event->status();
 	}
 
 	/**

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Wporg\TranslationEvents\Event;
+
+use WP_User;
+
+class Event_Capabilities {
+	private const CREATE = 'create_translation_event';
+
+	private const CAPS = array(
+		self::CREATE,
+	);
+
+	private function has_cap( string $cap, array $args, WP_User $user ): bool {
+		switch ( $cap ) {
+			case self::CREATE:
+				return $this->has_create( $user );
+		}
+
+		return false;
+	}
+
+	private function has_create( WP_User $user ): bool {
+		// TODO.
+		return true;
+	}
+
+	public function register_hooks(): void {
+		add_action(
+			'user_has_cap',
+			function ( $allcaps, $caps, $args, $user ) {
+				foreach ( $caps as $cap ) {
+					if ( ! in_array( $cap, self::CAPS, true ) ) {
+						continue;
+					}
+					if ( $this->has_cap( $cap, $args, $user ) ) {
+						$allcaps[ $cap ] = true;
+					}
+				}
+				return $allcaps;
+			},
+			10,
+			4,
+		);
+	}
+}

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -53,10 +53,10 @@ class Event_Capabilities {
 			case self::VIEW:
 			case self::EDIT:
 			case self::DELETE:
-				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
+				if ( ! isset( $args[2] ) || ! is_numeric( $args[2] ) ) {
 					return false;
 				}
-				$event = $this->event_repository->get_event( $args[2] );
+				$event = $this->event_repository->get_event( intval( $args[2] ) );
 				if ( ! $event ) {
 					return false;
 				}

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -2,6 +2,7 @@
 
 namespace Wporg\TranslationEvents\Event;
 
+use GP;
 use WP_User;
 
 class Event_Capabilities {
@@ -21,8 +22,11 @@ class Event_Capabilities {
 	}
 
 	private function has_create( WP_User $user ): bool {
-		// TODO.
-		return true;
+		return $this->has_gp_crud( $user );
+	}
+
+	private function has_gp_crud( WP_User $user ): bool {
+		return apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->user_can( $user, 'admin' ) );
 	}
 
 	public function register_hooks(): void {

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -7,12 +7,14 @@ use WP_User;
 
 class Event_Capabilities {
 	private const CREATE = 'create_translation_event';
+	private const EDIT   = 'edit_translation_event';
 
 	/**
 	 * All the capabilities that concern an Event.
 	 */
 	private const CAPS = array(
 		self::CREATE,
+		self::EDIT,
 	);
 
 	private Event_Repository_Interface $event_repository;
@@ -33,6 +35,15 @@ class Event_Capabilities {
 		switch ( $cap ) {
 			case self::CREATE:
 				return $this->has_create( $user );
+			case self::EDIT:
+				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
+					return false;
+				}
+				$event = $this->event_repository->get_event( $args[2] );
+				if ( ! $event ) {
+					return false;
+				}
+				return $this->has_edit( $user, $event );
 		}
 
 		return false;
@@ -46,6 +57,18 @@ class Event_Capabilities {
 	 */
 	private function has_create( WP_User $user ): bool {
 		return $this->is_gp_admin( $user );
+	}
+
+	/**
+	 * Evaluate whether a user can edit a specific event.
+	 *
+	 * @param WP_User $user  User for which we're evaluating the capability.
+	 * @param Event   $event Event for which we're evaluating the capability.
+	 * @return bool
+	 */
+	private function has_edit( WP_User $user, Event $event ): bool {
+		// TODO.
+		return false;
 	}
 
 	/**

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -63,9 +63,11 @@ class Event_Capabilities {
 
 				if ( self::VIEW === $cap ) {
 					return $this->has_view( $user, $event );
-				} elseif ( self::EDIT === $cap ) {
+				}
+				if ( self::EDIT === $cap ) {
 					return $this->has_edit( $user, $event );
-				} elseif ( self::DELETE === $cap ) {
+				}
+				if ( self::DELETE === $cap ) {
 					return $this->has_delete( $user, $event );
 				}
 				break;

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -110,6 +110,10 @@ class Event_Capabilities {
 			return true;
 		}
 
+		if ( $this->is_gp_admin( $user ) ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -4,6 +4,7 @@ namespace Wporg\TranslationEvents\Event;
 
 use GP;
 use WP_User;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
@@ -77,7 +78,27 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit( WP_User $user, Event $event ): bool {
-		// TODO.
+		if ( $event->end()->is_in_the_past() ) {
+			return false;
+		}
+
+		if ( $this->stats_calculator->event_has_stats( $event->id() ) ) {
+			return false;
+		}
+
+		if ( $event->author_id() === $user->ID ) {
+			return true;
+		}
+
+		if ( user_can( $user->ID, 'edit_post', $event->id() ) ) {
+			return true;
+		}
+
+		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		if ( ( $attendee instanceof Attendee ) && $attendee->is_host() ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -51,23 +51,7 @@ class Event_Capabilities {
 			case self::CREATE:
 				return $this->has_create( $user );
 			case self::VIEW:
-				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
-					return false;
-				}
-				$event = $this->event_repository->get_event( $args[2] );
-				if ( ! $event ) {
-					return false;
-				}
-				return $this->has_view( $user, $event );
 			case self::EDIT:
-				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
-					return false;
-				}
-				$event = $this->event_repository->get_event( $args[2] );
-				if ( ! $event ) {
-					return false;
-				}
-				return $this->has_edit( $user, $event );
 			case self::DELETE:
 				if ( ! isset( $args[2] ) || ! is_int( $args[2] ) ) {
 					return false;
@@ -76,7 +60,15 @@ class Event_Capabilities {
 				if ( ! $event ) {
 					return false;
 				}
-				return $this->has_delete( $user, $event );
+
+				if ( self::VIEW === $cap ) {
+					return $this->has_view( $user, $event );
+				} elseif ( self::EDIT === $cap ) {
+					return $this->has_edit( $user, $event );
+				} elseif ( self::DELETE === $cap ) {
+					return $this->has_delete( $user, $event );
+				}
+				break;
 		}
 
 		return false;

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -15,6 +15,12 @@ class Event_Capabilities {
 		self::CREATE,
 	);
 
+	private Event_Repository_Interface $event_repository;
+
+	public function __construct( Event_Repository_Interface $event_repository ) {
+		$this->event_repository = $event_repository;
+	}
+
 	/**
 	 * This function is automatically called whenever user_can() is called for one the capabilities in self::CAPS.
 	 *

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -8,10 +8,21 @@ use WP_User;
 class Event_Capabilities {
 	private const CREATE = 'create_translation_event';
 
+	/**
+	 * All the capabilities that concern an Event.
+	 */
 	private const CAPS = array(
 		self::CREATE,
 	);
 
+	/**
+	 * This function is automatically called whenever user_can() is called for one the capabilities in self::CAPS.
+	 *
+	 * @param string  $cap  Requested capability.
+	 * @param array   $args Arguments that accompany the requested capability check.
+	 * @param WP_User $user User for which we're evaluating the capability.
+	 * @return bool
+	 */
 	private function has_cap( string $cap, array $args, WP_User $user ): bool {
 		switch ( $cap ) {
 			case self::CREATE:
@@ -21,11 +32,23 @@ class Event_Capabilities {
 		return false;
 	}
 
+	/**
+	 * Evaluate whether a user can create events.
+	 *
+	 * @param WP_User $user User for which we're evaluating the capability.
+	 * @return bool
+	 */
 	private function has_create( WP_User $user ): bool {
-		return $this->has_gp_crud( $user );
+		return $this->is_gp_admin( $user );
 	}
 
-	private function has_gp_crud( WP_User $user ): bool {
+	/**
+	 * Evaluate whether a user is a GlotPress admin.
+	 *
+	 * @param WP_User $user User for which we're evaluating the capability.
+	 * @return bool
+	 */
+	private function is_gp_admin( WP_User $user ): bool {
 		return apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->user_can( $user, 'admin' ) );
 	}
 

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -25,13 +25,15 @@ class Event_Form_Handler {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
 
+		$event_id = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : 0;
+
 		if ( 'create_event' === $action && ( ! current_user_can( 'create_translation_event' ) ) ) {
 			wp_send_json_error( esc_html__( 'You do not have permissions to create events.', 'gp-translation-events' ), 403 );
 		}
-		if ( 'edit_event' === $action && ( ! current_user_can( 'edit_translation_event' ) ) ) {
+		if ( 'edit_event' === $action && ( ! current_user_can( 'edit_translation_event', $event_id ) ) ) {
 			wp_send_json_error( esc_html__( 'You do not have permissions to edit this event.', 'gp-translation-events' ), 403 );
 		}
-		if ( 'delete_event' === $action && ( ! current_user_can( 'delete_translation_event' ) ) ) {
+		if ( 'delete_event' === $action && ( ! current_user_can( 'delete_translation_event', $event_id ) ) ) {
 			wp_send_json_error( esc_html__( 'You do not have permissions to delete this event.', 'gp-translation-events' ), 403 );
 		}
 

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -37,7 +37,7 @@ class Event_Form_Handler {
 		 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
 		 */
 		$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
-		if ( 'create_event' === $action && ( ! $can_crud_event ) ) {
+		if ( 'create_event' === $action && ( ! current_user_can( 'create_translation_event' ) ) ) {
 			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
 		}
 		if ( 'edit_event' === $action ) {

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -19,10 +19,8 @@ class Event_Form_Handler {
 		if ( ! is_user_logged_in() ) {
 			wp_send_json_error( esc_html__( 'The user must be logged in.', 'gp-translation-events' ), 403 );
 		}
-		$action           = isset( $form_data['form_name'] ) ? sanitize_text_field( wp_unslash( $form_data['form_name'] ) ) : '';
-		$response_message = '';
-		$is_nonce_valid   = false;
-		$nonce_name       = '_event_nonce';
+
+		$action = isset( $form_data['form_name'] ) ? sanitize_text_field( wp_unslash( $form_data['form_name'] ) ) : '';
 		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
@@ -37,6 +35,8 @@ class Event_Form_Handler {
 			wp_send_json_error( esc_html__( 'You do not have permissions to delete this event.', 'gp-translation-events' ), 403 );
 		}
 
+		$is_nonce_valid = false;
+		$nonce_name     = '_event_nonce';
 		if ( isset( $form_data[ $nonce_name ] ) ) {
 			$nonce_value = sanitize_text_field( wp_unslash( $form_data[ $nonce_name ] ) );
 			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {
@@ -47,6 +47,7 @@ class Event_Form_Handler {
 			wp_send_json_error( esc_html__( 'Nonce verification failed.', 'gp-translation-events' ), 403 );
 		}
 
+		$response_message = '';
 		if ( 'delete_event' === $action ) {
 			// Delete event.
 			$event_id = intval( sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -5,19 +5,14 @@ namespace Wporg\TranslationEvents\Event;
 use DateTime;
 use DateTimeZone;
 use Exception;
-use GP;
 use WP_Error;
-use Wporg\TranslationEvents\Attendee\Attendee;
-use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 
 class Event_Form_Handler {
 	private Event_Repository_Interface $event_repository;
-	private Attendee_Repository $attendee_repository;
 
-	public function __construct( Event_Repository_Interface $event_repository, Attendee_Repository $attendee_repository ) {
-		$this->event_repository    = $event_repository;
-		$this->attendee_repository = $attendee_repository;
+	public function __construct( Event_Repository_Interface $event_repository ) {
+		$this->event_repository = $event_repository;
 	}
 
 	public function handle( array $form_data ): void {
@@ -31,35 +26,17 @@ class Event_Form_Handler {
 		if ( ! in_array( $action, array( 'create_event', 'edit_event', 'delete_event' ), true ) ) {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
-		/**
-		 * Filter the ability to create, edit, or delete an event.
-		 *
-		 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
-		 */
-		$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
+
 		if ( 'create_event' === $action && ( ! current_user_can( 'create_translation_event' ) ) ) {
-			wp_send_json_error( esc_html__( 'The user does not have permission to create an event.', 'gp-translation-events' ), 403 );
+			wp_send_json_error( esc_html__( 'You do not have permissions to create events.', 'gp-translation-events' ), 403 );
 		}
-		if ( 'edit_event' === $action ) {
-			$event_id = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : '';
-			$event    = $this->event_repository->get_event( $event_id );
-			$attendee = $this->attendee_repository->get_attendee( $event->id(), get_current_user_id() );
-			if ( ! ( $can_crud_event || ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event_id ) || $event->author_id() === get_current_user_id() ) ) {
-				wp_send_json_error( esc_html__( 'The user does not have permission to edit or delete the event.', 'gp-translation-events' ), 403 );
-			}
+		if ( 'edit_event' === $action && ( ! current_user_can( 'edit_translation_event' ) ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permissions to edit this event.', 'gp-translation-events' ), 403 );
 		}
-		if ( 'delete_event' === $action ) {
-			$event_id         = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : '';
-			$event            = $this->event_repository->get_event( $event_id );
-			$attendee         = $this->attendee_repository->get_attendee( $event->id(), get_current_user_id() );
-			$stats_calculator = new Stats_Calculator();
-			if ( $stats_calculator->event_has_stats( $event->id() ) ) {
-				wp_send_json_error( esc_html__( 'The event has stats so it cannot be deleted.', 'gp-translation-events' ), 422 );
-			}
-			if ( ! ( $can_crud_event || ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'delete_post', $event_id ) || get_current_user_id() === $event->author_id() ) ) {
-				wp_send_json_error( esc_html__( 'You do not have permission to delete this event.', 'gp-translation-events' ), 403 );
-			}
+		if ( 'delete_event' === $action && ( ! current_user_can( 'delete_translation_event' ) ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permissions to delete this event.', 'gp-translation-events' ), 403 );
 		}
+
 		if ( isset( $form_data[ $nonce_name ] ) ) {
 			$nonce_value = sanitize_text_field( wp_unslash( $form_data[ $nonce_name ] ) );
 			if ( wp_verify_nonce( $nonce_value, $nonce_name ) ) {

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -16,6 +16,11 @@ class Create_Route extends Route {
 			wp_safe_redirect( wp_login_url( home_url( $wp->request ) ) );
 			exit;
 		}
+
+		if ( ! current_user_can( 'create_translation_event' ) ) {
+			$this->die_with_error( 'You do not have permission to create events.' );
+		}
+
 		$event_page_title         = 'Create Event';
 		$event_form_name          = 'create_event';
 		$css_show_url             = 'hide-event-url';

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -62,11 +62,6 @@ class Details_Route extends Route {
 			$this->die_with_error( esc_html__( 'Failed to calculate event stats', 'gp-translation-events' ) );
 		}
 
-		$is_editable_event = true;
-		if ( $event_end->is_in_the_past() || $stats_calculator->event_has_stats( $event->id() ) ) {
-			$is_editable_event = false;
-		}
-
 		$this->tmpl( 'event', get_defined_vars() );
 	}
 }

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -35,13 +35,7 @@ class Details_Route extends Route {
 			$this->die_with_404();
 		}
 
-		/**
-		 * Filter the ability to create, edit, or delete an event.
-		 *
-		 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
-		 */
-		$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
-		if ( 'publish' !== $event->status() && ! $can_crud_event ) {
+		if ( ! current_user_can( 'view_translation_event', $event->id() ) ) {
 			$this->die_with_error( esc_html__( 'You are not authorized to view this page.', 'gp-translation-events' ), 403 );
 		}
 

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -28,10 +28,14 @@ class Edit_Route extends Route {
 			wp_safe_redirect( wp_login_url( home_url( $wp->request ) ) );
 			exit;
 		}
-		$event    = $this->event_repository->get_event( $event_id );
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), get_current_user_id() );
 
-		if ( ! $event || ! ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event->id() ) || $event->author_id() === get_current_user_id() ) ) {
+		$event = $this->event_repository->get_event( $event_id );
+		if ( ! $event ) {
+			$this->die_with_404();
+		}
+
+		$attendee = $this->attendee_repository->get_attendee( $event->id(), get_current_user_id() );
+		if ( ! ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event->id() ) || $event->author_id() === get_current_user_id() ) ) {
 			$this->die_with_error( esc_html__( 'Event does not exist, or you do not have permission to edit it.', 'gp-translation-events' ), 403 );
 		}
 		if ( 'trash' === $event->status() ) {

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -2,11 +2,8 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
-use Wporg\TranslationEvents\Attendee\Attendee;
-use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
-use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
 
 /**
@@ -14,12 +11,10 @@ use Wporg\TranslationEvents\Translation_Events;
  */
 class Edit_Route extends Route {
 	private Event_Repository_Interface $event_repository;
-	private Attendee_Repository $attendee_repository;
 
 	public function __construct() {
 		parent::__construct();
-		$this->event_repository    = Translation_Events::get_event_repository();
-		$this->attendee_repository = Translation_Events::get_attendee_repository();
+		$this->event_repository = Translation_Events::get_event_repository();
 	}
 
 	public function handle( int $event_id ): void {
@@ -34,12 +29,8 @@ class Edit_Route extends Route {
 			$this->die_with_404();
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), get_current_user_id() );
-		if ( ! ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event->id() ) || $event->author_id() === get_current_user_id() ) ) {
-			$this->die_with_error( esc_html__( 'Event does not exist, or you do not have permission to edit it.', 'gp-translation-events' ), 403 );
-		}
-		if ( 'trash' === $event->status() ) {
-			$this->die_with_error( esc_html__( 'You cannot edit a trashed event', 'gp-translation-events' ), 403 );
+		if ( ! current_user_can( 'edit_translation_event', $event->id() ) ) {
+			$this->die_with_error( esc_html__( 'You do not have permission to edit this event.', 'gp-translation-events' ), 403 );
 		}
 
 		include ABSPATH . 'wp-admin/includes/post.php';
@@ -57,23 +48,7 @@ class Edit_Route extends Route {
 		$event_end                     = $event->end();
 		$create_delete_button          = false;
 		$visibility_delete_button      = 'inline-flex';
-
-		if ( $event->end()->is_in_the_past() ) {
-			$this->die_with_error( esc_html__( 'You cannot edit a past event.', 'gp-translation-events' ), 403 );
-		}
-
-		$stats_calculator = new Stats_Calculator();
-
-		if ( $stats_calculator->event_has_stats( $event->id() ) ) {
-			$this->die_with_error( esc_html__( 'You cannot edit an event with translations.', 'gp-translation-events' ), 403 );
-		}
-
-		if ( ! $stats_calculator->event_has_stats( $event->id() ) ) {
-			$current_user = wp_get_current_user();
-			if ( ( $current_user->ID === $event->author_id() || ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) ) && ! $event->end()->is_in_the_past() ) {
-				$create_delete_button = true;
-			}
-		}
+		$create_delete_button          = current_user_can( 'delete_translation_event', $event->id() );
 
 		$this->tmpl( 'events-form', get_defined_vars() );
 	}

--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -39,7 +39,7 @@ class Host_Event_Route extends Route {
 			$this->die_with_error( esc_html__( "Only logged-in users can manage the event's hosts.", 'gp-translation-events' ), 403 );
 		}
 
-		if ( ! current_user_can( 'edit_translation_event' ) ) {
+		if ( ! current_user_can( 'edit_translation_event', $event_id ) ) {
 			$this->die_with_error( esc_html__( "You do not have permissions to manage the event's hosts.", 'gp-translation-events' ), 403 );
 		}
 

--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -36,12 +36,11 @@ class Host_Event_Route extends Route {
 	public function handle( int $event_id, int $user_id ): void {
 		$current_user = wp_get_current_user();
 		if ( ! $current_user->exists() ) {
-			$this->die_with_error( esc_html__( "Only logged-in users can manage event's hosts.", 'gp-translation-events' ), 403 );
+			$this->die_with_error( esc_html__( "Only logged-in users can manage the event's hosts.", 'gp-translation-events' ), 403 );
 		}
 
-		$current_user_attendee = $this->attendee_repository->get_attendee( $event_id, $current_user->ID );
-		if ( ! current_user_can( 'manage_options' ) && ! $current_user_attendee->is_host() ) {
-			$this->die_with_error( esc_html__( "This user does not have permissions to manage event's hosts.", 'gp-translation-events' ), 403 );
+		if ( ! current_user_can( 'edit_translation_event' ) ) {
+			$this->die_with_error( esc_html__( "You do not have permissions to manage the event's hosts.", 'gp-translation-events' ), 403 );
 		}
 
 		$event = $this->event_repository->get_event( $event_id );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 
     <rule ref="WordPress">
         <properties>
-            <property name="custom_capabilities[]" value="create_translation_event"/>
+            <property name="custom_capabilities[]" value="create_translation_event,edit_translation_event"/>
         </properties>
         <exclude name="Squiz.Commenting.ClassComment.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.Missing"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 
     <rule ref="WordPress">
         <properties>
-            <property name="custom_capabilities[]" value="create_translation_event,edit_translation_event"/>
+            <property name="custom_capabilities[]" value="create_translation_event,edit_translation_event,delete_translation_event"/>
         </properties>
         <exclude name="Squiz.Commenting.ClassComment.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.Missing"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 
     <rule ref="WordPress">
         <properties>
-            <property name="custom_capabilities[]" value="create_translation_event,edit_translation_event,delete_translation_event"/>
+            <property name="custom_capabilities[]" value="create_translation_event,view_translation_event,edit_translation_event,delete_translation_event"/>
         </properties>
         <exclude name="Squiz.Commenting.ClassComment.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.Missing"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,6 +12,9 @@
     <file>./wporg-gp-translation-events.php</file>
 
     <rule ref="WordPress">
+        <properties>
+            <property name="custom_capabilities[]" value="create_translation_event"/>
+        </properties>
         <exclude name="Squiz.Commenting.ClassComment.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>

--- a/templates/event.php
+++ b/templates/event.php
@@ -59,7 +59,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
-							if ( current_user_can( 'edit_translation_event' ) ) :
+							if ( current_user_can( 'edit_translation_event', $event->id() ) ) :
 								$_attendee = $attendee_repo->get_attendee( $event_id, $contributor->ID );
 								if ( $_attendee instanceof Attendee ) :
 									echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$contributor->ID" ) ) . '">';
@@ -79,7 +79,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 				</ul>
 			</div>
 		<?php endif; ?>
-		<?php if ( ! empty( $attendees ) && current_user_can( 'edit_translation_event' ) ) : ?>
+		<?php if ( ! empty( $attendees ) && current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 			<div class="event-attendees">
 				<h2>
 				<?php

--- a/templates/event.php
+++ b/templates/event.php
@@ -96,19 +96,15 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
-							if ( ! $event->end()->is_in_the_past() ) :
-								if ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) || $user->ID === $event->author_id() ) :
-									$_attendee = $attendee_repo->get_attendee( $event_id, $_user->ID );
-									if ( $_attendee instanceof Attendee ) :
-										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$_user->ID" ) ) . '">';
-										if ( $_attendee->is_host() ) :
-											echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
-										else :
-											echo '<input type="submit" class="button is-secondary convert-to-host" value="Make co-host"/>';
-										endif;
-										echo '</form>';
-									endif;
+							$_attendee = $attendee_repo->get_attendee( $event_id, $_user->ID );
+							if ( $_attendee instanceof Attendee ) :
+								echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$_user->ID" ) ) . '">';
+								if ( $_attendee->is_host() ) :
+									echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
+								else :
+									echo '<input type="submit" class="button is-secondary convert-to-host" value="Make co-host"/>';
 								endif;
+								echo '</form>';
 							endif;
 							?>
 						</li>

--- a/templates/event.php
+++ b/templates/event.php
@@ -59,20 +59,18 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 							<?php
-							if ( ! $event->end()->is_in_the_past() ) :
-								if ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) || $user->ID === $event->author_id() ) :
-									$_attendee = $attendee_repo->get_attendee( $event_id, $contributor->ID );
-									if ( $_attendee instanceof Attendee ) :
-										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$contributor->ID" ) ) . '">';
-										if ( $_attendee->is_host() ) :
-											echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
-										else :
-											echo '<input type="submit" class="button is-secondary convert-to-host" value="Make co-host"/>';
-										endif;
-										echo '</form>';
+							if ( current_user_can( 'edit_translation_event' ) ) :
+								$_attendee = $attendee_repo->get_attendee( $event_id, $contributor->ID );
+								if ( $_attendee instanceof Attendee ) :
+									echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$contributor->ID" ) ) . '">';
+									if ( $_attendee->is_host() ) :
+										echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
 									else :
-										echo '<span class="event-not-attending">' . esc_html__( 'Not attending', 'gp-translation-events' ) . '</span>';
+										echo '<input type="submit" class="button is-secondary convert-to-host" value="Make co-host"/>';
 									endif;
+									echo '</form>';
+								else :
+									echo '<span class="event-not-attending">' . esc_html__( 'Not attending', 'gp-translation-events' ) . '</span>';
 								endif;
 							endif;
 							?>
@@ -81,7 +79,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 				</ul>
 			</div>
 		<?php endif; ?>
-		<?php if ( ! empty( $attendees ) && ( ! $event->end()->is_in_the_past() || ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) || $user->ID === $event->author_id() ) ) ) : ?>
+		<?php if ( ! empty( $attendees ) && current_user_can( 'edit_translation_event' ) ) : ?>
 			<div class="event-attendees">
 				<h2>
 				<?php

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -8,7 +8,6 @@ use Wporg\TranslationEvents\Event\Event;
 /** @var Attendee $attendee */
 /** @var Event  $event */
 /** @var string $event_page_title */
-/** @var bool   $is_editable_event */
 ?>
 
 <div class="event-list-top-bar">
@@ -54,8 +53,7 @@ use Wporg\TranslationEvents\Event\Event;
 					<?php endif; ?>
 				<?php endforeach; ?>
 			</span>
-			<?php $show_edit_button = ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event->id() ) ) && $is_editable_event; ?>
-			<?php if ( $show_edit_button ) : ?>
+			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 				<a class="event-page-edit-link" href="<?php echo esc_url( gp_url( 'events/edit/' . $event->id() ) ); ?>"><span class="dashicons dashicons-edit"></span><?php esc_html_e( 'Edit event', 'gp-translation-events' ); ?></a>
 			<?php endif ?>
 		</p>

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\TranslationEvents;
 
-use GP;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Event\Event;
 
@@ -23,13 +22,7 @@ use Wporg\TranslationEvents\Event\Event;
 		<?php if ( is_user_logged_in() ) : ?>
 			<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
 			<?php
-			/**
-			 * Filter the ability to create, edit, or delete an event.
-			 *
-			 * @param bool $can_crud_event Whether the user can create, edit, or delete an event.
-			 */
-			$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
-			if ( $can_crud_event ) :
+			if ( current_user_can( 'create_translation_event' ) ) :
 				?>
 				<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
 			<?php endif; ?>

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -105,7 +105,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertFalse( user_can( $non_author_user_id, 'delete_translation_event', $event_id ) );
 	}
 
-	public function test_cannot_delete_without_manage_options_capability() {
+	public function test_cannot_delete_without_delete_post_capability() {
 		$this->set_normal_user_as_current();
 
 		$event_id = $this->event_factory->create_active();
@@ -113,7 +113,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'delete_translation_event', $event_id ) );
 	}
 
-	public function test_can_delete_with_manage_options_capability() {
+	public function test_can_delete_with_delete_post_capability() {
 		$this->set_admin_user_as_current();
 
 		$event_id = $this->event_factory->create_active();

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Wporg\Tests\Event;
+
+use GP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Capabilities;
+use Wporg\TranslationEvents\Event\Event_Repository;
+use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Tests\Stats_Factory;
+
+class Event_Capabilities_Test extends GP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		$this->event_factory       = new Event_Factory();
+		$this->stats_factory       = new Stats_Factory();
+		$this->attendee_repository = new Attendee_Repository();
+		$this->event_repository    = new Event_Repository( $this->attendee_repository );
+		$this->capilities          = new Event_Capabilities();
+	}
+}

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -35,6 +35,30 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertTrue( current_user_can( 'create_translation_event' ) );
 	}
 
+	public function test_cannot_view_non_published_events() {
+		$this->set_normal_user_as_current();
+
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->event_repository->get_event( $event_id );
+		$event->set_status( 'draft' );
+		$this->event_repository->update_event( $event );
+
+		$this->assertFalse( current_user_can( 'view_translation_event', $event_id ) );
+	}
+
+	public function test_gp_admin_can_view_non_published_events() {
+		$this->set_normal_user_as_current();
+
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->event_repository->get_event( $event_id );
+		$event->set_status( 'draft' );
+		$this->event_repository->update_event( $event );
+
+		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
+
+		$this->assertTrue( current_user_can( 'view_translation_event', $event_id ) );
+	}
+
 	public function test_author_can_edit() {
 		$this->set_normal_user_as_current();
 

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -64,6 +64,14 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertTrue( current_user_can( 'view_translation_event', $event_id ) );
 	}
 
+	public function test_event_id_as_string() {
+		$this->set_normal_user_as_current();
+
+		$event_id = $this->event_factory->create_active();
+
+		$this->assertTrue( current_user_can( 'edit_translation_event', (string) $event_id ) );
+	}
+
 	public function test_author_can_edit() {
 		$this->set_normal_user_as_current();
 

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -67,6 +67,16 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertTrue( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
 	}
 
+	public function test_gp_admin_can_edit() {
+		$this->set_normal_user_as_current();
+		$non_author_user_id = get_current_user_id();
+		$this->set_normal_user_as_current(); // This user is the author.
+
+		$event_id = $this->event_factory->create_active();
+		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
+
+		$this->assertTrue( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
+	}
 
 	public function test_cannot_edit_past_event() {
 		$this->set_normal_user_as_current();

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -4,7 +4,6 @@ namespace Wporg\Tests\Event;
 
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
-use Wporg\TranslationEvents\Event\Event_Capabilities;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
@@ -16,6 +15,22 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();
 		$this->event_repository    = new Event_Repository( $this->attendee_repository );
-		$this->capilities          = new Event_Capabilities();
+	}
+
+	public function test_cannot_create_if_no_crud_permission() {
+		$this->set_normal_user_as_current();
+
+		add_filter( 'gp_translation_events_can_crud_event', '__return_false' );
+
+		$this->assertFalse( current_user_can( 'create_translation_event' ) );
+	}
+
+	public function test_can_create_if_crud_permission() {
+		$this->set_normal_user_as_current();
+		get_current_user_id();
+
+		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
+
+		$this->assertTrue( current_user_can( 'create_translation_event' ) );
 	}
 }

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -85,4 +85,29 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
 	}
+
+	public function test_cannot_delete_if_cannot_edit() {
+		$this->set_normal_user_as_current();
+		$non_author_user_id = get_current_user_id();
+		$this->set_normal_user_as_current(); // This user is the author.
+
+		$event_id = $this->event_factory->create_active();
+		$this->assertFalse( user_can( $non_author_user_id, 'delete_translation_event', $event_id ) );
+	}
+
+	public function test_cannot_delete_without_manage_options_capability() {
+		$this->set_normal_user_as_current();
+
+		$event_id = $this->event_factory->create_active();
+
+		$this->assertFalse( current_user_can( 'delete_translation_event', $event_id ) );
+	}
+
+	public function test_can_delete_with_manage_options_capability() {
+		$this->set_admin_user_as_current();
+
+		$event_id = $this->event_factory->create_active();
+
+		$this->assertFalse( current_user_can( 'delete_translation_event', $event_id ) );
+	}
 }

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -10,6 +10,11 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 
 class Event_Capabilities_Test extends GP_UnitTestCase {
+	private Event_Factory $event_factory;
+	private Stats_Factory $stats_factory;
+	private Attendee_Repository $attendee_repository;
+	private Event_Repository $event_repository;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory       = new Event_Factory();

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -30,6 +30,7 @@ use Wporg\TranslationEvents\Event\Event_Capabilities;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
+use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Stats\Stats_Listener;
 
 class Translation_Events {
@@ -79,7 +80,11 @@ class Translation_Events {
 			Upgrade::upgrade_if_needed();
 		}
 
-		$this->event_capabilities = new Event_Capabilities( self::get_event_repository() );
+		$this->event_capabilities = new Event_Capabilities(
+			self::get_event_repository(),
+			self::get_attendee_repository(),
+			new Stats_Calculator()
+		);
 		$this->event_capabilities->register_hooks();
 	}
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -79,7 +79,7 @@ class Translation_Events {
 			Upgrade::upgrade_if_needed();
 		}
 
-		$this->event_capabilities = new Event_Capabilities();
+		$this->event_capabilities = new Event_Capabilities( self::get_event_repository() );
 		$this->event_capabilities->register_hooks();
 	}
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -26,6 +26,7 @@ use WP_Post;
 use WP_Query;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Capabilities;
 use Wporg\TranslationEvents\Event\Event_Form_Handler;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
@@ -33,6 +34,8 @@ use Wporg\TranslationEvents\Stats\Stats_Listener;
 
 class Translation_Events {
 	public const CPT = 'translation_event';
+
+	private Event_Capabilities $event_capabilities;
 
 	public static function get_instance(): Translation_Events {
 		static $instance = null;
@@ -75,6 +78,9 @@ class Translation_Events {
 		if ( is_admin() ) {
 			Upgrade::upgrade_if_needed();
 		}
+
+		$this->event_capabilities = new Event_Capabilities();
+		$this->event_capabilities->register_hooks();
 	}
 
 	public function gp_init() {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -186,7 +186,7 @@ class Translation_Events {
 	 * Handle the event form submission for the creation, editing, and deletion of events. This function is called via AJAX.
 	 */
 	public function submit_event_ajax() {
-		$form_handler = new Event_Form_Handler( self::get_event_repository(), self::get_attendee_repository() );
+		$form_handler = new Event_Form_Handler( self::get_event_repository() );
 		// Nonce verification is done by the form handler.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$form_handler->handle( $_POST );


### PR DESCRIPTION
This PR introduces the following custom capabilities, and changes the whole codebase so that these capabilities are used, through calls to `current_user_can()`:

- `create_translation_event`
- `view_translation_event`
- `edit_translation_event`
- `delete_translation_event`

There should be no changes to how things work, everything should work the same as before.

## References

- [Meta capabilities for custom post types](https://justintadlock.com/archives/2010/07/10/meta-capabilities-for-custom-post-types)
- [`current_user_can()`](https://developer.wordpress.org/reference/functions/current_user_can/)
- [`map_meta_cap()`](https://developer.wordpress.org/reference/hooks/map_meta_cap/)

> This function also accepts an ID of an object to check against if the capability is a meta capability. Meta capabilities such as edit_post and edit_user are capabilities used by the map_meta_cap() function to map to primitive capabilities that a user or role has, such as edit_posts and edit_others_posts.

- [`friends/includes/class-access-control.php#L52`](https://github.com/akirk/friends/blob/5a9ee0d07c021ef1bd022790e4ce9cfb4b34d161/includes/class-access-control.php#L52)
- [`friends/includes/class-access-control.php#L302`](https://github.com/akirk/friends/blob/5a9ee0d07c021ef1bd022790e4ce9cfb4b34d161/includes/class-access-control.php#L302)
- [`global.wordpress.org/public_html/wp-content/mu-plugins/roles/cross-locale-pte.php#L386`](https://github.com/WordPress/wordpress.org/blame/trunk/global.wordpress.org/public_html/wp-content/mu-plugins/roles/cross-locale-pte.php#L386)
