### PR TITLE
New Event: Quickly Fill Upcoming WordCamp Data

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -6,7 +6,8 @@
 
 .translation-event-form #event-title,
 .translation-event-form #event-description {
-	width: 30%;
+	width: auto;
+	resize: both;
 }
 
 .translation-event-form input[type="text"],
@@ -84,7 +85,8 @@
 	font-weight: bold;
 }
 
-.event-contributors li, .event-attendees li {
+.event-contributors li,
+.event-attendees li {
 	display: inline-block;
 	list-style-type: none;
 	margin-right: 1em;
@@ -92,7 +94,9 @@
 	width: 15em;
 }
 
-.event-contributors li .avatar, .event-attendees li .avatar, td a.attendee-avatar .avatar {
+.event-contributors li .avatar,
+.event-attendees li .avatar,
+td a.attendee-avatar .avatar {
 	border-radius: 50%;
 	vertical-align: middle;
 }
@@ -107,6 +111,7 @@ span.event-not-attending {
 	margin-top: 1em;
 	font-size: smaller;
 }
+
 .hide-event-url {
 	display: none;
 }
@@ -247,7 +252,8 @@ span.active-events-before-translation-table a {
 	padding: 0;
 }
 
-input[type="submit"].remove-as-host, input[type="submit"].convert-to-host {
+input[type="submit"].remove-as-host,
+input[type="submit"].convert-to-host {
 	text-align: center;
 	display: inline;
 	margin-top: 1em;
@@ -354,6 +360,7 @@ ul.text-snippets {
 	padding: 0;
 	margin-left: 160px;
 }
+
 .first-time-contributor-tada::after {
 	content: ' 🎉';
 }
@@ -365,38 +372,65 @@ ul#translation-links li {
 .icons li .name {
 	display: none;
 }
-.icons li  {
+
+.icons li {
 	width: auto !important;
 }
-.event-attendees h2, .event-contributors h2 {
+
+.event-attendees h2,
+.event-contributors h2 {
 	cursor: pointer;
 	display: inline-block;
 }
+
 ul.event-attendees-filter {
 	padding-left: 1rem;
 }
+
 ul.event-attendees-filter li {
 	display: inline;
 	margin-right: .4em;
 }
+
 form.translation-event-form {
 	float: left;
 	width: 85%;
 }
+
 div.event-edit-right {
 	float: right;
 	width: 15%;
 	text-align: right;
 }
+
 .view-event-page {
 	float: right;
 }
+
 a.active-filter {
 	font-weight: bold;
 }
+
 .event-edit-right a.manage-attendees-btn {
 	margin-top: 1em;
 }
+
+#quick-add.loading::after {
+	content: 'Loading...';
+}
+
+#quick-add summary {
+	cursor: pointer;
+}
+
+#quick-add {
+	padding: 0 .5em;
+	border-left: #d9d8d8 thin solid;
+	border-bottom: #d9d8d8 thin solid;
+	max-height: 8em;
+	overflow: auto;
+}
+
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {
 

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -62,7 +62,7 @@
 							year: 'numeric'
 						};
 
-						fetch( 'https://central.wordcamp.org/wp-json/wp/v2/wordcamps?per_page=30&status=wcpt-scheduled&order=desc' ).then(
+						fetch( 'https://central.wordcamp.org/wp-json/wp/v2/wordcamps?per_page=30&status=wcpt-scheduled' ).then(
 							response => response.json()
 						).then(
 							function ( data ) {

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -47,6 +47,59 @@
 							$( '.convert-to-host, .remove-as-host' ).toggle();
 					}
 				);
+
+				$( '#quick-add' ).on(
+					'toggle',
+					function () {
+						if ( $( this ).data( 'loaded' ) ) {
+							return;
+						}
+						$( this ).addClass( 'loading' );
+						const options = {
+							weekday: 'short',
+							day: 'numeric',
+							month: 'short',
+							year: 'numeric'
+						};
+
+						fetch( 'https://central.wordcamp.org/wp-json/wp/v2/wordcamps?per_page=30&status=wcpt-scheduled&order=desc' ).then(
+							response => response.json()
+						).then(
+							function ( data ) {
+								data.sort( ( a, b ) => a['Start Date (YYYY-mm-dd)'] - b['Start Date (YYYY-mm-dd)'] );
+								const ul = $( '<ul>' );
+								for ( const wordcamp of data ) {
+									const li = $( '<li>' ).data( 'wordcamp', wordcamp );
+									li.append( $( '<a>' ).attr( 'href', wordcamp.link ).text( wordcamp.title.rendered ) );
+									li.append( $( '<span>' ).text( ' ' + new Date( 1000 * wordcamp['Start Date (YYYY-mm-dd)'] ).toLocaleDateString( navigator.language, options ) + ' - ' + new Date( 1000 * wordcamp['End Date (YYYY-mm-dd)'] ).toLocaleDateString( navigator.language, options ) ) );
+									ul.append( li );
+								}
+								$( '#quick-add' ).data( 'loaded', true ).removeClass( 'loading' ).append( ul );
+							}
+						);
+					}
+				);
+				$( document ).on(
+					'click',
+					'#quick-add a',
+					function ( e ) {
+						e.preventDefault();
+						e.stopPropagation();
+
+						const wordcamp = $( e.target ).closest( 'li' ).data( 'wordcamp' );
+						if ( ! wordcamp ) {
+							return;
+						}
+
+						$( '#event-title' ).val( wordcamp.title.rendered );
+						$( '#event-description' ).val( wordcamp.content.rendered );
+						$( '#event-start' ).val( new Date( 1000 * wordcamp['Start Date (YYYY-mm-dd)'] ).toISOString().slice( 0,11 ) + '09:00' );
+						$( '#event-end' ).val( new Date( 1000 * wordcamp['End Date (YYYY-mm-dd)'] ).toISOString().slice( 0,11 ) + '18:00' );
+						$( '#event-timezone' ).val( wordcamp['Event Timezone'] );
+
+					}
+				);
+
 			}
 		);
 

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -33,6 +33,7 @@ class Create_Route extends Route {
 		$event_timezone           = null;
 		$event_start              = new Event_Start_Date( date_i18n( 'Y - m - d H:i' ) );
 		$event_end                = new Event_End_Date( date_i18n( 'Y - m - d H:i' ) );
+		$event_slug               = '';
 
 		$this->tmpl( 'events-form', get_defined_vars() );
 	}

--- a/includes/routes/event/edit.php
+++ b/includes/routes/event/edit.php
@@ -45,6 +45,7 @@ class Edit_Route extends Route {
 		$event_timezone           = $event->timezone();
 		$event_start              = $event->start();
 		$event_end                = $event->end();
+		$event_slug               = $event->slug();
 		$create_delete_button     = false;
 		$visibility_delete_button = 'inline-flex';
 		$create_delete_button     = current_user_can( 'delete_translation_event', $event->id() );

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -28,21 +28,22 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 <div class="event-page-wrapper">
 <form class="translation-event-form" action="" method="post">
 	<?php wp_nonce_field( '_event_nonce', '_event_nonce' ); ?>
+	<details id="quick-add"><summary><?php esc_html_e( 'Quick Add', 'gp-translation-events' ); ?></summary><div class="loading"></div></details>
 	<input type="hidden" name="action" value="submit_event_ajax">
 	<input type="hidden" id="form-name" name="form_name" value="<?php echo esc_attr( $event_form_name ); ?>">
 	<input type="hidden" id="event-id" name="event_id" value="<?php echo esc_attr( $event_id ); ?>">
 	<input type="hidden" id="event-form-action" name="event_form_action">
 	<div>
-		<label for="event-title">Event Title</label>
-		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event_title ); ?>" required>
+		<label for="event-title"><?php esc_html_e( 'Event Title', 'gp-translation-events' ); ?></label>
+		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event_title ); ?>" required size="42">
 	</div>
 	<div id="event-url" class="<?php echo esc_attr( $css_show_url ); ?>">
-		<label for="event-permalink">Event URL</label>
+		<label for="event-permalink"><?php esc_html_e( 'Event URL', 'gp-translation-events' ); ?></label>
 		<a id="event-permalink" class="event-permalink" href="<?php echo esc_url( $event_url ); ?>" target="_blank"><?php echo esc_url( $event_url ); ?></a>
 	</div>
 	<div>
-		<label for="event-description">Event Description</label>
-		<textarea id="event-description" name="event_description" rows="4" required><?php echo esc_html( $event_description ); ?></textarea>
+		<label for="event-description"><?php esc_html_e( 'Event Description', 'gp-translation-events' ); ?></label>
+		<textarea id="event-description" name="event_description" rows="4" cols="40" required><?php echo esc_html( $event_description ); ?></textarea>
 		<?php
 		echo wp_kses(
 			Event_Text_Snippet::get_snippet_links(),
@@ -58,15 +59,15 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 		);
 		?>
 			<div>
-		<label for="event-start">Start Date</label>
+		<label for="event-start"><?php esc_html_e( 'Start Date', 'gp-translation-events' ); ?></label>
 		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event_start->format( 'Y-m-d H:i' ) ); ?>" required>
 	</div>
 	<div>
-		<label for="event-end">End Date</label>
+		<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
 		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event_end->format( 'Y-m-d H:i' ) ); ?>" required>
 	</div>
 	<div>
-		<label for="event-timezone">Event Timezone</label>
+		<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>
 		<select id="event-timezone" name="event_timezone" required>
 			<?php
 			echo wp_kses(
@@ -126,8 +127,10 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 </form>
 </div>
-<div class="event-edit-right">
-		<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event->slug() ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
+<?php if ( $event_slug ) : ?>
+	<div class="event-edit-right">
+		<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event_slug ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
 	</div>
+<?php endif; ?>
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -28,7 +28,9 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 <div class="event-page-wrapper">
 <form class="translation-event-form" action="" method="post">
 	<?php wp_nonce_field( '_event_nonce', '_event_nonce' ); ?>
-	<details id="quick-add"><summary><?php esc_html_e( 'Quick Add', 'gp-translation-events' ); ?></summary><div class="loading"></div></details>
+	<?php if ( ! $event_id ) : ?>
+		<details id="quick-add"><summary><?php esc_html_e( 'Upcoming WordCamps', 'gp-translation-events' ); ?></summary><div class="loading"></div></details>
+	<?php endif; ?>
 	<input type="hidden" name="action" value="submit_event_ajax">
 	<input type="hidden" id="form-name" name="form_name" value="<?php echo esc_attr( $event_form_name ); ?>">
 	<input type="hidden" id="event-id" name="event_id" value="<?php echo esc_attr( $event_id ); ?>">


### PR DESCRIPTION
Loads the [next WordCamps](https://central.wordcamp.org/wp-json/wp/v2/wordcamps) and makes it easy to create an event from them:

![quick-add](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/c96b9c55-b879-4d15-8048-19b963c0fdad)


Along the way it fixes a bug where we try accessing the slug() on the not yet created event object.