### PR TITLE
Add buttons to event lists

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -135,6 +135,7 @@ span.event-list-date.events-i-am-attending {
 	font-weight: normal;
 }
 
+/* Event title. */
 .event-list-item a:first-child {
 	font-weight: bold;
 	font-size: 1.2em;
@@ -143,6 +144,17 @@ span.event-list-date.events-i-am-attending {
 li.event-list-item {
 	list-style-type: none;
 	margin-bottom: .5em;
+}
+
+.event-list-item-button {
+	text-decoration: none;
+	vertical-align: bottom;
+}
+.event-list-item-button:nth-child(2) { /* The first button. */
+	margin-left: .3em;
+}
+.event-list-item-button.is-destructive {
+	color: var(--gp-color-btn-danger-text);
 }
 
 li.event-list-item p {

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -135,7 +135,7 @@ span.event-list-date.events-i-am-attending {
 	font-weight: normal;
 }
 
-.event-list-item a {
+.event-list-item a:first-child {
 	font-weight: bold;
 	font-size: 1.2em;
 }

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -100,7 +100,7 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_manage( WP_User $user ): bool {
-		return $this->is_gp_admin( $user );
+		return apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->user_can( $user, 'admin' ) );
 	}
 
 	/**
@@ -110,7 +110,7 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_create( WP_User $user ): bool {
-		return $this->is_gp_admin( $user );
+		return $this->has_manage( $user );
 	}
 
 	/**
@@ -121,7 +121,7 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_view( WP_User $user, Event $event ): bool {
-		if ( $this->is_gp_admin( $user ) ) {
+		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 
@@ -157,7 +157,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		if ( $this->is_gp_admin( $user ) ) {
+		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 
@@ -183,7 +183,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		if ( $this->is_gp_admin( $user ) ) {
+		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 
@@ -205,7 +205,7 @@ class Event_Capabilities {
 			return false;
 		}
 
-		if ( $this->is_gp_admin( $user ) ) {
+		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 
@@ -220,7 +220,7 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit_attendees( WP_User $user, Event $event ): bool {
-		if ( $this->is_gp_admin( $user ) ) {
+		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 
@@ -234,16 +234,6 @@ class Event_Capabilities {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Evaluate whether a user is a GlotPress admin.
-	 *
-	 * @param WP_User $user User for which we're evaluating the capability.
-	 * @return bool
-	 */
-	private function is_gp_admin( WP_User $user ): bool {
-		return apply_filters( 'gp_translation_events_can_crud_event', GP::$permission->user_can( $user, 'admin' ) );
 	}
 
 	public function register_hooks(): void {

--- a/includes/routes/user/my-events.php
+++ b/includes/routes/user/my-events.php
@@ -65,9 +65,10 @@ class My_Events_Route extends Route {
 		$this->render(
 			'events-my-events',
 			array(
-				'events_i_created_query'  => $events_i_created_query,
-				'events_i_host_query'     => $events_i_host_query,
-				'events_i_attended_query' => $events_i_attended_query,
+				'events_i_am_or_will_attend_query' => $events_i_am_or_will_attend_query,
+				'events_i_created_query'           => $events_i_created_query,
+				'events_i_host_query'              => $events_i_host_query,
+				'events_i_attended_query'          => $events_i_attended_query,
 			),
 		);
 	}

--- a/includes/templates.php
+++ b/includes/templates.php
@@ -14,4 +14,8 @@ class Templates {
 	public static function footer( array $data = array() ) {
 		self::render( 'footer', $data );
 	}
+
+	public static function partial( string $template, array $data ) {
+		self::render( "partials/$template", $data );
+	}
 }

--- a/includes/templates.php
+++ b/includes/templates.php
@@ -8,11 +8,11 @@ class Templates {
 	}
 
 	public static function header( array $data ) {
-		self::render( 'header', $data );
+		self::partial( 'header', $data );
 	}
 
 	public static function footer( array $data = array() ) {
-		self::render( 'footer', $data );
+		self::partial( 'footer', $data );
 	}
 
 	public static function partial( string $template, array $data ) {

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -1,3 +1,8 @@
+<?php
+namespace Wporg\TranslationEvents\Templates;
+
+?>
+
 </div>
 <div class="clear"></div>
 <script type="text/javascript">

--- a/templates/event-translations-header.php
+++ b/templates/event-translations-header.php
@@ -1,9 +1,8 @@
 <?php
+namespace Wporg\TranslationEvents\Templates;
 
-namespace Wporg\TranslationEvents;
-
-use GP;
 use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Urls;
 
 /** @var Event  $event */
 

--- a/templates/event.php
+++ b/templates/event.php
@@ -2,8 +2,7 @@
 /**
  * Template for event page.
  */
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use GP_Locales;
 use WP_User;
@@ -11,6 +10,8 @@ use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Stats\Event_Stats;
 use Wporg\TranslationEvents\Stats\Stats_Row;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /** @var bool $user_is_attending */
 /** @var bool $user_is_contributor */

--- a/templates/events-attendees.php
+++ b/templates/events-attendees.php
@@ -2,10 +2,11 @@
 /**
  * Attendees list page.
  */
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /**  @var Event $event */
 /** @var bool $is_active_filter */

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -2,10 +2,12 @@
 /**
  * Template for event form.
  */
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Event;
+use Wporg\TranslationEvents\Event_Text_Snippet;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /** @var bool $is_create_form */
 /** @var Event $event */

--- a/templates/events-list-trashed.php
+++ b/templates/events-list-trashed.php
@@ -3,7 +3,6 @@ namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
 use Wporg\TranslationEvents\Templates;
-use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $trashed_events_query */
 
@@ -20,37 +19,16 @@ Templates::header(
 		<?php if ( empty( $trashed_events_query->events ) ) : ?>
 			<?php esc_html_e( 'No deleted events found.', 'gp-translation-events' ); ?>
 		<?php else : ?>
-			<ul class="event-list">
-				<?php foreach ( $trashed_events_query->events as $event ) : ?>
-					<li class="event-list-item">
-						<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-						<?php if ( current_user_can( 'trash_translation_event', $event->id() ) ) : ?>
-							<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small">Restore</a>
-						<?php endif; ?>
-						<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
-							<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
-						<?php endif; ?>
-						<?php if ( $event->is_past() ) : ?>
-							<span class="event-list-date">ended <?php $event->end()->print_relative_time_html(); ?></time></span>
-						<?php else : ?>
-							<span class="event-list-date">ends <?php $event->end()->print_relative_time_html(); ?></time></span>
-						<?php endif; ?>
-						<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
-					</li>
-				<?php endforeach; ?>
-			</ul>
-
 			<?php
-			echo wp_kses_post(
-				paginate_links(
-					array(
-						'total'     => $trashed_events_query->page_count,
-						'current'   => $trashed_events_query->current_page,
-						'format'    => '?page=%#%',
-						'prev_text' => '&laquo; Previous',
-						'next_text' => 'Next &raquo;',
-					)
-				) ?? ''
+			Templates::partial(
+				'event-list',
+				array(
+					'query'                  => $trashed_events_query,
+					'pagination_query_param' => 'page',
+					'show_start'             => true,
+					'show_end'               => true,
+					'relative_time'          => false,
+				),
 			);
 			?>
 		<?php endif; ?>

--- a/templates/events-list-trashed.php
+++ b/templates/events-list-trashed.php
@@ -1,8 +1,9 @@
 <?php
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $trashed_events_query */
 

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -2,13 +2,14 @@
 /**
  * Events list page.
  */
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use DateTime;
 use WP_Query;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Events_Query_Result;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $current_events_query */
 /** @var Events_Query_Result $upcoming_events_query */

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -24,6 +24,10 @@ Templates::header(
 <div class="event-page-wrapper">
 <div class="event-left-col">
 <?php
+if ( empty( $current_events_query->events ) && empty( $upcoming_events_query->events ) && empty( $past_events_query->post_count ) ) :
+	esc_html_e( 'No events found.', 'gp-translation-events' );
+endif;
+
 if ( ! empty( $current_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Current events', 'gp-translation-events' ); ?></h2>
@@ -65,11 +69,8 @@ if ( ! empty( $past_events_query->events ) ) :
 		),
 	);
 endif;
-
-if ( empty( $current_events_query->events ) && empty( $upcoming_events_query->events ) && empty( $past_events_query->post_count ) ) :
-	esc_html_e( 'No events found.', 'gp-translation-events' );
-endif;
 ?>
+
 </div>
 <?php if ( is_user_logged_in() ) : ?>
 	<div class="event-right-col">

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -82,11 +82,7 @@ endif;
 				<?php foreach ( $user_attending_events_query->events as $event ) : ?>
 					<li class="event-list-item">
 						<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-						<?php if ( $event->start() === $event->end() ) : ?>
-							<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?></span>
-						<?php else : ?>
-							<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?> - <?php $event->end()->print_time_html( 'F j, Y H:i T' ); ?></span>
-						<?php endif; ?>
+						<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?> - <?php $event->end()->print_time_html( 'F j, Y H:i T' ); ?></span>
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -6,7 +6,6 @@ namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
 use Wporg\TranslationEvents\Templates;
-use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $current_events_query */
 /** @var Events_Query_Result $upcoming_events_query */
@@ -78,28 +77,20 @@ endif;
 		<?php if ( empty( $user_attending_events_query->events ) ) : ?>
 			<p>You don't have any events to attend.</p>
 		<?php else : ?>
-			<ul class="event-attending-list">
-				<?php foreach ( $user_attending_events_query->events as $event ) : ?>
-					<li class="event-list-item">
-						<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-						<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html( 'F j, Y H:i T' ); ?> - <?php $event->end()->print_time_html( 'F j, Y H:i T' ); ?></span>
-					</li>
-				<?php endforeach; ?>
-			</ul>
 			<?php
-				echo wp_kses_post(
-					paginate_links(
-						array(
-							'total'     => $user_attending_events_query->page_count,
-							'current'   => $user_attending_events_query->current_page,
-							'format'    => '?user_attending_events_paged=%#%',
-							'prev_text' => '&laquo; Previous',
-							'next_text' => 'Next &raquo;',
-						)
-					) ?? ''
-				);
-
-				wp_reset_postdata();
+			Templates::partial(
+				'event-list',
+				array(
+					'query'                  => $user_attending_events_query,
+					'pagination_query_param' => 'user_attending_events_paged',
+					'show_start'             => true,
+					'show_end'               => true,
+					'show_excerpt'           => false,
+					'date_format'            => 'F j, Y H:i T',
+					'relative_time'          => false,
+					'classes'                => array( 'event-attending-list' ),
+				),
+			);
 		endif;
 		?>
 	</div>

--- a/templates/events-list.php
+++ b/templates/events-list.php
@@ -4,9 +4,6 @@
  */
 namespace Wporg\TranslationEvents\Templates;
 
-use DateTime;
-use WP_Query;
-use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Events_Query_Result;
 use Wporg\TranslationEvents\Templates;
 use Wporg\TranslationEvents\Urls;
@@ -30,87 +27,43 @@ Templates::header(
 if ( ! empty( $current_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Current events', 'gp-translation-events' ); ?></h2>
-	<ul class="event-list">
-		<?php foreach ( $current_events_query->events as $event ) : ?>
-			<li class="event-list-item">
-				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<span class="event-list-date">ends <?php $event->end()->print_relative_time_html(); ?></time></span>
-				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
-			</li>
-		<?php endforeach; ?>
-	</ul>
-
 	<?php
-	echo wp_kses_post(
-		paginate_links(
-			array(
-				'total'     => $current_events_query->page_count,
-				'current'   => $current_events_query->current_page,
-				'format'    => '?current_events_paged=%#%',
-				'prev_text' => '&laquo; Previous',
-				'next_text' => 'Next &raquo;',
-			)
-		) ?? ''
+	Templates::partial(
+		'event-list',
+		array(
+			'query'                  => $current_events_query,
+			'pagination_query_param' => 'current_events_paged',
+			'show_end'               => true,
+		),
 	);
-
-	wp_reset_postdata();
 endif;
 
 if ( ! empty( $upcoming_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Upcoming events', 'gp-translation-events' ); ?></h2>
-	<ul class="event-list">
-		<?php foreach ( $upcoming_events_query->events as $event ) : ?>
-			<li class="event-list-item">
-				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<span class="event-list-date">starts <?php $event->start()->print_relative_time_html(); ?></span>
-				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
-			</li>
-		<?php endforeach; ?>
-	</ul>
-
 	<?php
-	echo wp_kses_post(
-		paginate_links(
-			array(
-				'total'     => $upcoming_events_query->page_count,
-				'current'   => $upcoming_events_query->current_page,
-				'format'    => '?upcoming_events_paged=%#%',
-				'prev_text' => '&laquo; Previous',
-				'next_text' => 'Next &raquo;',
-			)
-		) ?? ''
+	Templates::partial(
+		'event-list',
+		array(
+			'query'                  => $upcoming_events_query,
+			'pagination_query_param' => 'upcoming_events_paged',
+			'show_start'             => true,
+		),
 	);
-
-	wp_reset_postdata();
 endif;
+
 if ( ! empty( $past_events_query->events ) ) :
 	?>
 	<h2><?php esc_html_e( 'Past events', 'gp-translation-events' ); ?></h2>
-	<ul class="event-list">
-		<?php foreach ( $past_events_query->events as $event ) : ?>
-			<li class="event-list-item">
-				<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<span class="event-list-date">ended <?php $event->end()->print_relative_time_html( 'F j, Y H:i T' ); ?></span>
-				<?php esc_html( get_the_excerpt( $event->id() ) ); ?>
-			</li>
-		<?php endforeach; ?>
-	</ul>
-
 	<?php
-	echo wp_kses_post(
-		paginate_links(
-			array(
-				'total'     => $past_events_query->page_count,
-				'current'   => $past_events_query->current_page,
-				'format'    => '?past_events_paged=%#%',
-				'prev_text' => '&laquo; Previous',
-				'next_text' => 'Next &raquo;',
-			)
-		) ?? ''
+	Templates::partial(
+		'event-list',
+		array(
+			'query'                  => $past_events_query,
+			'pagination_query_param' => 'past_events_paged',
+			'show_end'               => true,
+		),
 	);
-
-	wp_reset_postdata();
 endif;
 
 if ( empty( $current_events_query->events ) && empty( $upcoming_events_query->events ) && empty( $past_events_query->post_count ) ) :

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -2,11 +2,12 @@
 /**
  * Template for My Events.
  */
-
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
+use Wporg\TranslationEvents\Templates;
+use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $events_i_created_query */
 /** @var Events_Query_Result $events_i_host_query */

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -6,7 +6,6 @@ namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
 use Wporg\TranslationEvents\Templates;
-use Wporg\TranslationEvents\Urls;
 
 /** @var Events_Query_Result $events_i_created_query */
 /** @var Events_Query_Result $events_i_host_query */
@@ -22,6 +21,12 @@ Templates::header(
 ?>
 
 <div class="event-page-wrapper">
+	<?php
+	if ( empty( $events_i_created_query->events ) && empty( $events_i_host_query->events ) && empty( $events_i_attended_query->post_count ) ) :
+		esc_html_e( 'No events found.', 'gp-translation-events' );
+	endif;
+	?>
+
 	<?php if ( ! empty( $events_i_host_query->events ) ) : ?>
 		<h2><?php esc_html_e( 'Events I host', 'gp-translation-events' ); ?> </h2>
 		<?php
@@ -54,8 +59,8 @@ Templates::header(
 	endif;
 	?>
 
-	<h2><?php esc_html_e( 'Events I attended', 'gp-translation-events' ); ?> </h2>
 	<?php if ( ! empty( $events_i_attended_query->events ) ) : ?>
+		<h2><?php esc_html_e( 'Events I attended', 'gp-translation-events' ); ?> </h2>
 		<?php
 		Templates::partial(
 			'event-list',
@@ -67,8 +72,6 @@ Templates::header(
 				'relative_time'          => false,
 			),
 		);
-	else :
-		echo 'No events found.';
 	endif;
 	?>
 </div>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -24,108 +24,49 @@ Templates::header(
 <div class="event-page-wrapper">
 	<?php if ( ! empty( $events_i_host_query->events ) ) : ?>
 		<h2><?php esc_html_e( 'Events I host', 'gp-translation-events' ); ?> </h2>
-		<ul>
 		<?php
-		foreach ( $events_i_host_query->events as $event ) :
-			?>
-			<li class="event-list-item">
-				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-					<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
-				<?php endif; ?>
-				<?php if ( 'draft' === $event->status() ) : ?>
-					<span class="event-label-<?php echo esc_attr( $event->status() ); ?>"><?php echo esc_html( $event->status() ); ?></span>
-				<?php endif; ?>
-				<?php if ( $event->start()->format( 'Y-m-d' ) === $event->end()->format( 'Y-m-d' ) ) : ?>
-					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?></span>
-				<?php else : ?>
-					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
-				<?php endif; ?>
-				<p><?php echo esc_html( get_the_excerpt( $event->id() ) ); ?></p>
-			</li>
-		<?php endforeach; ?>
-		</ul>
-
-		<?php
-		echo wp_kses_post(
-			paginate_links(
-				array(
-					'total'     => $events_i_host_query->page_count,
-					'current'   => $events_i_host_query->current_page,
-					'format'    => '?events_i_hosted_paged=%#%',
-					'prev_text' => '&laquo; Previous',
-					'next_text' => 'Next &raquo;',
-				)
-			) ?? ''
+		Templates::partial(
+			'event-list',
+			array(
+				'query'                  => $events_i_host_query,
+				'pagination_query_param' => 'events_i_hosted_paged',
+				'show_start'             => true,
+				'show_end'               => true,
+				'relative_time'          => false,
+			),
 		);
-
-		wp_reset_postdata();
 	endif;
 	?>
 
 	<?php if ( ! empty( $events_i_created_query->events ) ) : ?>
 		<h2><?php esc_html_e( 'Events I have created', 'gp-translation-events' ); ?> </h2>
-		<ul>
-			<?php
-			foreach ( $events_i_created_query->events as $event ) :
-				?>
-				<li class="event-list-item">
-					<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-					<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-						<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
-					<?php endif; ?>
-					<?php if ( 'draft' === $event->status() ) : ?>
-						<span class="event-label-<?php echo esc_attr( $event->status() ); ?>"><?php echo esc_html( $event->status() ); ?></span>
-					<?php endif; ?>
-					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
-					<p><?php echo esc_html( get_the_excerpt( $event->id() ) ); ?></p>
-				</li>
-			<?php endforeach; ?>
-		</ul>
-
 		<?php
-		echo wp_kses_post(
-			paginate_links(
-				array(
-					'total'     => $events_i_created_query->page_count,
-					'current'   => $events_i_created_query->current_page,
-					'format'    => '?events_i_created_paged=%#%',
-					'prev_text' => '&laquo; Previous',
-					'next_text' => 'Next &raquo;',
-				)
-			) ?? ''
+		Templates::partial(
+			'event-list',
+			array(
+				'query'                  => $events_i_created_query,
+				'pagination_query_param' => 'events_i_created_paged',
+				'show_start'             => true,
+				'show_end'               => true,
+				'relative_time'          => false,
+			),
 		);
-
-		wp_reset_postdata();
 	endif;
 	?>
 
 	<h2><?php esc_html_e( 'Events I attended', 'gp-translation-events' ); ?> </h2>
 	<?php if ( ! empty( $events_i_attended_query->events ) ) : ?>
-		<ul>
-		<?php foreach ( $events_i_attended_query->events as $event ) : ?>
-			<li class="event-list-item">
-				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
-				<p><?php echo esc_html( get_the_excerpt( $event->id() ) ); ?></p>
-			</li>
-		<?php endforeach; ?>
-		</ul>
-
 		<?php
-		echo wp_kses_post(
-			paginate_links(
-				array(
-					'total'     => $events_i_attended_query->page_count,
-					'current'   => $events_i_attended_query->current_page,
-					'format'    => '?events_i_attended_paged=%#%',
-					'prev_text' => '&laquo; Previous',
-					'next_text' => 'Next &raquo;',
-				)
-			) ?? ''
+		Templates::partial(
+			'event-list',
+			array(
+				'query'                  => $events_i_attended_query,
+				'pagination_query_param' => 'events_i_attended_paged',
+				'show_start'             => true,
+				'show_end'               => true,
+				'relative_time'          => false,
+			),
 		);
-
-		wp_reset_postdata();
 	else :
 		echo 'No events found.';
 	endif;

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -5,7 +5,6 @@
 namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Event\Events_Query_Result;
-use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Templates;
 use Wporg\TranslationEvents\Urls;
 
@@ -28,12 +27,10 @@ Templates::header(
 		<ul>
 		<?php
 		foreach ( $events_i_host_query->events as $event ) :
-			$stats_calculator = new Stats_Calculator();
-			$has_stats        = $stats_calculator->event_has_stats( $event->id() );
 			?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<?php if ( ! $event->end()->is_in_the_past() && ! $has_stats ) : ?>
+				<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 					<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 				<?php endif; ?>
 				<?php if ( 'draft' === $event->status() ) : ?>
@@ -71,12 +68,10 @@ Templates::header(
 		<ul>
 			<?php
 			foreach ( $events_i_created_query->events as $event ) :
-				$stats_calculator = new Stats_Calculator();
-				$has_stats        = $stats_calculator->event_has_stats( $event->id() );
 				?>
 				<li class="event-list-item">
 					<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-					<?php if ( ! $event->end()->is_in_the_past() && ! $has_stats ) : ?>
+					<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 						<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 					<?php endif; ?>
 					<?php if ( 'draft' === $event->status() ) : ?>

--- a/templates/events-my-events.php
+++ b/templates/events-my-events.php
@@ -77,11 +77,7 @@ Templates::header(
 					<?php if ( 'draft' === $event->status() ) : ?>
 						<span class="event-label-<?php echo esc_attr( $event->status() ); ?>"><?php echo esc_html( $event->status() ); ?></span>
 					<?php endif; ?>
-					<?php if ( $event->start()->format( 'Y-m-d' ) === $event->end()->format( 'Y-m-d' ) ) : ?>
-						<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?></span>
-					<?php else : ?>
-						<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
-					<?php endif; ?>
+					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
 					<p><?php echo esc_html( get_the_excerpt( $event->id() ) ); ?></p>
 				</li>
 			<?php endforeach; ?>
@@ -110,11 +106,7 @@ Templates::header(
 		<?php foreach ( $events_i_attended_query->events as $event ) : ?>
 			<li class="event-list-item">
 				<a class="event-link-<?php echo esc_attr( $event->status() ); ?>" href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
-				<?php if ( $event->start() === $event->end() ) : ?>
-					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?></span>
-				<?php else : ?>
-					<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
-				<?php endif; ?>
+				<span class="event-list-date events-i-am-attending"><?php $event->start()->print_time_html(); ?> - <?php $event->end()->print_time_html(); ?></span>
 				<p><?php echo esc_html( get_the_excerpt( $event->id() ) ); ?></p>
 			</li>
 		<?php endforeach; ?>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,2 +1,7 @@
+<?php
+namespace Wporg\TranslationEvents\Templates;
+
+?>
+
 <div class="clear"></div>
 <?php gp_tmpl_footer(); ?>

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,4 +1,5 @@
 <?php
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Urls;
 

--- a/templates/helper-functions.php
+++ b/templates/helper-functions.php
@@ -1,4 +1,5 @@
 <?php
+namespace Wporg\TranslationEvents\Templates;
 
 use Wporg\TranslationEvents\Urls;
 

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -1,0 +1,75 @@
+<?php
+namespace Wporg\TranslationEvents\Templates\Partials;
+
+use Wporg\TranslationEvents\Event\Event_End_Date;
+use Wporg\TranslationEvents\Event\Event_Start_Date;
+use Wporg\TranslationEvents\Event\Events_Query_Result;
+use Wporg\TranslationEvents\Urls;
+
+/** @var Events_Query_Result $query */
+/** @var ?string $pagination_query_param */
+/** @var ?bool $show_start */
+/** @var ?bool $show_end */
+/** @var ?bool $show_excerpt */
+/** @var ?string $date_format */
+/** @var ?bool $relative_time */
+/** @var ?string[] $extra_classes */
+
+$show_start    = $show_start ?? false;
+$show_end      = $show_end ?? false;
+$show_excerpt  = $show_excerpt ?? true;
+$date_format   = $date_format ?? '';
+$relative_time = $relative_time ?? true;
+$extra_classes = isset( $extra_classes ) ? implode( $extra_classes, ' ' ) : '';
+
+/**
+ * @param Event_Start_Date|Event_End_Date $time
+ */
+$print_time = function ( $time ) use ( $date_format, $relative_time ): void {
+	if ( $relative_time ) {
+		$time->print_time_html( $date_format );
+	} else {
+		$time->print_relative_time_html( $date_format );
+	}
+};
+?>
+
+<ul class="event-list <?php echo esc_attr( $extra_classes ); ?>">
+	<?php foreach ( $query->events as $event ) : ?>
+		<li class="event-list-item">
+			<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+			<?php if ( $show_start ) : ?>
+				<?php if ( $event->start()->is_in_the_past() ) : ?>
+					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>
+				<?php else : ?>
+					<span class="event-list-date">starts <?php $print_time( $event->start() ); ?></span>
+				<?php endif; ?>
+			<?php endif; ?>
+			<?php if ( $show_end ) : ?>
+				<?php if ( $event->end()->is_in_the_past() ) : ?>
+					<span class="event-list-date">ended <?php $print_time( $event->end() ); ?></span>
+				<?php else : ?>
+					<span class="event-list-date">ends <?php $print_time( $event->end() ); ?></time></span>
+				<?php endif; ?>
+			<?php endif; ?>
+			<?php if ( $show_excerpt ) : ?>
+				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
+			<?php endif; ?>
+		</li>
+	<?php endforeach; ?>
+</ul>
+
+<?php
+if ( ! empty( $pagination_parameter ) ) {
+	echo wp_kses_post(
+		paginate_links(
+			array(
+				'total'     => $query->page_count,
+				'current'   => $query->current_page,
+				'format'    => "?$pagination_query_param=%#%",
+				'prev_text' => '&laquo; Previous',
+				'next_text' => 'Next &raquo;',
+			)
+		) ?? ''
+	);
+}

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -59,10 +59,8 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small is-destructive">Delete</a>
 				<?php endif; ?>
 			<?php endif; ?>
-			<?php if ( current_user_can( 'manage_translation_events' ) ) : ?>
-				<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
-					<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
-				<?php endif; ?>
+			<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
+				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
 			<?php endif; ?>
 
 			<?php // Dates. ?>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -37,6 +37,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 <ul class="event-list <?php echo esc_attr( $extra_classes ); ?>">
 	<?php foreach ( $query->events as $event ) : ?>
 		<li class="event-list-item">
+			<?php // Title. ?>
 			<?php // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>
 			<a <?php if ( $event->is_draft() ) : ?>class="event-link-draft" <?php endif; ?>
 				href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"
@@ -46,6 +47,8 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php if ( $event->is_draft() ) : ?>
 				<span class="event-label-draft">Draft</span>
 			<?php endif; ?>
+
+			<?php // Buttons. ?>
 			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 			<?php endif; ?>
@@ -61,6 +64,8 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
 				<?php endif; ?>
 			<?php endif; ?>
+
+			<?php // Dates. ?>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
 					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>
@@ -75,6 +80,8 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					<span class="event-list-date">ends <?php $print_time( $event->end() ); ?></time></span>
 				<?php endif; ?>
 			<?php endif; ?>
+
+			<?php // Excerpt. ?>
 			<?php if ( $show_excerpt ) : ?>
 				<?php echo esc_html( get_the_excerpt( $event->id() ) ); ?>
 			<?php endif; ?>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -43,6 +43,9 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			>
 				<?php echo esc_html( $event->title() ); ?>
 			</a>
+			<?php if ( $event->is_draft() ) : ?>
+				<span class="event-label-draft">Draft</span>
+			<?php endif; ?>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
 					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -27,9 +27,9 @@ $extra_classes = isset( $extra_classes ) ? implode( $extra_classes, ' ' ) : '';
  */
 $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 	if ( $relative_time ) {
-		$time->print_time_html( $date_format );
-	} else {
 		$time->print_relative_time_html( $date_format );
+	} else {
+		$time->print_time_html( $date_format );
 	}
 };
 ?>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -46,6 +46,9 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php if ( $event->is_draft() ) : ?>
 				<span class="event-label-draft">Draft</span>
 			<?php endif; ?>
+			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
+				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
+			<?php endif; ?>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
 					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -88,7 +88,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 </ul>
 
 <?php
-if ( ! empty( $pagination_parameter ) ) {
+if ( ! empty( $pagination_query_param ) ) {
 	echo wp_kses_post(
 		paginate_links(
 			array(

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -37,7 +37,12 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 <ul class="event-list <?php echo esc_attr( $extra_classes ); ?>">
 	<?php foreach ( $query->events as $event ) : ?>
 		<li class="event-list-item">
-			<a href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"><?php echo esc_html( $event->title() ); ?></a>
+			<?php // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>
+			<a <?php if ( $event->is_draft() ) : ?>class="event-link-draft" <?php endif; ?>
+				href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"
+			>
+				<?php echo esc_html( $event->title() ); ?>
+			</a>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
 					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -50,27 +50,31 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php // Buttons. ?>
 			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"
-					class="button is-small action edit">
-					Edit
+					class="button is-small action edit"
+					title="<?php echo esc_attr__( 'Edit', 'gp-translation-events' ); ?>">
+					<span class="dashicons dashicons-edit"></span>
 				</a>
 			<?php endif; ?>
 			<?php if ( current_user_can( 'trash_translation_event', $event->id() ) ) : ?>
 				<?php if ( $event->is_trashed() ) : ?>
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
-						class="button is-small">
-						Restore
+						class="button is-small"
+						title="<?php echo esc_attr__( 'Restore', 'gp-translation-events' ); ?>">
+						<?php echo esc_attr__( 'Restore', 'gp-translation-events' ); ?>
 					</a>
 				<?php else : ?>
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
-						class="button is-small is-destructive">
-						Delete
+						class="button is-small is-destructive"
+						title="<?php echo esc_attr__( 'Delete', 'gp-translation-events' ); ?>">
+						<span class="dashicons dashicons-trash"></span>
 					</a>
 				<?php endif; ?>
 			<?php endif; ?>
 			<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>"
-					class="button is-small is-destructive">
-					Delete Permanently
+					class="button is-small is-destructive"
+					title="<?php echo esc_attr__( 'Delete permanently', 'gp-translation-events' ); ?>">
+					<?php echo esc_attr__( 'Delete permanently', 'gp-translation-events' ); ?>
 				</a>
 			<?php endif; ?>
 

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -50,7 +50,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php // Buttons. ?>
 			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"
-					class="button is-small action edit"
+					class="event-list-item-button"
 					title="<?php echo esc_attr__( 'Edit', 'gp-translation-events' ); ?>">
 					<span class="dashicons dashicons-edit"></span>
 				</a>
@@ -64,7 +64,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					</a>
 				<?php else : ?>
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
-						class="button is-small is-destructive"
+						class="event-list-item-button is-destructive"
 						title="<?php echo esc_attr__( 'Delete', 'gp-translation-events' ); ?>">
 						<span class="dashicons dashicons-trash"></span>
 					</a>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -49,6 +49,18 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
 			<?php endif; ?>
+			<?php if ( current_user_can( 'trash_translation_event', $event->id() ) ) : ?>
+				<?php if ( $event->is_trashed() ) : ?>
+					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small">Restore</a>
+				<?php else : ?>
+					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small is-destructive">Delete</a>
+				<?php endif; ?>
+			<?php endif; ?>
+			<?php if ( current_user_can( 'manage_translation_events' ) ) : ?>
+				<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
+					<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
+				<?php endif; ?>
+			<?php endif; ?>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
 					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -40,8 +40,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php // Title. ?>
 			<?php // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>
 			<a <?php if ( $event->is_draft() ) : ?>class="event-link-draft" <?php endif; ?>
-				href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>"
-			>
+				href="<?php echo esc_url( Urls::event_details( $event->id() ) ); ?>">
 				<?php echo esc_html( $event->title() ); ?>
 			</a>
 			<?php if ( $event->is_draft() ) : ?>
@@ -50,17 +49,29 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 
 			<?php // Buttons. ?>
 			<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>" class="button is-small action edit">Edit</a>
+				<a href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"
+					class="button is-small action edit">
+					Edit
+				</a>
 			<?php endif; ?>
 			<?php if ( current_user_can( 'trash_translation_event', $event->id() ) ) : ?>
 				<?php if ( $event->is_trashed() ) : ?>
-					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small">Restore</a>
+					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
+						class="button is-small">
+						Restore
+					</a>
 				<?php else : ?>
-					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>" class="button is-small is-destructive">Delete</a>
+					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
+						class="button is-small is-destructive">
+						Delete
+					</a>
 				<?php endif; ?>
 			<?php endif; ?>
 			<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
-				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>" class="button is-small is-destructive">Delete Permanently</a>
+				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>"
+					class="button is-small is-destructive">
+					Delete Permanently
+				</a>
 			<?php endif; ?>
 
 			<?php // Dates. ?>

--- a/templates/partials/footer.php
+++ b/templates/partials/footer.php
@@ -1,5 +1,5 @@
 <?php
-namespace Wporg\TranslationEvents\Templates;
+namespace Wporg\TranslationEvents\Templates\Partials;
 
 ?>
 

--- a/templates/partials/header.php
+++ b/templates/partials/header.php
@@ -1,7 +1,8 @@
 <?php
-namespace Wporg\TranslationEvents\Templates;
+namespace Wporg\TranslationEvents\Templates\Partials;
 
 use Wporg\TranslationEvents\Urls;
+use function Wporg\TranslationEvents\Templates\gp_breadcrumb_translation_events;
 
 /** @var string $html_title */
 /** @var string|callable $page_title */

--- a/templates/translations.php
+++ b/templates/translations.php
@@ -1,5 +1,5 @@
 <?php
-namespace Wporg\TranslationEvents;
+namespace Wporg\TranslationEvents\Templates;
 
 use GP;
 use Wporg\TranslationEvents\Event\Event;

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -210,7 +210,7 @@ class Translation_Events {
 	}
 
 	public function register_translation_event_js() {
-		wp_register_style( 'translation-events-css', plugins_url( 'assets/css/translation-events.css', __FILE__ ), array(), filemtime( __DIR__ . '/assets/css/translation-events.css' ) );
+		wp_register_style( 'translation-events-css', plugins_url( 'assets/css/translation-events.css', __FILE__ ), array( 'dashicons' ), filemtime( __DIR__ . '/assets/css/translation-events.css' ) );
 		gp_enqueue_style( 'translation-events-css' );
 		wp_register_script( 'translation-events-js', plugins_url( 'assets/js/translation-events.js', __FILE__ ), array( 'jquery', 'gp-common' ), filemtime( __DIR__ . '/assets/js/translation-events.js' ), false );
 		gp_enqueue_script( 'translation-events-js' );


### PR DESCRIPTION
Fixes #247

This PR adds a "partial template" that renders a list of events, and uses that partial everywhere we need to render a list of events. This simplifies things quite a bit IMHO.

Additionally, "Edit", "Delete", "Restore" and "Delete permanently" buttons were added to each entry in the list, provided that the user has permissions to do those actions on a given event.

The buttons don't look great, but we can improve that later, if that's ok with you. Note that most users won't see the buttons, they will only see edit and delete for events they are hosts of.

## Testing instructions

This PR only changes the pages that render lists of events (listed below). Testing this PR means taking a look at those pages to make sure they render correctly.

- Home page
- My events
- Deleted events

## Screen captures

<img width="939" alt="Screenshot 2024-05-14 at 14 56 21" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/137823c6-b6a2-463f-87fb-f2c17711d55a">

<img width="939" alt="Screenshot 2024-05-14 at 14 57 03" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/e3da2f14-5a52-4617-b99f-f407a5aa10a4">
 

<img width="953" alt="Screenshot 2024-05-10 at 15 33 33" src="https://github.com/WordPress/wporg-gp-translation-events/assets/550401/499b2313-bf88-4adf-b4bc-be270edf835f">