### PR TITLE
Update the redirection after trashing an event

### DIFF
--- a/includes/routes/event/trash.php
+++ b/includes/routes/event/trash.php
@@ -42,13 +42,14 @@ class Trash_Route extends Route {
 		if ( ! $event->is_trashed() ) {
 			// Trash.
 			$this->event_repository->trash_event( $event );
+			wp_safe_redirect( Urls::events_home() );
 		} else {
 			// Restore.
 			$event->set_status( 'draft' );
 			$this->event_repository->update_event( $event );
+			wp_safe_redirect( Urls::event_edit( $event->id() ) );
 		}
 
-		wp_safe_redirect( Urls::event_edit( $event->id() ) );
 		exit;
 	}
 }


### PR DESCRIPTION
After trashing and untrashing an event, the user is redirected to the edit page for this event.

This PR changes this:
- Trashing: it redirects to the main page (events home).
- Untrashing: it redirects to the edit event page.

To test it:
- Create an event and publish it.
- Trash the event. You should be redirected to the main page.
- Go to the "Deleted Events" page. Untrash this event. You should be redirected to the edit page for this event.

Fixes #275.