### PR TITLE
Add revisions for some postmeta keys

### DIFF
--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -413,8 +413,17 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	private function update_event_meta( Event $event ) {
+		$hosts     = $this->attendee_repository->get_hosts( $event->id() );
+		$hosts_ids = array_map(
+			function ( $host ) {
+				return $host->user_id();
+			},
+			$hosts
+		);
+		$hosts_ids = implode( ', ', $hosts_ids );
 		update_post_meta( $event->id(), '_event_start', $event->start()->utc()->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event->id(), '_event_end', $event->end()->utc()->format( 'Y-m-d H:i:s' ) );
 		update_post_meta( $event->id(), '_event_timezone', $event->timezone()->getName() );
+		update_post_meta( $event->id(), '_hosts', $hosts_ids );
 	}
 }

--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -59,6 +59,7 @@ class Host_Event_Route extends Route {
 			}
 
 			$this->attendee_repository->update_attendee( $affected_attendee );
+			$this->event_repository->update_event( $event );
 		}
 
 		wp_safe_redirect( Urls::event_details( $event->id() ) );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -379,7 +379,7 @@ class Translation_Events {
 	 * @return array The modified list of meta keys to keep in post revisions.
 	 */
 	public function wp_post_revision_meta_keys( array $keys ): array {
-		$meta_keys_to_keep = array( '_event_start', '_event_end', '_event_timezone' );
+		$meta_keys_to_keep = array( '_event_start', '_event_end', '_event_timezone', '_hosts' );
 		return array_merge( $keys, $meta_keys_to_keep );
 	}
 }

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -75,6 +75,7 @@ class Translation_Events {
 		add_filter( 'wp_insert_post_data', array( $this, 'generate_event_slug' ), 10, 2 );
 		add_action( 'gp_init', array( $this, 'gp_init' ) );
 		add_action( 'gp_before_translation_table', array( $this, 'add_active_events_current_user' ) );
+		add_filter( 'wp_post_revision_meta_keys', array( $this, 'wp_post_revision_meta_keys' ) );
 
 		if ( is_admin() ) {
 			Upgrade::upgrade_if_needed();
@@ -368,6 +369,18 @@ class Translation_Events {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Add the event meta keys to the list of meta keys to keep in post revisions.
+	 *
+	 * @param array $keys The list of meta keys to keep in post revisions.
+	 *
+	 * @return array The modified list of meta keys to keep in post revisions.
+	 */
+	public function wp_post_revision_meta_keys( array $keys ): array {
+		$meta_keys_to_keep = array( '_event_start', '_event_end', '_event_timezone' );
+		return array_merge( $keys, $meta_keys_to_keep );
 	}
 }
 Translation_Events::get_instance();


### PR DESCRIPTION
With this PR, each time we update the post, it creates:
- A new post revision (this is the current behavior).
- 4 post meta (`_event_start`, `_event_end`, `_event_timezone`, `_hosts`) for each revision.
- The `_hosts` post meta key is a string with all the user ids that are hosts in this revision, separated with commas.

## `posts` table

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/2e1368f8-afd1-4725-8cba-0539ffe6f6e5)

## `postmeta` table

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/a1f929cb-371c-46c2-a7cd-175aa9a8b549)

To test it, you can create and update an event, and change the hosts. Then you can review the updates in these tables: `posts` and `postmeta`.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/204.