### PR TITLE
Consolidate URL generation

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/includes/upgrade.php';
+require_once __DIR__ . '/includes/urls.php';
 require_once __DIR__ . '/templates/helper-functions.php';
 require_once __DIR__ . '/includes/routes/route.php';
 require_once __DIR__ . '/includes/routes/event/create.php';

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -10,6 +10,7 @@ use WP_Error;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
+use Wporg\TranslationEvents\Urls;
 
 class Event_Form_Handler {
 	private Event_Repository_Interface $event_repository;
@@ -164,16 +165,14 @@ class Event_Form_Handler {
 			$event_status = $new_event->status();
 		}
 
-		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
-		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
 		wp_send_json_success(
 			array(
 				'message'        => $response_message,
 				'eventId'        => $event_id,
-				'eventUrl'       => str_replace( '%pagename%', $post_name, $permalink ),
 				'eventStatus'    => $event_status,
-				'eventEditUrl'   => esc_url( gp_url( '/events/edit/' . $event_id ) ),
-				'eventDeleteUrl' => esc_url( gp_url( '/events/my-events/' ) ),
+				'eventUrl'       => Urls::event_details_absolute( $event_id ),
+				'eventEditUrl'   => Urls::event_edit( $event_id ),
+				'eventDeleteUrl' => Urls::my_events(), // The URL the user is redirected to after deleting.
 			)
 		);
 	}

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -8,6 +8,7 @@ use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Urls;
 
 /**
  * Displays the event edit page.
@@ -39,20 +40,18 @@ class Edit_Route extends Route {
 		}
 
 		include ABSPATH . 'wp-admin/includes/post.php';
-		$event_page_title              = 'Edit Event';
-		$event_form_name               = 'edit_event';
-		$css_show_url                  = '';
-		$event_title                   = $event->title();
-		$event_description             = $event->description();
-		$event_status                  = $event->status();
-		list( $permalink, $post_name ) = get_sample_permalink( $event->id() );
-		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-		$event_url                     = get_site_url() . gp_url( wp_make_link_relative( $permalink ) );
-		$event_timezone                = $event->timezone();
-		$event_start                   = $event->start();
-		$event_end                     = $event->end();
-		$create_delete_button          = false;
-		$visibility_delete_button      = 'inline-flex';
+		$event_page_title         = 'Edit Event';
+		$event_form_name          = 'edit_event';
+		$css_show_url             = '';
+		$event_title              = $event->title();
+		$event_description        = $event->description();
+		$event_status             = $event->status();
+		$event_url                = Urls::event_details_absolute( $event_id );
+		$event_timezone           = $event->timezone();
+		$event_start              = $event->start();
+		$event_end                = $event->end();
+		$create_delete_button     = false;
+		$visibility_delete_button = 'inline-flex';
 
 		if ( $event->end()->is_in_the_past() ) {
 			$this->die_with_error( esc_html__( 'You cannot edit a past event.', 'gp-translation-events' ), 403 );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -8,6 +8,7 @@ use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Stats\Stats_Importer;
 use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Urls;
 
 /**
  * Toggle whether the current user is attending an event.
@@ -59,7 +60,7 @@ class Attend_Event_Route extends Route {
 			}
 		}
 
-		wp_safe_redirect( gp_url( "/events/{$event->slug()}" ) );
+		wp_safe_redirect( Urls::event_details( $event->id() ) );
 		exit;
 	}
 }

--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -7,6 +7,7 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Urls;
 
 /**
  * Toggle whether the current user is hosting an event.
@@ -61,7 +62,7 @@ class Host_Event_Route extends Route {
 			$this->attendee_repository->update_attendee( $affected_attendee );
 		}
 
-		wp_safe_redirect( gp_url( "/events/{$event->slug()}" ) );
+		wp_safe_redirect( Urls::event_details( $event->id() ) );
 		exit;
 	}
 }

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -3,6 +3,10 @@
 namespace Wporg\TranslationEvents;
 
 class Urls {
+	public static function events_home(): string {
+		return gp_url( '/events' );
+	}
+
 	public static function event_details( int $event_id ): string {
 		return gp_url( wp_make_link_relative( get_the_permalink( $event_id ) ) );
 	}

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -22,6 +22,14 @@ class Urls {
 		return gp_url( '/events/new/' );
 	}
 
+	public static function event_toggle_attendee( int $event_id ): string {
+		return gp_url( "/events/attend/$event_id" );
+	}
+
+	public static function event_toggle_host( int $event_id, int $user_id ): string {
+		return gp_url( "/events/host/$event_id/$user_id" );
+	}
+
 	public static function my_events(): string {
 		return gp_url( '/events/my-events/' );
 	}

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -6,4 +6,10 @@ class Urls {
 	public static function event_details( int $event_id ): string {
 		return gp_url( wp_make_link_relative( get_the_permalink( $event_id ) ) );
 	}
+
+	public static function event_details_absolute( int $event_id ): string {
+		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
+		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
+		return str_replace( '%postname%', $post_name, $permalink );
+	}
 }

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -12,4 +12,12 @@ class Urls {
 		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
 		return str_replace( '%postname%', $post_name, $permalink );
 	}
+
+	public static function event_edit( int $event_id ): string {
+		return gp_url( '/events/edit/' . $event_id );
+	}
+
+	public static function my_events(): string {
+		return gp_url( '/events/my-events/' );
+	}
 }

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -10,7 +10,8 @@ class Urls {
 	public static function event_details_absolute( int $event_id ): string {
 		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
 		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-		return str_replace( '%postname%', $post_name, $permalink );
+
+		return get_site_url() . gp_url( wp_make_link_relative( $permalink ) );
 	}
 
 	public static function event_edit( int $event_id ): string {

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Wporg\TranslationEvents;
+
+class Urls {
+	public static function event_details( int $event_id ): string {
+		return gp_url( wp_make_link_relative( get_the_permalink( $event_id ) ) );
+	}
+}

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -18,6 +18,10 @@ class Urls {
 		return gp_url( '/events/edit/' . $event_id );
 	}
 
+	public static function event_create(): string {
+		return gp_url( '/events/new/' );
+	}
+
 	public static function my_events(): string {
 		return gp_url( '/events/my-events/' );
 	}

--- a/templates/event.php
+++ b/templates/event.php
@@ -63,7 +63,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								if ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) || $user->ID === $event->author_id() ) :
 									$_attendee = $attendee_repo->get_attendee( $event_id, $contributor->ID );
 									if ( $_attendee instanceof Attendee ) :
-										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$contributor->ID" ) ) . '">';
+										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( Urls::event_toggle_host( $event_id, $contributor->ID ) ) . '">';
 										if ( $_attendee->is_host() ) :
 											echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
 										else :
@@ -102,7 +102,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 								if ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'manage_options' ) || $user->ID === $event->author_id() ) :
 									$_attendee = $attendee_repo->get_attendee( $event_id, $_user->ID );
 									if ( $_attendee instanceof Attendee ) :
-										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( gp_url( "/events/host/$event_id/$_user->ID" ) ) . '">';
+										echo '<form class="add-remove-user-as-host" method="post" action="' . esc_url( Urls::event_toggle_host( $event_id, $_user->ID ) ) . '">';
 										if ( $_attendee->is_host() ) :
 											echo '<input type="submit" class="button is-primary remove-as-host" value="Remove as host"/>';
 										else :
@@ -271,7 +271,7 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 					<button disabled="disabled" class="button is-primary attend-btn"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></button>
 				<?php endif; ?>
 			<?php else : ?>
-				<form class="event-details-attend" method="post" action="<?php echo esc_url( gp_url( "/events/attend/$event_id" ) ); ?>">
+				<form class="event-details-attend" method="post" action="<?php echo esc_url( Urls::event_toggle_attendee( $event_id ) ); ?>">
 					<?php if ( $attendee instanceof Attendee ) : ?>
 						<input type="submit" class="button is-secondary attending-btn" value="You're attending" />
 					<?php else : ?>

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -21,7 +21,7 @@ use Wporg\TranslationEvents\Event\Event;
 </h2>
 	<ul class="event-list-nav">
 		<?php if ( is_user_logged_in() ) : ?>
-			<li><a href="<?php echo esc_url( gp_url( '/events/my-events/' ) ); ?>">My Events</a></li>
+			<li><a href="<?php echo esc_url( Urls::my_events() ); ?>">My Events</a></li>
 			<?php
 			/**
 			 * Filter the ability to create, edit, or delete an event.
@@ -31,7 +31,7 @@ use Wporg\TranslationEvents\Event\Event;
 			$can_crud_event = apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->current_user_can( 'admin' ) );
 			if ( $can_crud_event ) :
 				?>
-				<li><a class="button is-primary" href="<?php echo esc_url( gp_url( '/events/new/' ) ); ?>">Create Event</a></li>
+				<li><a class="button is-primary" href="<?php echo esc_url( Urls::event_create() ); ?>">Create Event</a></li>
 			<?php endif; ?>
 		<?php endif; ?>
 	</ul>
@@ -63,7 +63,7 @@ use Wporg\TranslationEvents\Event\Event;
 			</span>
 			<?php $show_edit_button = ( ( $attendee instanceof Attendee && $attendee->is_host() ) || current_user_can( 'edit_post', $event->id() ) ) && $is_editable_event; ?>
 			<?php if ( $show_edit_button ) : ?>
-				<a class="event-page-edit-link" href="<?php echo esc_url( gp_url( 'events/edit/' . $event->id() ) ); ?>"><span class="dashicons dashicons-edit"></span><?php esc_html_e( 'Edit event', 'gp-translation-events' ); ?></a>
+				<a class="event-page-edit-link" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><span class="dashicons dashicons-edit"></span><?php esc_html_e( 'Edit event', 'gp-translation-events' ); ?></a>
 			<?php endif ?>
 		</p>
 		<?php endif; ?>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -29,18 +29,13 @@ if ( ! empty( $current_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Current events', 'gp-translation-events' ); ?></h2>
 	<ul class="event-list">
-		<?php
-		foreach ( $current_events_query->events as $event ) :
-			$event_url = gp_url( wp_make_link_relative( get_the_permalink( $event->id() ) ) );
-			?>
+		<?php foreach ( $current_events_query->events as $event ) : ?>
 			<li class="event-list-item">
-				<a href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 				<span class="event-list-date">ends <?php $event->end()->print_relative_time_html(); ?></time></span>
 				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
 			</li>
-			<?php
-		endforeach;
-		?>
+		<?php endforeach; ?>
 	</ul>
 
 	<?php
@@ -63,18 +58,13 @@ if ( ! empty( $upcoming_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Upcoming events', 'gp-translation-events' ); ?></h2>
 	<ul class="event-list">
-		<?php
-		foreach ( $upcoming_events_query->events as $event ) :
-			$event_url = gp_url( wp_make_link_relative( get_the_permalink( $event->id() ) ) );
-			?>
+		<?php foreach ( $upcoming_events_query->events as $event ) : ?>
 			<li class="event-list-item">
-				<a href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 				<span class="event-list-date">starts <?php $event->start()->print_relative_time_html(); ?></span>
 				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
 			</li>
-			<?php
-		endforeach;
-		?>
+		<?php endforeach; ?>
 	</ul>
 
 	<?php
@@ -96,18 +86,13 @@ if ( ! empty( $past_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Past events', 'gp-translation-events' ); ?></h2>
 	<ul class="event-list">
-		<?php
-		foreach ( $past_events_query->events as $event ) :
-			$event_url = gp_url( wp_make_link_relative( get_the_permalink( $event->id() ) ) );
-			?>
+		<?php foreach ( $past_events_query->events as $event ) : ?>
 			<li class="event-list-item">
-				<a href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 				<span class="event-list-date">ended <?php $event->end()->print_relative_time_html( 'F j, Y H:i T' ); ?></span>
 				<?php esc_html( get_the_excerpt( $event->id() ) ); ?>
 			</li>
-			<?php
-		endforeach;
-		?>
+		<?php endforeach; ?>
 	</ul>
 
 	<?php
@@ -138,21 +123,16 @@ endif;
 			<p>You don't have any events to attend.</p>
 		<?php else : ?>
 			<ul class="event-attending-list">
-				<?php
-				foreach ( $user_attending_events_query->events as $event ) :
-					$event_url = gp_url( wp_make_link_relative( get_the_permalink( $event->id() ) ) );
-					?>
+				<?php foreach ( $user_attending_events_query->events as $event ) : ?>
 					<li class="event-list-item">
-						<a href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+						<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 						<?php if ( $event->start() === $event->end() ) : ?>
 							<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?></span>
 						<?php else : ?>
 							<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?> - <?php $event->end()->print_time_html( 'F j, Y H:i T' ); ?></span>
 						<?php endif; ?>
 					</li>
-					<?php
-				endforeach;
-				?>
+				<?php endforeach; ?>
 			</ul>
 			<?php
 				echo wp_kses_post(

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -25,17 +25,13 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<ul>
 		<?php
 		foreach ( $events_i_host_query->events as $event ) :
-			list( $permalink, $post_name ) = get_sample_permalink( $event->id() );
-			$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
-			$event_edit_url                = gp_url( 'events/edit/' . $event->id() );
-			$stats_calculator              = new Stats_Calculator();
-			$has_stats                     = $stats_calculator->event_has_stats( $event->id() );
+			$stats_calculator = new Stats_Calculator();
+			$has_stats        = $stats_calculator->event_has_stats( $event->id() );
 			?>
 			<li class="event-list-item">
-				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 				<?php if ( ! $event->end()->is_in_the_past() && ! $has_stats ) : ?>
-					<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
+					<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event->status() ) : ?>
 					<span class="event-label-<?php echo esc_attr( $event->status() ); ?>"><?php echo esc_html( $event->status() ); ?></span>
@@ -72,17 +68,13 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		<ul>
 			<?php
 			foreach ( $events_i_created_query->events as $event ) :
-				list( $permalink, $post_name ) = get_sample_permalink( $event->id() );
-				$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-				$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
-				$event_edit_url                = gp_url( 'events/edit/' . $event->id() );
-				$stats_calculator              = new Stats_Calculator();
-				$has_stats                     = $stats_calculator->event_has_stats( $event->id() );
+				$stats_calculator = new Stats_Calculator();
+				$has_stats        = $stats_calculator->event_has_stats( $event->id() );
 				?>
 				<li class="event-list-item">
-					<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+					<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 					<?php if ( ! $event->end()->is_in_the_past() && ! $has_stats ) : ?>
-						<a href="<?php echo esc_url( $event_edit_url ); ?>" class="button is-small action edit">Edit</a>
+						<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 					<?php endif; ?>
 					<?php if ( 'draft' === $event->status() ) : ?>
 						<span class="event-label-<?php echo esc_attr( $event->status() ); ?>"><?php echo esc_html( $event->status() ); ?></span>
@@ -117,14 +109,9 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	<h2><?php esc_html_e( 'Events I attended', 'gp-translation-events' ); ?> </h2>
 	<?php if ( ! empty( $events_i_attended_query->events ) ) : ?>
 		<ul>
-		<?php
-		foreach ( $events_i_attended_query->events as $event ) :
-			list( $permalink, $post_name ) = get_sample_permalink( $event->id() );
-			$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-			$event_url                     = gp_url( wp_make_link_relative( $permalink ) );
-			?>
+		<?php foreach ( $events_i_attended_query->events as $event ) : ?>
 			<li class="event-list-item">
-				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( $event_url ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
 				<?php if ( $event->start() === $event->end() ) : ?>
 					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?></span>
 				<?php else : ?>

--- a/templates/helper-functions.php
+++ b/templates/helper-functions.php
@@ -1,4 +1,7 @@
 <?php
+
+use Wporg\TranslationEvents\Urls;
+
 /**
  * Get event breadcrumb.
  *
@@ -8,7 +11,7 @@
  */
 function gp_breadcrumb_translation_events( $extra_items = array() ) {
 	$breadcrumb = array(
-		empty( $extra_items ) ? __( 'Events', 'gp-translation-events' ) : gp_link_get( gp_url( '/events' ), __( 'Events', 'gp-translation-events' ) ),
+		empty( $extra_items ) ? __( 'Events', 'gp-translation-events' ) : gp_link_get( Urls::events_home(), __( 'Events', 'gp-translation-events' ) ),
 	);
 	if ( ! empty( $extra_items ) ) {
 		$breadcrumb = array_merge( $breadcrumb, $extra_items );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -17,14 +17,10 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->event_factory    = new Event_Factory();
 		$this->event_repository = new Event_Repository( new Attendee_Repository() );
 		$this->set_normal_user_as_current();
-
-		if ( ! defined( 'GP_URL_BASE' ) ) {
-			define( 'GP_URL_BASE', '/' );
-		}
 	}
 
 	public function test_events_home() {
-		$expected = '/events';
+		$expected = '/glotpress/events';
 		$this->assertEquals( $expected, Urls::events_home() );
 	}
 
@@ -32,7 +28,7 @@ class Urls_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );
 
-		$expected = "/events/{$event->slug()}";
+		$expected = "/glotpress/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
 	}
 
@@ -40,21 +36,21 @@ class Urls_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );
 
-		$expected = site_url() . "/events/{$event->slug()}";
+		$expected = site_url() . "/glotpress/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details_absolute( $event_id ) );
 	}
 
 	public function test_event_edit() {
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/events/edit/$event_id";
+		$expected = "/glotpress/events/edit/$event_id";
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
 	public function test_event_toggle_attendee() {
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/events/attend/$event_id";
+		$expected = "/glotpress/events/attend/$event_id";
 		$this->assertEquals( $expected, Urls::event_toggle_attendee( $event_id ) );
 	}
 
@@ -62,17 +58,17 @@ class Urls_Test extends GP_UnitTestCase {
 		$user_id  = get_current_user_id();
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/events/host/$event_id/$user_id";
+		$expected = "/glotpress/events/host/$event_id/$user_id";
 		$this->assertEquals( $expected, Urls::event_toggle_host( $event_id, $user_id ) );
 	}
 
 	public function test_event_create() {
-		$expected = '/events/new';
+		$expected = '/glotpress/events/new';
 		$this->assertEquals( $expected, Urls::event_create() );
 	}
 
 	public function test_my_events() {
-		$expected = '/events/my-events';
+		$expected = '/glotpress/events/my-events';
 		$this->assertEquals( $expected, Urls::my_events() );
 	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -31,7 +31,7 @@ class Urls_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );
 
-		$expected = site_url() . "/events/{$event->slug()}";
+		$expected = site_url() . "/glotpress/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details_absolute( $event_id ) );
 	}
 

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -34,4 +34,16 @@ class Urls_Test extends GP_UnitTestCase {
 		$expected = site_url() . "/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details_absolute( $event_id ) );
 	}
+
+	public function test_event_edit() {
+		$event_id = $this->event_factory->create_active();
+
+		$expected = "/glotpress/events/edit/$event_id";
+		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
+	}
+
+	public function test_my_events() {
+		$expected = '/glotpress/events/my-events';
+		$this->assertEquals( $expected, Urls::my_events() );
+	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -42,6 +42,11 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
+	public function test_event_create() {
+		$expected = '/glotpress/events/new';
+		$this->assertEquals( $expected, Urls::event_create() );
+	}
+
 	public function test_my_events() {
 		$expected = '/glotpress/events/my-events';
 		$this->assertEquals( $expected, Urls::my_events() );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Wporg\Tests;
+
+use GP_UnitTestCase;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Repository;
+use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Urls;
+
+class Urls_Test extends GP_UnitTestCase {
+	private Event_Factory $event_factory;
+	private Event_Repository $event_repository;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->event_factory    = new Event_Factory();
+		$this->event_repository = new Event_Repository( new Attendee_Repository() );
+		$this->set_normal_user_as_current();
+	}
+
+	public function test_event_details() {
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->event_repository->get_event( $event_id );
+
+		$expected = "/glotpress/events/{$event->slug()}";
+
+		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
+	}
+}

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -71,4 +71,14 @@ class Urls_Test extends GP_UnitTestCase {
 		$expected = '/glotpress/events/my-events';
 		$this->assertEquals( $expected, Urls::my_events() );
 	}
+
+	/**
+	 * This test must be last because once it runs, the GP_URL_BASE constant
+	 * will be changed from the default ('/glotpress') to '/'.
+	 */
+	public function test_custom_gp_url_base() {
+		define( 'GP_URL_BASE', '/' );
+		$expected = '/events';
+		$this->assertEquals( $expected, Urls::events_home() );
+	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -42,6 +42,21 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
+	public function test_event_toggle_attendee() {
+		$event_id = $this->event_factory->create_active();
+
+		$expected = "/glotpress/events/attend/$event_id";
+		$this->assertEquals( $expected, Urls::event_toggle_attendee( $event_id ) );
+	}
+
+	public function test_event_toggle_host() {
+		$user_id  = get_current_user_id();
+		$event_id = $this->event_factory->create_active();
+
+		$expected = "/glotpress/events/host/$event_id/$user_id";
+		$this->assertEquals( $expected, Urls::event_toggle_host( $event_id, $user_id ) );
+	}
+
 	public function test_event_create() {
 		$expected = '/glotpress/events/new';
 		$this->assertEquals( $expected, Urls::event_create() );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -17,10 +17,14 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->event_factory    = new Event_Factory();
 		$this->event_repository = new Event_Repository( new Attendee_Repository() );
 		$this->set_normal_user_as_current();
+
+		if ( ! defined( 'GP_URL_BASE' ) ) {
+			define( 'GP_URL_BASE', '/' );
+		}
 	}
 
 	public function test_events_home() {
-		$expected = '/glotpress/events';
+		$expected = '/events';
 		$this->assertEquals( $expected, Urls::events_home() );
 	}
 
@@ -28,7 +32,7 @@ class Urls_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );
 
-		$expected = "/glotpress/events/{$event->slug()}";
+		$expected = "/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
 	}
 
@@ -36,21 +40,21 @@ class Urls_Test extends GP_UnitTestCase {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );
 
-		$expected = site_url() . "/glotpress/events/{$event->slug()}";
+		$expected = site_url() . "/events/{$event->slug()}";
 		$this->assertEquals( $expected, Urls::event_details_absolute( $event_id ) );
 	}
 
 	public function test_event_edit() {
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/glotpress/events/edit/$event_id";
+		$expected = "/events/edit/$event_id";
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
 	public function test_event_toggle_attendee() {
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/glotpress/events/attend/$event_id";
+		$expected = "/events/attend/$event_id";
 		$this->assertEquals( $expected, Urls::event_toggle_attendee( $event_id ) );
 	}
 
@@ -58,17 +62,17 @@ class Urls_Test extends GP_UnitTestCase {
 		$user_id  = get_current_user_id();
 		$event_id = $this->event_factory->create_active();
 
-		$expected = "/glotpress/events/host/$event_id/$user_id";
+		$expected = "/events/host/$event_id/$user_id";
 		$this->assertEquals( $expected, Urls::event_toggle_host( $event_id, $user_id ) );
 	}
 
 	public function test_event_create() {
-		$expected = '/glotpress/events/new';
+		$expected = '/events/new';
 		$this->assertEquals( $expected, Urls::event_create() );
 	}
 
 	public function test_my_events() {
-		$expected = '/glotpress/events/my-events';
+		$expected = '/events/my-events';
 		$this->assertEquals( $expected, Urls::my_events() );
 	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -24,7 +24,14 @@ class Urls_Test extends GP_UnitTestCase {
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = "/glotpress/events/{$event->slug()}";
-
 		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
+	}
+
+	public function test_event_details_absolute() {
+		$event_id = $this->event_factory->create_active();
+		$event    = $this->event_repository->get_event( $event_id );
+
+		$expected = site_url() . "/events/{$event->slug()}";
+		$this->assertEquals( $expected, Urls::event_details_absolute( $event_id ) );
 	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -19,6 +19,11 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 	}
 
+	public function test_events_home() {
+		$expected = '/glotpress/events';
+		$this->assertEquals( $expected, Urls::events_home() );
+	}
+
 	public function test_event_details() {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -236,7 +236,7 @@ class Translation_Events {
 		if ( 'main' !== $location ) {
 			return $items;
 		}
-		$new[ esc_url( gp_url( '/events/' ) ) ] = esc_html__( 'Events', 'gp-translation-events' );
+		$new[ esc_url( Urls::events_home() ) ] = esc_html__( 'Events', 'gp-translation-events' );
 		return array_merge( $items, $new );
 	}
 
@@ -329,9 +329,8 @@ class Translation_Events {
 			}
 
 			$remaining_events = $number_of_events - 2;
-			$url              = esc_url( gp_url( '/events/' ) );
 			/* translators: %d: Number of remaining events */
-			$content .= '<span class="remaining-events"><a href="' . $url . '" target="_blank">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</a></span>';
+			$content .= '<span class="remaining-events"><a href="' . esc_url( Urls::events_home() ) . '" target="_blank">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</a></span>';
 
 		} else {
 			while ( $user_attending_events_query->have_posts() ) {


### PR DESCRIPTION
This PR makes it so that all URLs of the plugin are generated through a new `Urls` class, so whenever there's a need to generate a URL you can simply do something like:

```
echo Urls::event_details( $event_id );
```

This PR also fixes an issue where the URL was wrong in the event edit page (it would be correct when post is draft, and incorrect when post is published).
