### PR TITLE
Use event repository when showing active events in translation table

### DIFF
--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -89,6 +89,18 @@ interface Event_Repository_Interface {
 	 * @return Events_Query_Result
 	 * @throws Exception
 	 */
+	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
+
+	/**
+	 * Get events that are currently active or happening in the future, for a given user.
+	 *
+	 * @param int $user_id   Id of the user.
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
+	 * @throws Exception
+	 */
 	public function get_current_and_upcoming_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -152,6 +152,38 @@ class Event_Repository implements Event_Repository_Interface {
 		// phpcs:enable
 	}
 
+	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		return $this->execute_events_query(
+			$page,
+			$page_size,
+			array(
+				'meta_query' => array(
+					array(
+						'key'     => '_event_start',
+						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'compare' => '<=',
+						'type'    => 'DATETIME',
+					),
+					array(
+						'key'     => '_event_end',
+						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'compare' => '>=',
+						'type'    => 'DATETIME',
+					),
+				),
+				'meta_key'   => '_event_start',
+				'orderby'    => 'meta_value',
+				'order'      => 'ASC',
+			),
+			$this->attendee_repository->get_events_for_user( $user_id ),
+		);
+		// phpcs:enable
+	}
+
 	public function get_current_and_upcoming_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -176,6 +176,34 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $event2_id, $events[1]->id() );
 	}
 
+	public function test_get_current_events_for_user() {
+		$user_id   = $this->set_normal_user_as_current();
+		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event1_id = $this->event_factory->create_active( array( $user_id ), $now );
+		$event2_id = $this->event_factory->create_active( array( $user_id ), $now );
+		$this->event_factory->create_active( array( $user_id ), $now->modify( '+2 hours' ) );
+		$this->event_factory->create_active( array( $user_id ), $now->modify( '+2 months' ) );
+		$this->event_factory->create_active( array(), $now );
+		$this->event_factory->create_inactive_past( array( $user_id ) );
+
+		$events = $this->repository->get_current_events_for_user( $user_id )->events;
+		$this->assertCount( 2, $events );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+
+		$result = $this->repository->get_current_events_for_user( $user_id, 1, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event1_id, $events[0]->id() );
+
+		$result = $this->repository->get_current_events_for_user( $user_id, 2, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 2, $result->page_count );
+		$this->assertEquals( $event2_id, $events[0]->id() );
+	}
+
 	public function test_get_current_and_upcoming_events_for_user() {
 		$user_id   = $this->set_normal_user_as_current();
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -319,26 +319,21 @@ class Translation_Events {
 		/* translators: %d: Number of events */
 		$content .= sprintf( _n( 'Contributing to %d event:', 'Contributing to %d events:', $number_of_events, 'gp-translation-events' ), $number_of_events );
 		$content .= '&nbsp;&nbsp;';
-		if ( $number_of_events > 3 ) {
-			$counter = 0;
-			while ( $user_attending_events_query->have_posts() && $counter < 2 ) {
-				$user_attending_events_query->the_post();
-				$url      = esc_url( gp_url( '/events/' . get_post_field( 'post_name', get_post() ) ) );
-				$content .= '<span class="active-events-before-translation-table"><a href="' . $url . '" target="_blank">' . get_the_title() . '</a></span>';
-				++$counter;
-			}
 
+		$counter = 0;
+		while ( $user_attending_events_query->have_posts() && $counter < 2 ) {
+			$user_attending_events_query->the_post();
+			$url      = esc_url( gp_url( '/events/' . get_post_field( 'post_name', get_post() ) ) );
+			$content .= '<span class="active-events-before-translation-table"><a href="' . $url . '" target="_blank">' . get_the_title() . '</a></span>';
+			++$counter;
+		}
+
+		if ( $number_of_events > 3 ) {
 			$remaining_events = $number_of_events - 2;
 			/* translators: %d: Number of remaining events */
 			$content .= '<span class="remaining-events"><a href="' . esc_url( Urls::events_home() ) . '" target="_blank">' . sprintf( esc_html__( ' and %d more events.', 'gp-translation-events' ), $remaining_events ) . '</a></span>';
-
-		} else {
-			while ( $user_attending_events_query->have_posts() ) {
-				$user_attending_events_query->the_post();
-				$url      = esc_url( gp_url( '/events/' . get_post_field( 'post_name', get_post() ) ) );
-				$content .= '<span class="active-events-before-translation-table"><a href="' . $url . '" target="_blank">' . get_the_title() . '</a></span>';
-			}
 		}
+
 		$content .= '</div>';
 
 		echo wp_kses(


### PR DESCRIPTION
There was one place where we were not using the event repository: to show the "Contributing to X events" in the translation table:

<img width="640" alt="Screenshot 2024-04-22 at 15 18 58" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/43ccf34f-fe31-4505-ad6b-8e86ba8e54ef">

---

We're now also using the `Urls` class to generate the URLs for the links.