### PR TITLE
Remove some unwanted translations in the event stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ You can run tests in `wp-env` with the following command:
 ```shell
 composer dev:test
 ```
+
+If you want to run only one test, you can use the following command:
+
+```shell
+wp-env run tests-cli --env-cwd=wp-content/plugins/wporg-gp-translation-events ./vendor/bin/phpunit --filter methods_name
+```

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ composer dev:test
 If you want to run only one test, you can use the following command:
 
 ```shell
-wp-env run tests-cli --env-cwd=wp-content/plugins/wporg-gp-translation-events ./vendor/bin/phpunit --filter methods_name
+composer dev:test -- --filter methods_name
 ```

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -143,9 +143,17 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$author_user_id = get_current_user_id();
 
-		$event_id = $this->event_factory->create_active();
-		$this->stats_factory->create( $event_id, $author_user_id, 1, 'create' );
-
+		$event_id        = $this->event_factory->create_active();
+		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
+		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
+		$this->factory->translation->create(
+			array(
+				'original_id'        => $original->id,
+				'translation_set_id' => $translation_set->id,
+				'status'             => 'current',
+			)
+		);
+		$this->stats_factory->create( $event_id, $author_user_id, $original->id, 'create', $translation_set->locale );
 		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 


### PR DESCRIPTION
The event page shows some incorrect stats in some situations: 
- When you replace one current translation, so you have one translation in `current` status and another in `old` status.
- When you reject one translation.
- When you have the same translated string in 2 different locales, they are counted in both locales.

This PR removes these problems. It only shows the translations in `current`, `fuzzy`, `waiting` and `changesrequested` status, avoiding the strings in `old` or `rejected` status.

To test it, try to reproduce the previous problems, see the stats, change to this branch and see the difference.

Let's see it with an example:

**Current situation**

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/f1de244a-8106-406a-a2f9-affebaea5398)

**Proposed situation** 

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/3552a4c6-b4a3-4fe6-95a3-2325b13b75fe)

Clicking on the links in the table, in the "Created" column, you can see the current translations (4) for Galician language and (1) for Spanish language.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/16cfd6af-d609-42ef-83e4-98520d83cc1c)

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/fe26d27c-ad70-412d-b187-b86af656c58d)

I needed to update some tests, because now the tests need data in the `translation_set` and in the `translations` tables. 

Fixes #258.