### PR TITLE
Add missing parameter

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -97,7 +97,7 @@ class Translation_Events {
 
 		GP::$router->add( '/events?', array( 'Wporg\TranslationEvents\Routes\Event\List_Route', 'handle' ) );
 		GP::$router->add( '/events/new', array( 'Wporg\TranslationEvents\Routes\Event\Create_Route', 'handle' ) );
-		GP::$router->add( '/events/edit/', array( 'Wporg\TranslationEvents\Routes\Event\Edit_Route', 'handle' ) );
+		GP::$router->add( "/events/edit/$id", array( 'Wporg\TranslationEvents\Routes\Event\Edit_Route', 'handle' ) );
 		GP::$router->add( "/events/attend/$id", array( 'Wporg\TranslationEvents\Routes\User\Attend_Event_Route', 'handle' ), 'post' );
 		GP::$router->add( "/events/host/$id/$id", array( 'Wporg\TranslationEvents\Routes\User\Host_Event_Route', 'handle' ), 'post' );
 		GP::$router->add( '/events/my-events', array( 'Wporg\TranslationEvents\Routes\User\My_Events_Route', 'handle' ) );


### PR DESCRIPTION
Event ID is missing in the route and clicking the `Edit Event` link leads to a 404. This PR adds the missing ID parameter.