### PR TITLE
Add new capabilty to make a form field editable

### DIFF
--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -297,7 +297,6 @@ class Event_Capabilities {
 		}
 
 		return false;
-
 	}
 
 	public function register_hooks(): void {

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -261,7 +261,7 @@ class Event_Capabilities {
 	 */
 	private function has_edit_form_field( WP_User $user, Event $event, $cap ): bool {
 		$event_start         = $event->start();
-		$happening_now       = $event->start()->is_in_the_past() && ! $event->end()->is_in_the_past();
+		$happening_now       = $event->is_active();
 		$now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -260,7 +260,6 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit_field( WP_User $user, Event $event, $cap ): bool {
-		$event_start         = $event->start();
 		$happening_now       = $event->is_active();
 		$now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
@@ -269,7 +268,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		if ( $event_start > $now ) {
+		if ( $event->start() > $now ) {
 			return true;
 		}
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -260,7 +260,6 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit_field( WP_User $user, Event $event, $cap ): bool {
-		$happening_now       = $event->is_active();
 		$now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
 
@@ -272,11 +271,11 @@ class Event_Capabilities {
 			return true;
 		}
 
-		if ( $happening_now && ! $this->stats_calculator->event_has_stats( $event->id() ) ) {
+		if ( $event->is_active() && ! $this->stats_calculator->event_has_stats( $event->id() ) ) {
 			return true;
 		}
 
-		if ( $happening_now && $this->stats_calculator->event_has_stats( $event->id() ) ) {
+		if ( $event->is_active() && $this->stats_calculator->event_has_stats( $event->id() ) ) {
 			return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
 		}
 

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -156,14 +156,6 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit( WP_User $user, Event $event ): bool {
-		if ( $event->end()->is_in_the_past() ) {
-			return false;
-		}
-
-		if ( $this->stats_calculator->event_has_stats( $event->id() ) ) {
-			return false;
-		}
-
 		if ( $event->author_id() === $user->ID ) {
 			return true;
 		}

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -17,6 +17,7 @@ class Event_Capabilities {
 	private const TRASH          = 'trash_translation_event';
 	private const DELETE         = 'delete_translation_event';
 	private const EDIT_ATTENDEES = 'edit_translation_event_attendees';
+	private const EDIT_FORM_FIELD = 'edit_translation_event_form_field';
 
 	/**
 	 * All the capabilities that concern Events.
@@ -29,6 +30,7 @@ class Event_Capabilities {
 		self::TRASH,
 		self::DELETE,
 		self::EDIT_ATTENDEES,
+		self::EDIT_FORM_FIELD,
 	);
 
 	private Event_Repository_Interface $event_repository;
@@ -86,6 +88,9 @@ class Event_Capabilities {
 				}
 				if ( self::EDIT_ATTENDEES === $cap ) {
 					return $this->has_edit_attendees( $user, $event );
+				}
+				if ( self::EDIT_FORM_FIELD === $cap ) {
+					return $this->has_edit_form_field( $user, $event );
 				}
 				break;
 		}

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -105,7 +105,7 @@ class Event_Capabilities {
 					return $this->has_edit_attendees( $user, $event );
 				}
 				if ( self::EDIT_TITLE === $cap || self::EDIT_DESCRIPTION === $cap || self::EDIT_START === $cap || self::EDIT_END === $cap || self::EDIT_TIMEZONE === $cap ) {
-					return $this->has_edit_form_field( $user, $event, $cap );
+					return $this->has_edit_field( $user, $event, $cap );
 				}
 				break;
 		}
@@ -259,7 +259,7 @@ class Event_Capabilities {
 	 * @param Event   $event Event for which we're evaluating the capability.
 	 * @return bool
 	 */
-	private function has_edit_form_field( WP_User $user, Event $event, $cap ): bool {
+	private function has_edit_field( WP_User $user, Event $event, $cap ): bool {
 		$event_start         = $event->start();
 		$happening_now       = $event->is_active();
 		$now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -127,10 +127,22 @@ class Event_Form_Handler {
 
 				try {
 					$event->set_status( $new_event->status() );
-					$event->set_title( $new_event->title() );
-					$event->set_description( $new_event->description() );
-					$event->set_timezone( $new_event->timezone() );
-					$event->set_times( $new_event->start(), $new_event->end() );
+					if ( current_user_can( 'edit_translation_event_title', $event->id() ) ) {
+						$event->set_title( $new_event->title() );
+					}
+					if ( current_user_can( 'edit_translation_event_description', $event->id() ) ) {
+						$event->set_description( $new_event->description() );
+					}
+					if ( current_user_can( 'edit_translation_event_timezone', $event->id() ) ) {
+						$event->set_timezone( $new_event->timezone() );
+					}
+					if ( current_user_can( 'edit_translation_event_start', $event->id() ) ) {
+						$event->set_start( $new_event->start() );
+					}
+					if ( current_user_can( 'edit_translation_event_end', $event->id() ) ) {
+						$event->set_end( $new_event->end() );
+					}
+					$event->validate_times( $event->start(), $event->end() );
 				} catch ( Exception $e ) {
 					wp_send_json_error( esc_html__( 'Failed to update event.', 'gp-translation-events' ), 422 );
 					return;

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -29,7 +29,8 @@ class Event_Form_Handler {
 			wp_send_json_error( esc_html__( 'Invalid form name.', 'gp-translation-events' ), 403 );
 		}
 
-		$event_id = isset( $form_data['event_id'] ) ? sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) : 0;
+		$event_id = isset( $form_data['event_id'] ) ? intval( sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) ) : 0;
+		$event    = null;
 
 		if ( 'create_event' === $action && ( ! current_user_can( 'create_translation_event' ) ) ) {
 			wp_send_json_error( esc_html__( 'You do not have permissions to create events.', 'gp-translation-events' ), 403 );
@@ -54,10 +55,12 @@ class Event_Form_Handler {
 		}
 
 		$response_message = '';
+		if ( $event_id ) {
+			$event = $this->event_repository->get_event( $event_id );
+		}
+
 		if ( 'trash_event' === $action ) {
 			// Trash event.
-			$event_id = intval( sanitize_text_field( wp_unslash( $form_data['event_id'] ) ) );
-			$event    = $this->event_repository->get_event( $event_id );
 			if ( ! $event ) {
 				wp_send_json_error( esc_html__( 'Event does not exist.', 'gp-translation-events' ), 404 );
 			}
@@ -84,6 +87,9 @@ class Event_Form_Handler {
 			// Create or update event.
 
 			try {
+				if ( 'edit_event' === $action && $event ) {
+					$form_data['event_timezone'] = $event->timezone()->getName();
+				}
 				$new_event = $this->parse_form_data( $form_data );
 			} catch ( InvalidTimeZone $e ) {
 				wp_send_json_error( esc_html__( 'Invalid time zone.', 'gp-translation-events' ), 422 );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -104,11 +104,6 @@ class Event_Form_Handler {
 				return;
 			}
 
-			if ( $new_event->end() < new DateTime( 'now', new DateTimeZone( 'UTC' ) ) ) {
-				wp_send_json_error( esc_html__( 'Past events cannot be created or edited.', 'gp-translation-events' ), 422 );
-				return;
-			}
-
 			// This is a list of slugs that are not allowed, as they conflict with the event URLs.
 			$invalid_slugs = array( 'new', 'edit', 'attend', 'my-events' );
 			if ( in_array( sanitize_title( $new_event->title() ), $invalid_slugs, true ) ) {

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -136,13 +136,15 @@ class Event_Form_Handler {
 					if ( current_user_can( 'edit_translation_event_timezone', $event->id() ) ) {
 						$event->set_timezone( $new_event->timezone() );
 					}
+
+					$event->validate_times( $new_event->start(), $new_event->end() );
+
 					if ( current_user_can( 'edit_translation_event_start', $event->id() ) ) {
 						$event->set_start( $new_event->start() );
 					}
 					if ( current_user_can( 'edit_translation_event_end', $event->id() ) ) {
 						$event->set_end( $new_event->end() );
 					}
-					$event->validate_times( $event->start(), $event->end() );
 				} catch ( Exception $e ) {
 					wp_send_json_error( esc_html__( 'Failed to update event.', 'gp-translation-events' ), 422 );
 					return;

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -57,6 +57,7 @@ class Event {
 		string $description
 	) {
 		$this->author_id = $author_id;
+		$this->validate_times( $start, $end );
 		$this->set_start( $start );
 		$this->set_end( $end );
 		$this->set_timezone( $timezone );

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -57,7 +57,8 @@ class Event {
 		string $description
 	) {
 		$this->author_id = $author_id;
-		$this->set_times( $start, $end );
+		$this->set_start( $start );
+		$this->set_end( $end );
 		$this->set_timezone( $timezone );
 		$this->set_status( $status );
 		$this->set_title( $title );
@@ -129,13 +130,12 @@ class Event {
 		$this->slug = $slug;
 	}
 
-	/**
-	 * @throws InvalidStart|InvalidEnd
-	 */
-	public function set_times( Event_Start_Date $start, Event_End_Date $end ): void {
-		$this->validate_times( $start, $end );
+	public function set_start( Event_Start_Date $start ): void {
 		$this->start = $start;
-		$this->end   = $end;
+	}
+
+	public function set_end( Event_End_Date $end ): void {
+		$this->end = $end;
 	}
 
 	public function set_timezone( DateTimeZone $timezone ): void {
@@ -164,7 +164,7 @@ class Event {
 	 * @throws InvalidStart
 	 * @throws InvalidEnd
 	 */
-	private function validate_times( Event_Start_Date $start, Event_End_Date $end ) {
+	public function validate_times( Event_Start_Date $start, Event_End_Date $end ) {
 		if ( $end <= $start ) {
 			throw new InvalidEnd();
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 
     <rule ref="WordPress">
         <properties>
-            <property name="custom_capabilities[]" value="manage_translation_events,create_translation_event,view_translation_event,edit_translation_event,trash_translation_event,delete_translation_event,edit_translation_event_attendees,edit_translation_event_form_field"/>
+            <property name="custom_capabilities[]" value="manage_translation_events,create_translation_event,view_translation_event,edit_translation_event,trash_translation_event,delete_translation_event,edit_translation_event_attendees,edit_translation_event_title,edit_translation_event_description,edit_translation_event_start,edit_translation_event_end,edit_translation_event_timezone"/>
         </properties>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 
     <rule ref="WordPress">
         <properties>
-            <property name="custom_capabilities[]" value="manage_translation_events,create_translation_event,view_translation_event,edit_translation_event,trash_translation_event,delete_translation_event,edit_translation_event_attendees"/>
+            <property name="custom_capabilities[]" value="manage_translation_events,create_translation_event,view_translation_event,edit_translation_event,trash_translation_event,delete_translation_event,edit_translation_event_attendees,edit_translation_event_form_field"/>
         </properties>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -36,7 +36,7 @@ Templates::header(
 	<input type="hidden" id="event-form-action" name="event_form_action">
 	<div>
 		<label for="event-title"><?php esc_html_e( 'Event Title', 'gp-translation-events' ); ?></label>
-		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event->title() ); ?>" required size="42">
+		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html(  $event->title() ); ?>" <?php echo current_user_can( 'edit_translation_event_title', $event->id() ) ?: 'readonly'; ?> required size="42">
 	</div>
 	<?php $event_url_class = $is_create_form ? 'hide-event-url' : ''; ?>
 	<?php $event_url = $is_create_form ? '' : Urls::event_details_absolute( $event->id() ); ?>
@@ -46,7 +46,7 @@ Templates::header(
 	</div>
 	<div>
 		<label for="event-description"><?php esc_html_e( 'Event Description', 'gp-translation-events' ); ?></label>
-		<textarea id="event-description" name="event_description" rows="4" cols="40" required><?php echo esc_html( $event->description() ); ?></textarea>
+		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly'; ?> ><?php echo esc_html( $event->description() ); ?></textarea>
 		<?php
 		echo wp_kses(
 			Event_Text_Snippet::get_snippet_links(),
@@ -63,15 +63,15 @@ Templates::header(
 		?>
 			<div>
 		<label for="event-start"><?php esc_html_e( 'Start Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required>
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly'; ?> >
 	</div>
 	<div>
 		<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly'; ?>>
 	</div>
 	<div>
 		<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>
-		<select id="event-timezone" name="event_timezone" required>
+		<select id="event-timezone" name="event_timezone" required <?php echo current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly'; ?> >
 			<?php
 			echo wp_kses(
 				wp_timezone_choice( $is_create_form ? null : $event->timezone()->getName(), get_user_locale() ),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -71,7 +71,7 @@ Templates::header(
 	</div>
 	<div>
 		<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>
-		<select id="event-timezone" name="event_timezone" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly' ); ?> >
+		<select id="event-timezone" name="event_timezone" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'disabled' ); ?> >
 			<?php
 			echo wp_kses(
 				wp_timezone_choice( $is_create_form ? null : $event->timezone()->getName(), get_user_locale() ),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -36,7 +36,7 @@ Templates::header(
 	<input type="hidden" id="event-form-action" name="event_form_action">
 	<div>
 		<label for="event-title"><?php esc_html_e( 'Event Title', 'gp-translation-events' ); ?></label>
-		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html(  $event->title() ); ?>" <?php echo current_user_can( 'edit_translation_event_title', $event->id() ) ?: 'readonly'; ?> required size="42">
+		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event->title() ); ?>" <?php echo esc_html( current_user_can( 'edit_translation_event_title', $event->id() ) ?: 'readonly' ); ?> required size="42">
 	</div>
 	<?php $event_url_class = $is_create_form ? 'hide-event-url' : ''; ?>
 	<?php $event_url = $is_create_form ? '' : Urls::event_details_absolute( $event->id() ); ?>
@@ -46,7 +46,7 @@ Templates::header(
 	</div>
 	<div>
 		<label for="event-description"><?php esc_html_e( 'Event Description', 'gp-translation-events' ); ?></label>
-		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly'; ?> ><?php echo esc_html( $event->description() ); ?></textarea>
+		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo esc_html( current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly' ); ?> ><?php echo esc_html( $event->description() ); ?></textarea>
 		<?php
 		echo wp_kses(
 			Event_Text_Snippet::get_snippet_links(),
@@ -63,15 +63,15 @@ Templates::header(
 		?>
 			<div>
 		<label for="event-start"><?php esc_html_e( 'Start Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly'; ?> >
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly' ); ?> >
 	</div>
 	<div>
 		<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly'; ?>>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
 	</div>
 	<div>
 		<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>
-		<select id="event-timezone" name="event_timezone" required <?php echo current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly'; ?> >
+		<select id="event-timezone" name="event_timezone" required <?php echo esc_html( current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly' ); ?> >
 			<?php
 			echo wp_kses(
 				wp_timezone_choice( $is_create_form ? null : $event->timezone()->getName(), get_user_locale() ),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -36,7 +36,7 @@ Templates::header(
 	<input type="hidden" id="event-form-action" name="event_form_action">
 	<div>
 		<label for="event-title"><?php esc_html_e( 'Event Title', 'gp-translation-events' ); ?></label>
-		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event->title() ); ?>" <?php echo esc_html( current_user_can( 'edit_translation_event_title', $event->id() ) ?: 'readonly' ); ?> required size="42">
+		<input type="text" id="event-title" name="event_title" value="<?php echo esc_html( $event->title() ); ?>" <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_title', $event->id() ) ?: 'readonly' ); ?> required size="42">
 	</div>
 	<?php $event_url_class = $is_create_form ? 'hide-event-url' : ''; ?>
 	<?php $event_url = $is_create_form ? '' : Urls::event_details_absolute( $event->id() ); ?>
@@ -46,7 +46,7 @@ Templates::header(
 	</div>
 	<div>
 		<label for="event-description"><?php esc_html_e( 'Event Description', 'gp-translation-events' ); ?></label>
-		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo esc_html( current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly' ); ?> ><?php echo esc_html( $event->description() ); ?></textarea>
+		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly' ); ?> ><?php echo esc_html( $event->description() ); ?></textarea>
 		<?php
 		echo wp_kses(
 			Event_Text_Snippet::get_snippet_links(),
@@ -63,15 +63,15 @@ Templates::header(
 		?>
 			<div>
 		<label for="event-start"><?php esc_html_e( 'Start Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly' ); ?> >
+		<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly' ); ?> >
 	</div>
 	<div>
 		<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
-		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
+		<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
 	</div>
 	<div>
 		<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>
-		<select id="event-timezone" name="event_timezone" required <?php echo esc_html( current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly' ); ?> >
+		<select id="event-timezone" name="event_timezone" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_timezone', $event->id() ) ?: 'readonly' ); ?> >
 			<?php
 			echo wp_kses(
 				wp_timezone_choice( $is_create_form ? null : $event->timezone()->getName(), get_user_locale() ),

--- a/templates/events-form.php
+++ b/templates/events-form.php
@@ -46,7 +46,7 @@ Templates::header(
 	</div>
 	<div>
 		<label for="event-description"><?php esc_html_e( 'Event Description', 'gp-translation-events' ); ?></label>
-		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly' ); ?> ><?php echo esc_html( $event->description() ); ?></textarea>
+		<textarea id="event-description" name="event_description" rows="4" cols="40" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_description', $event->id() ) ?: 'readonly' ); ?>><?php echo esc_html( $event->description() ); ?></textarea>
 		<?php
 		echo wp_kses(
 			Event_Text_Snippet::get_snippet_links(),

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -112,7 +112,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_can_edit_past_event() {
 		$this->set_normal_user_as_current();
 
-		$event_id = $this->event_factory->create_inactive_past();
+		$event_id = $this->event_factory->create_inactive_past( $this->now );
 
 		$this->assertTrue( current_user_can( 'edit_translation_event', $event_id ) );
 	}
@@ -121,7 +121,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$author_user_id = get_current_user_id();
 
-		$event_id        = $this->event_factory->create_active();
+		$event_id        = $this->event_factory->create_active( $this->now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(
@@ -231,7 +231,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_editable_fields_before_event_start() {
 		$this->set_normal_user_as_current();
 
-		$event_id = $this->event_factory->create_inactive_future();
+		$event_id = $this->event_factory->create_inactive_future( $this->now );
 
 		$this->assertTrue( current_user_can( 'edit_translation_event_title', $event_id ) );
 		$this->assertTrue( current_user_can( 'edit_translation_event_description', $event_id ) );
@@ -243,7 +243,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_editable_fields_after_event_start_no_stats() {
 		$this->set_normal_user_as_current();
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $this->now );
 
 		$this->assertTrue( current_user_can( 'edit_translation_event_title', $event_id ) );
 		$this->assertTrue( current_user_can( 'edit_translation_event_description', $event_id ) );
@@ -256,7 +256,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$author_user_id = get_current_user_id();
 
-		$event_id        = $this->event_factory->create_active();
+		$event_id        = $this->event_factory->create_active( $this->now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -5,8 +5,6 @@ namespace Wporg\Tests\Event;
 use DateTimeImmutable;
 use DateTimeZone;
 use GP_UnitTestCase;
-use DateTimeImmutable;
-use DateTimeZone;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -111,14 +109,19 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertTrue( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
 	}
 
-	public function test_cannot_edit_past_event() {
-		$event_id = $this->event_factory->create_inactive_past( $this->now );
-		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
+	public function test_can_edit_past_event() {
+		$this->set_normal_user_as_current();
+
+		$event_id = $this->event_factory->create_inactive_past();
+
+		$this->assertTrue( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 
-	public function test_cannot_edit_event_with_stats() {
-		$author_user_id  = get_current_user_id();
-		$event_id        = $this->event_factory->create_active( $this->now );
+	public function test_can_edit_event_with_stats() {
+		$this->set_normal_user_as_current();
+		$author_user_id = get_current_user_id();
+
+		$event_id        = $this->event_factory->create_active();
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(
@@ -129,7 +132,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 			)
 		);
 		$this->stats_factory->create( $event_id, $author_user_id, $original->id, 'create', $translation_set->locale );
-		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
+		$this->assertTrue( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 
 	public function test_cannot_trash_event_with_stats() {

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -298,7 +298,7 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_id = $this->event_factory->create_event(
 			$now->modify( '-3 hours' ),
-			$now->modify( '-1 hours +1 minutes' ),
+			$now->modify( '-1 hours  -1 minutes' ),
 			$timezone,
 			array(),
 		);

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -104,7 +104,8 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$event    = $this->repository->get_event( $event_id );
 
 		// phpcs:disable Squiz.PHP.DisallowMultipleAssignments.Found
-		$event->set_times( $updated_start = ( new Event_Start_Date( 'now' ) )->modify( '+1 days' ), $updated_end = ( new Event_End_Date( 'now' ) )->modify( '+2 days' ) );
+		$event->set_start( $updated_start = ( new Event_Start_Date( 'now' ) )->modify( '+1 days' ) );
+		$event->set_end( $updated_end = ( new Event_End_Date( 'now' ) )->modify( '+2 days' ) );
 		$event->set_timezone( $updated_timezone = new DateTimeZone( 'Europe/Madrid' ) );
 		$event->set_status( $updated_status = 'draft' );
 		$event->set_title( $updated_title = 'Updated title' );


### PR DESCRIPTION
Fixes #227 

To test, kindly create the events that satisfies the conditions listed in the issue #227 


1. **Create an event that starts in the future, you would only be able to edit the following;**
Title
Description
Dates

 A. **Edit the event created in 1 to start now**

2. **With no contributions to the event created in A, you would only be able to edit the following;**
Title
Description
Dates

4. **Add contributions to the event created in A, you would only be able to edit the following;**
Title
Description
Extend the end date

B. **Find or create an event that has ended**

5. **Within 0-1 hour after the event has ended, you would only be able to edit the following;**
Title
Description
Extend the end date

6. **After one hour after the event has ended, you would only be able to edit the following;**
Description