### PR TITLE
Add some context to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # wporg-gp-translation-events
 
+Here we are implementing Translation Events, as discussed in our Polyglots Make P2 Post: [Translation Events Prototype](https://make.wordpress.org/polyglots/2024/02/28/translation-events-prototype/).
+
 ## Development environment
 First follow [instructions to install `wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#prerequisites).
 


### PR DESCRIPTION
We posted about the [Translation Events Prototype](https://make.wordpress.org/polyglots/2024/02/28/translation-events-prototype/), we should link to it in the README.