### PR TITLE
Enable admin UI

### DIFF
--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -169,9 +169,9 @@ class Translation_Events {
 			$hosts = array( $post->post_author );
 		}
 		?>
-		<label for="event_start">Start Date: </label>
+		<label for="event_start">Start Date (UTC): </label>
 		<input type="datetime-local" id="event_start" name="event_start" value="<?php echo esc_attr( $event_start ); ?>" required><br>
-		<label for="event_end">End Date: </label>
+		<label for="event_end">End Date (UTC): </label>
 		<input type="datetime-local" id="event_end" name="event_end" value="<?php echo esc_attr( $event_end ); ?>" required><br>
 		<label for="event-timezone">Timezone: </label>
 		<select id="event-timezone" name="event_timezone" required>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -164,8 +164,8 @@ class Translation_Events {
 		$event_start    = get_post_meta( $post->ID, '_event_start', true );
 		$event_end      = get_post_meta( $post->ID, '_event_end', true );
 		$event_timezone = get_post_meta( $post->ID, '_event_timezone', true );
-		$hosts          = explode( ',', get_post_meta( $post->ID, '_hosts', true ) );
-		if ( empty( $hosts ) ) {
+		$hosts          = explode( ',', get_post_meta( $post->ID, '_hosts' ) );
+		if ( empty( $hosts[0] ) ) {
 			$hosts = array( $post->post_author );
 		}
 		?>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -141,9 +141,8 @@ class Translation_Events {
 			'has_archive'  => true,
 			'hierarchical' => true,
 			'menu_icon'    => 'dashicons-calendar',
-			'supports'     => array( 'title', 'editor', 'thumbnail', 'revisions' ),
+			'supports'     => array( 'title', 'editor', 'thumbnail', 'revisions', 'page-attributes' ),
 			'rewrite'      => array( 'slug' => 'events' ),
-			'show_ui'      => false,
 		);
 
 		register_post_type( self::CPT, $args );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -192,7 +192,7 @@ class Translation_Events {
 	 * @param  WP_Post $post The current post object.
 	 */
 	public function hosts_meta_box( WP_Post $post ) {
-		$hosts = self::get_attendee_repository()->get_hosts( $post->ID );
+		$hosts      = self::get_attendee_repository()->get_hosts( $post->ID );
 		$hosts_list = array_map(
 			function ( Attendee $host ) {
 				$user = get_user_by( 'ID', $host->user_id() );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -194,24 +194,26 @@ class Translation_Events {
 	 * @param  WP_Post $post The current post object.
 	 */
 	public function hosts_meta_box( WP_Post $post ) {
-		$hosts          = explode( ',', get_post_meta( $post->ID, '_hosts', true ) );
+		$hosts = explode( ',', get_post_meta( $post->ID, '_hosts', true ) );
 		if ( empty( $hosts ) ) {
 			$hosts = array( $post->post_author );
 		}
-		$hosts_list = array_map( function ( $user_id ) {
-			$user = get_user_by( 'ID', $user_id );
-			if ( ! $user ) {
-				return '<i>Unknown user id: ' . esc_html( $user_id ) . '</i>';
-			}
-			return '<a href="' . esc_attr( get_author_posts_url( $user_id ) ). '">' . esc_html( $user->display_name ). '</a>';
-		}, $hosts );
+		$hosts_list = array_map(
+			function ( $user_id ) {
+				$user = get_user_by( 'ID', $user_id );
+				if ( ! $user ) {
+						return '<i>Unknown user id: ' . esc_html( $user_id ) . '</i>';
+				}
+				return '<a href="' . esc_attr( get_author_posts_url( $user_id ) ) . '">' . esc_html( $user->display_name ) . '</a>';
+			},
+			$hosts
+		);
 		echo wp_kses(
 			implode( ', ', $hosts_list ),
 			array(
 				'a' => array( 'href' => array() ),
 			)
 		);
-
 	}
 
 	/**


### PR DESCRIPTION
Fixes #174. If we want to add the year to old events, we need to add the right parent page (see #255). Let's enable the admin UI to achieve that. This PR fixes the event and timezone saving for that and adds a new meta box for hosts.

![Screenshot 2024-05-14 at 15-05-44 Edit Translation Event „WordCamp Europe“ ‹ glotpress local — WordPress](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/800d2306-6eaa-482e-ac6d-3b8fc85f063d)


