### PR TITLE
Update the has_trash method

### DIFF
--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -174,16 +174,20 @@ class Event_Capabilities {
 	 * @throws Exception
 	 */
 	private function has_trash( WP_User $user, Event $event ): bool {
+		if ( $this->has_manage( $user ) ) {
+			return true;
+		}
+
+		if ( $this->stats_calculator->event_has_stats( $event->id() ) ) {
+			return false;
+		}
+
 		if ( $event->author_id() === $user->ID ) {
 			return true;
 		}
 
 		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
 		if ( ( $attendee instanceof Attendee ) && $attendee->is_host() ) {
-			return true;
-		}
-
-		if ( $this->has_manage( $user ) ) {
 			return true;
 		}
 

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -157,6 +157,24 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 
+	public function test_cannot_trash_event_with_stats() {
+		$this->set_normal_user_as_current();
+		$author_user_id = get_current_user_id();
+
+		$event_id        = $this->event_factory->create_active();
+		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
+		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
+		$this->factory->translation->create(
+			array(
+				'original_id'        => $original->id,
+				'translation_set_id' => $translation_set->id,
+				'status'             => 'current',
+			)
+		);
+		$this->stats_factory->create( $event_id, $author_user_id, $original->id, 'create', $translation_set->locale );
+		$this->assertFalse( current_user_can( 'trash_translation_event', $event_id ) );
+	}
+
 	public function test_author_can_trash() {
 		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active();

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -175,6 +175,24 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'trash_translation_event', $event_id ) );
 	}
 
+	public function test_admin_can_trash_event_with_stats() {
+		$this->set_admin_user_as_current();
+		$author_user_id = get_current_user_id();
+
+		$event_id        = $this->event_factory->create_active();
+		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
+		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
+		$this->factory->translation->create(
+			array(
+				'original_id'        => $original->id,
+				'translation_set_id' => $translation_set->id,
+				'status'             => 'current',
+			)
+		);
+		$this->stats_factory->create( $event_id, $author_user_id, $original->id, 'create', $translation_set->locale );
+		$this->assertTrue( current_user_can( 'trash_translation_event', $event_id ) );
+	}
+
 	public function test_author_can_trash() {
 		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active();


### PR DESCRIPTION
This PR updates the `has_trash` method, checking if event has stats and refuse the capability, unless user has the `manage` capability.

Fixes https://github.com/WordPress/wporg-gp-translation-events/issues/274.