### PR TITLE
Fix Manage Attendees Urls

### DIFF
--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -62,7 +62,7 @@ class Host_Event_Route extends Route {
 			$this->event_repository->update_event( $event );
 		}
 
-		wp_safe_redirect( Urls::event_attendees( $event->slug() ) );
+		wp_safe_redirect( Urls::event_attendees( $event->id() ) );
 		exit;
 	}
 }

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -42,7 +42,7 @@ class Urls {
 		return gp_url( '/events/my-events/' );
 	}
 
-	public static function event_attendees( string $event_slug ): string {
-		return gp_url( "/events/$event_slug/attendees" );
+	public static function event_attendees( int $event_id ): string {
+		return self::event_details( $event_id ) . 'attendees/';
 	}
 }

--- a/templates/events-attendees.php
+++ b/templates/events-attendees.php
@@ -16,14 +16,12 @@ gp_tmpl_header();
 $event_page_title = __( 'Manage Attendees', 'gp-translation-events' );
 gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 
-
-
 ?>
 <div class="event-page-wrapper">
 	<div class="event-details-stats">
 	<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>" class="view-event-page">Go to event page</a>
 	<ul class="event-attendees-filter">
-		<li><a class="<?php echo ( ! $is_active_filter ) ? 'active-filter' : ''; ?>" href="<?php echo esc_url( Urls::event_attendees( $event->slug() ) ); ?>"><?php esc_html_e( 'All attendees', 'gp-translation-events' ); ?></a></a></li>
+		<li><a class="<?php echo ( ! $is_active_filter ) ? 'active-filter' : ''; ?>" href="<?php echo esc_url( Urls::event_attendees( $event->id() ) ); ?>"><?php esc_html_e( 'All attendees', 'gp-translation-events' ); ?></a></a></li>
 		<li><a class="<?php echo ( $is_active_filter ) ? 'active-filter' : ''; ?>" href="?filter=hosts"><?php esc_html_e( 'Hosts', 'gp-translation-events' ); ?></a></li>
 	</ul>
 <?php if ( ! empty( $attendees ) ) : ?>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -129,9 +129,9 @@ gp_tmpl_load( 'events-header', get_defined_vars(), __DIR__ );
 	</div>
 </form>
 </div>
-<?php if ( $event_slug ) : ?>
+<?php if ( $event_id ) : ?>
 	<div class="event-edit-right">
-		<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event_slug ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
+		<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event_id ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
 	</div>
 <?php endif; ?>
 <div class="clear"></div>


### PR DESCRIPTION
After #248, the Manage Attendees URL is broken because it directly uses the event slug. This makes it use the already existing `event_details()` method which fixes the links.