### PR TITLE
Fix a bug showing the event creator when the event doesn't have any host

### DIFF
--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -45,7 +45,7 @@ use Wporg\TranslationEvents\Event\Event;
 					else :
 						esc_html_e( 'Created by:', 'gp-translation-events' );
 						?>
-						&nbsp;<a href="<?php echo esc_attr( get_author_posts_url( $user->ID ) ); ?>"><?php echo esc_html( get_the_author_meta( 'display_name', $user->ID ) ); ?></a>
+						&nbsp;<a href="<?php echo esc_attr( get_author_posts_url( $event->author_id() ) ); ?>"><?php echo esc_html( get_the_author_meta( 'display_name', $event->author_id() ) ); ?></a>
 						<?php
 					endif;
 					?>


### PR DESCRIPTION
If the event doesn't have any host, it should show the event creator. Currently, it shows the logged user of an empty string if the user is logged out.

This PR solves this problem, changing the method to get the ID of the author of the post.

To test it:
- Create an event.
- Remove all hosts.
- Open the event page with the event creator logged.
- Open the event page with a different user logged.
- Open the event page without any user logged.
- In these 3 situations, you should see the event creator after the "Created by: " text.

Fixes #259.