### PR TITLE
Generate unify generation of draft and published urls

### DIFF
--- a/includes/urls.php
+++ b/includes/urls.php
@@ -12,9 +12,9 @@ class Urls {
 	}
 
 	public static function event_details( int $event_id ): string {
-		$status = get_post_status( $event_id );
-		if ( 'draft' === $status ) {
+		if ( 'draft' === get_post_status( $event_id ) ) {
 			// Drafts don't yet have a slug, so we need to generate a sample permalink.
+			require_once ABSPATH . '/wp-admin/includes/post.php';
 			list( $permalink, $post_name ) = get_sample_permalink( $event_id );
 			$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
 		} else {

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -12,8 +12,9 @@ class Urls {
 	}
 
 	public static function event_details( int $event_id ): string {
+		// Drafts don't yet have a slug, so we need to generate a sample permalink.
 		if ( 'draft' === get_post_status( $event_id ) ) {
-			// Drafts don't yet have a slug, so we need to generate a sample permalink.
+			// get_sample_permalink is only available in the admin, so we need to include the file in case we are elsewhere.
 			require_once ABSPATH . '/wp-admin/includes/post.php';
 			list( $permalink, $post_name ) = get_sample_permalink( $event_id );
 			$permalink                     = str_replace( '%pagename%', $post_name, $permalink );

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -12,14 +12,20 @@ class Urls {
 	}
 
 	public static function event_details( int $event_id ): string {
-		return gp_url( wp_make_link_relative( get_the_permalink( $event_id ) ) );
+		$status = get_post_status( $event_id );
+		if ( 'draft' === $status ) {
+			// Drafts don't yet have a slug, so we need to generate a sample permalink.
+			list( $permalink, $post_name ) = get_sample_permalink( $event_id );
+			$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
+		} else {
+			$permalink = get_permalink( $event_id );
+		}
+
+		return gp_url( wp_make_link_relative( $permalink ) );
 	}
 
 	public static function event_details_absolute( int $event_id ): string {
-		list( $permalink, $post_name ) = get_sample_permalink( $event_id );
-		$permalink                     = str_replace( '%pagename%', $post_name, $permalink );
-
-		return get_site_url() . gp_url( wp_make_link_relative( $permalink ) );
+		return site_url( self::event_details( $event_id ) );
 	}
 
 	public static function event_translations( int $event_id, string $locale, string $status = '' ): string {

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -32,6 +32,18 @@ class Urls_Test extends GP_UnitTestCase {
 		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
 	}
 
+	public function test_event_details_draft() {
+		$event_id          = $this->event_factory->create_active();
+		$post              = get_post( $event_id );
+		$post->post_status = 'draft';
+		wp_update_post( $post );
+
+		$event = $this->event_repository->get_event( $event_id );
+
+		$expected = "/glotpress/events/{$event->slug()}";
+		$this->assertEquals( $expected, Urls::event_details( $event_id ) );
+	}
+
 	public function test_event_details_absolute() {
 		$event_id = $this->event_factory->create_active();
 		$event    = $this->event_repository->get_event( $event_id );


### PR DESCRIPTION
Previously, a draft post would get a temporary `Urls::event_details` URL like https://glotpress.local/?post_type=translation_event&p=570/ which also didn't work. This now also generates slug URLs for drafts.