### PR TITLE
Add Year to event URL

### DIFF
--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -20,21 +20,26 @@ class Event_Repository implements Event_Repository_Interface {
 		$this->attendee_repository = $attendee_repository;
 	}
 
-	public function insert_event( Event $event ) {
-		$year        = $event->start()->utc()->format( 'Y' );
-		$parent_post = get_page_by_path( $year, OBJECT, self::POST_TYPE );
-		if ( ! $parent_post ) {
-			$parent_post = wp_insert_post(
+	private function get_year_post_id( $year ) {
+		$year_post = get_page_by_path( $year, OBJECT, self::POST_TYPE );
+		if ( ! $year_post ) {
+			return wp_insert_post(
 				array(
 					'post_type'    => self::POST_TYPE,
 					'post_title'   => $year,
+					'post_name'    => $year,
 					'post_status'  => 'publish',
 					'post_content' => '',
 				)
 			);
-			if ( $parent_post instanceof WP_Error ) {
-				return $parent_post;
-			}
+		}
+		return $year_post->ID;
+	}
+
+	public function insert_event( Event $event ) {
+		$post_parent = $this->get_year_post_id( $event->start()->utc()->format( 'Y' ) );
+		if ( is_wp_error( $post_parent ) ) {
+			return $post_parent;
 		}
 
 		$event_id_or_error = wp_insert_post(
@@ -44,7 +49,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_title'   => $event->title(),
 				'post_content' => $event->description(),
 				'post_status'  => $event->status(),
-				'post_parent'  => $parent_post->ID,
+				'post_parent'  => $post_parent,
 			)
 		);
 		if ( $event_id_or_error instanceof WP_Error ) {
@@ -57,6 +62,10 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function update_event( Event $event ) {
+		$post_parent = $this->get_year_post_id( $event->start()->utc()->format( 'Y' ) );
+		if ( is_wp_error( $post_parent ) ) {
+			return $post_parent;
+		}
 		$event_id_or_error = wp_update_post(
 			array(
 				'ID'           => $event->id(),
@@ -64,6 +73,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_title'   => $event->title(),
 				'post_content' => $event->description(),
 				'post_status'  => $event->status(),
+				'post_parent'  => $post_parent,
 			)
 		);
 		if ( $event_id_or_error instanceof WP_Error ) {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -20,9 +20,11 @@ class Event_Repository implements Event_Repository_Interface {
 		$this->attendee_repository = $attendee_repository;
 	}
 
-        /*
-         * @return int|WP_Error
-         */
+	/**
+	 * Get or create the parent post for the year.
+	 *
+	 * @return int|WP_Error
+	 */
 	private function get_year_post_id( string $year ) {
 		$year_post = get_page_by_path( $year, OBJECT, self::POST_TYPE );
 		if ( ! $year_post ) {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -20,7 +20,10 @@ class Event_Repository implements Event_Repository_Interface {
 		$this->attendee_repository = $attendee_repository;
 	}
 
-	private function get_year_post_id( $year ) {
+        /*
+         * @return int|WP_Error
+         */
+	private function get_year_post_id( string $year ) {
 		$year_post = get_page_by_path( $year, OBJECT, self::POST_TYPE );
 		if ( ! $year_post ) {
 			return wp_insert_post(

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -21,6 +21,22 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function insert_event( Event $event ) {
+		$year        = $event->start()->utc()->format( 'Y' );
+		$parent_post = get_page_by_path( $year, OBJECT, self::POST_TYPE );
+		if ( ! $parent_post ) {
+			$parent_post = wp_insert_post(
+				array(
+					'post_type'    => self::POST_TYPE,
+					'post_title'   => $year,
+					'post_status'  => 'publish',
+					'post_content' => '',
+				)
+			);
+			if ( $parent_post instanceof WP_Error ) {
+				return $parent_post;
+			}
+		}
+
 		$event_id_or_error = wp_insert_post(
 			array(
 				'post_type'    => self::POST_TYPE,
@@ -28,6 +44,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_title'   => $event->title(),
 				'post_content' => $event->description(),
 				'post_status'  => $event->status(),
+				'post_parent'  => $parent_post->ID,
 			)
 		);
 		if ( $event_id_or_error instanceof WP_Error ) {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -90,6 +90,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $status, $created_event->status() );
 		$this->assertEquals( $title, $created_event->title() );
 		$this->assertEquals( $description, $created_event->description() );
+		$this->assertEquals( '/events/' . $start->format( 'Y' ) . '/foo-title', wp_make_link_relative( get_the_permalink( $event->id() ) ) );
 	}
 
 	public function test_update_event() {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -362,6 +362,7 @@ class Translation_Events {
 		if ( self::CPT !== $post_type || $post_parent ) {
 			return $override_slug;
 		}
+		// Normally the slug is not allowed to be a year, this overrides it since we have a CPT and translate.wordpress.org doesn't have blog posts.
 		if ( preg_match( '/^2[0-9]{3}$/', $slug ) ) {
 			return $slug;
 		}

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -92,7 +92,7 @@ class Translation_Events {
 
 	public function gp_init() {
 		$locale = '(' . implode( '|', wp_list_pluck( GP_Locales::locales(), 'slug' ) ) . ')';
-		$slug   = '([a-z0-9_-]+)';
+		$slug   = '(2[0-9]{3}/[a-z0-9_-]+)';
 		$status = '(waiting)';
 		$id     = '(\d+)';
 
@@ -133,13 +133,14 @@ class Translation_Events {
 		);
 
 		$args = array(
-			'labels'      => $labels,
-			'public'      => true,
-			'has_archive' => true,
-			'menu_icon'   => 'dashicons-calendar',
-			'supports'    => array( 'title', 'editor', 'thumbnail', 'revisions' ),
-			'rewrite'     => array( 'slug' => 'events' ),
-			'show_ui'     => false,
+			'labels'       => $labels,
+			'public'       => true,
+			'has_archive'  => true,
+			'hierarchical' => true,
+			'menu_icon'    => 'dashicons-calendar',
+			'supports'     => array( 'title', 'editor', 'thumbnail', 'revisions' ),
+			'rewrite'      => array( 'slug' => 'events' ),
+			'show_ui'      => false,
 		);
 
 		register_post_type( self::CPT, $args );


### PR DESCRIPTION
By making the post type hierarchical, we can add the year to the slug.

WordCamp Europe in 2024 becomes https://translate.wordpress.org/events/2024/wordcamp-europe/ and in 2025 https://translate.wordpress.org/events/2025/wordcamp-europe/

![add-year](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/9f18c4ab-2b25-4814-8b82-1066a1c43aab)
