### PR TITLE
Show or hide subhead

### DIFF
--- a/includes/routes/attendee/list.php
+++ b/includes/routes/attendee/list.php
@@ -27,7 +27,6 @@ class List_Route extends Route {
 		global $wp;
 		$user             = wp_get_current_user();
 		$is_active_filter = false;
-		$hide_sub_head    = true;
 		if ( ! is_user_logged_in() ) {
 			wp_safe_redirect( wp_login_url( home_url( $wp->request ) ) );
 			exit;

--- a/includes/routes/event/details.php
+++ b/includes/routes/event/details.php
@@ -57,6 +57,7 @@ class Details_Route extends Route {
 		$current_user_attendee = $attendees[ $user->ID ] ?? null;
 		$user_is_attending     = $current_user_attendee instanceof Attendee;
 		$user_is_contributor   = $user_is_attending && $current_user_attendee->is_contributor();
+		$show_sub_head         = true;
 
 		$hosts = array_filter(
 			$attendees,

--- a/templates/events-header.php
+++ b/templates/events-header.php
@@ -31,7 +31,7 @@ use Wporg\TranslationEvents\Event\Event;
 			<?php endif; ?>
 		<?php endif; ?>
 	</ul>
-	<?php if ( isset( $event ) && ! isset( $event_form_name ) && ! isset( $hide_sub_head ) ) : ?>
+	<?php if ( isset( $event ) && isset( $show_sub_head ) && true === $show_sub_head ) : ?>
 	<p class="event-sub-head">
 			<span class="event-host">
 				<?php


### PR DESCRIPTION
In this PR, we use a flag to hide or show the sub-head, the sub-head is a UI component that contains list of the hosts of an event , edit event and manage attendees links. Before this PR, we were hiding the sub heads only for the forms, we would check  if `$event_form_name` was not set and then we would hide the sub-head. However, there was a need to hide the sub-head for a page that isn't a form, hence the need for this approach.



<img width="1541" alt="Screenshot 2024-05-10 at 11 26 33" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/606aab67-0f5d-48d2-bd64-36b874bed7ac">