### PR TITLE
Make it possible to query all events of a user

### DIFF
--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -131,6 +131,72 @@ class Attendee_Repository {
 	}
 
 	/**
+	 * @var int[] $event_ids
+	 * @return Attendee[]
+	 * @throws Exception
+	 */
+	public function get_attendees_for_events_for_user( array $event_ids, int $user_id ): array {
+		if ( empty( $event_ids ) ) {
+			return array();
+		}
+
+		// Prevent SQL injection.
+		foreach ( $event_ids as $event_id ) {
+			if ( is_numeric( $event_id ) ) {
+				$event_id = intval( $event_id );
+			}
+			if ( ! is_int( $event_id ) || $event_id <= 0 ) {
+				return array();
+			}
+		}
+
+		global $wpdb, $gp_table_prefix;
+		$event_id_params = implode( ',', array_fill( 0, count( $event_ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+					select
+					    event_id,
+						user_id,
+						is_host,
+						is_new_contributor,
+						(
+							select group_concat( distinct locale )
+							from {$gp_table_prefix}event_actions
+							where event_id = attendees.event_id
+							  and user_id = attendees.user_id
+						) as locales
+					from {$gp_table_prefix}event_attendees attendees
+					where event_id in ($event_id_params)
+					  and user_id = %d
+				",
+				array_merge(
+					$event_ids,
+					array( $user_id ),
+				),
+			),
+		);
+		// phpcs:enable
+
+		return array_map(
+			function ( $row ) {
+				return new Attendee(
+					$row->event_id,
+					$row->user_id,
+					'1' === $row->is_host,
+					'1' === $row->is_new_contributor,
+					null === $row->locales ? array() : explode( ',', $row->locales ),
+				);
+			},
+			$rows,
+		);
+	}
+
+	/**
 	 * Retrieve all the attendees of an event.
 	 *
 	 * @return Attendee[] Attendees of the event. Associative array with user_id as key.

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -87,47 +87,11 @@ class Attendee_Repository {
 	 * @throws Exception
 	 */
 	public function get_attendee_for_event_for_user( int $event_id, int $user_id ): ?Attendee {
-		global $wpdb, $gp_table_prefix;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		$row = $wpdb->get_row(
-			$wpdb->prepare(
-				"
-				select
-					user_id,
-					is_host,
-					is_new_contributor,
-					(
-						select group_concat( distinct locale )
-						from {$gp_table_prefix}event_actions
-						where event_id = attendees.event_id
-						  and user_id = attendees.user_id
-					) as locales
-				from {$gp_table_prefix}event_attendees attendees
-				where event_id = %d
-				  and user_id = %d
-			",
-				array(
-					$event_id,
-					$user_id,
-				),
-			)
-		);
-		// phpcs:enable
-
-		if ( ! $row ) {
+		$attendees = $this->get_attendees_for_events_for_user( array( $event_id ), $user_id );
+		if ( empty( $attendees ) ) {
 			return null;
 		}
-
-		return new Attendee(
-			$event_id,
-			$row->user_id,
-			'1' === $row->is_host,
-			'1' === $row->is_new_contributor,
-			null === $row->locales ? array() : explode( ',', $row->locales ),
-		);
+		return $attendees[0];
 	}
 
 	/**

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -124,7 +124,7 @@ class Attendee_Repository {
 			$wpdb->prepare(
 				"
 					select
-					    event_id,
+						event_id,
 						user_id,
 						is_host,
 						is_new_contributor,

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -91,12 +91,12 @@ class Attendee_Repository {
 		if ( 1 !== count( $attendees ) ) {
 			return null;
 		}
-		return $attendees[0];
+		return $attendees[ $event_id ];
 	}
 
 	/**
 	 * @var int[] $event_ids
-	 * @return Attendee[]
+	 * @return Attendee[] Associative array with event id as key.
 	 * @throws Exception
 	 */
 	public function get_attendees_for_events_for_user( array $event_ids, int $user_id ): array {
@@ -141,8 +141,9 @@ class Attendee_Repository {
 				array_merge(
 					$event_ids,
 					array( $user_id ),
-				),
+				)
 			),
+			OBJECT_K
 		);
 		// phpcs:enable
 

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -243,41 +243,4 @@ class Attendee_Repository {
 			}
 		);
 	}
-
-	/**
-	 * @deprecated
-	 * TODO: This method should be moved out of this class because it's not about attendance,
-	 *       it returns events that match a condition (have a user as attendee), so it belongs in an event repository.
-	 *       However, since we don't have an event repository yet, the method is placed here for now.
-	 *       When the method is moved to an event repository, it should return Event instances instead of event ids.
-	 *
-	 * @return int[] Event ids.
-	 */
-	public function get_events_for_user( int $user_id ): array {
-		global $wpdb, $gp_table_prefix;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-				select event_id
-				from {$gp_table_prefix}event_attendees
-				where user_id = %d
-			",
-				array(
-					$user_id,
-				)
-			)
-		);
-		// phpcs:enable
-
-		return array_map(
-			function ( object $row ) {
-				return intval( $row->event_id );
-			},
-			$rows
-		);
-	}
 }

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -86,7 +86,7 @@ class Attendee_Repository {
 	/**
 	 * @throws Exception
 	 */
-	public function get_attendee( int $event_id, int $user_id ): ?Attendee {
+	public function get_attendee_for_event_for_user( int $event_id, int $user_id ): ?Attendee {
 		global $wpdb, $gp_table_prefix;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -88,7 +88,7 @@ class Attendee_Repository {
 	 */
 	public function get_attendee_for_event_for_user( int $event_id, int $user_id ): ?Attendee {
 		$attendees = $this->get_attendees_for_events_for_user( array( $event_id ), $user_id );
-		if ( empty( $attendees ) ) {
+		if ( 1 !== count( $attendees ) ) {
 			return null;
 		}
 		return $attendees[0];

--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -152,7 +152,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user->ID );
 		if ( ( $attendee instanceof Attendee ) && $attendee->is_host() ) {
 			return true;
 		}
@@ -186,7 +186,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user->ID );
 		if ( ( $attendee instanceof Attendee ) && $attendee->is_host() ) {
 			return true;
 		}
@@ -232,7 +232,7 @@ class Event_Capabilities {
 			return true;
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user->ID );
+		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user->ID );
 		if ( ( $attendee instanceof Attendee ) && $attendee->is_host() ) {
 			return true;
 		}

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -100,7 +100,7 @@ interface Event_Repository_Interface {
 	public function get_trashed_events( int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
-	 * Get events for a given user.
+	 * Get events for a given user. Includes events created by the user.
 	 *
 	 * @param int $user_id   Id of the user.
 	 * @param int $page      Index of the page to return.

--- a/includes/event/event-repository-interface.php
+++ b/includes/event/event-repository-interface.php
@@ -100,6 +100,18 @@ interface Event_Repository_Interface {
 	public function get_trashed_events( int $page = -1, int $page_size = -1 ): Events_Query_Result;
 
 	/**
+	 * Get events for a given user.
+	 *
+	 * @param int $user_id   Id of the user.
+	 * @param int $page      Index of the page to return.
+	 * @param int $page_size Page size.
+	 *
+	 * @return Events_Query_Result
+	 * @throws Exception
+	 */
+	public function get_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result;
+
+	/**
 	 * Get events that are currently active for a given user.
 	 *
 	 * @param int $user_id   Id of the user.

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -478,10 +478,11 @@ class Event_Repository implements Event_Repository_Interface {
 
 		if ( null !== $user_id ) {
 			$user_id_filter_callback = 'Wporg\TranslationEvents\Event\add_user_id_where_clause_to_events_query';
+			$user_id_filter_priority = 10;
 			// Only return events for which this user is an attendee, or (optionally) the event author.
 			// We use a filter to modify the where clause of the query.
 			// The filter removes itself, so it will only apply to the next query.
-			add_filter( 'posts_where', $user_id_filter_callback, 10, 2 );
+			add_filter( 'posts_where', $user_id_filter_callback, $user_id_filter_priority, 2 );
 			$args['translation_events_user_id']                 = $user_id;
 			$args['translation_events_include_created_by_user'] = $include_created_by_user;
 		}
@@ -491,7 +492,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 		if ( isset( $user_id_filter_callback ) ) {
 			// Remove the filter, so it only applies to this query.
-			remove_filter( 'posts_where', $user_id_filter_callback );
+			remove_filter( 'posts_where', $user_id_filter_callback, $user_id_filter_priority );
 		}
 
 		$events = array();

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -250,7 +250,8 @@ class Event_Repository implements Event_Repository_Interface {
 				'orderby'    => 'meta_value',
 				'order'      => 'ASC',
 			),
-			$this->attendee_repository->get_events_for_user( $user_id ),
+			array(),
+			$user_id,
 		);
 		// phpcs:enable
 	}
@@ -276,18 +277,14 @@ class Event_Repository implements Event_Repository_Interface {
 				'orderby'    => 'meta_value',
 				'order'      => 'ASC',
 			),
-			$this->attendee_repository->get_events_for_user( $user_id ),
+			array(),
+			$user_id,
 		);
 		// phpcs:enable
 	}
 
 	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
-		$user_events = $this->attendee_repository->get_events_for_user( $user_id );
-		if ( empty( $user_events ) ) {
-			return new Events_Query_Result( array(), 1, 1 );
-		}
 
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
@@ -308,7 +305,8 @@ class Event_Repository implements Event_Repository_Interface {
 				'orderby'    => 'meta_value',
 				'order'      => 'DESC',
 			),
-			$user_events
+			array(),
+			$user_id,
 		);
 		// phpcs:enable
 	}

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -223,6 +223,22 @@ class Event_Repository implements Event_Repository_Interface {
 		);
 	}
 
+	public function get_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		return $this->execute_events_query(
+			$page,
+			$page_size,
+			array(
+				'meta_key' => '_event_start',
+				'orderby'  => 'meta_value',
+				'order'    => 'DESC',
+			),
+			array(),
+			$user_id,
+		);
+		// phpcs:enable
+	}
+
 	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -586,5 +586,5 @@ function add_user_id_where_clause_to_events_query( string $where, WP_Query $quer
 		$where_creator = "$posts_table.post_author = $user_id";
 	}
 
-	return $where . " and ( $where_creator or exists( select * from $attendees_table where user_id = $user_id and event_id = $posts_table.ID ) )";
+	return $where . " and ( $where_creator or exists( select * from $attendees_table where event_id = $posts_table.ID and user_id = $user_id ) )";
 }

--- a/includes/routes/attendee/remove.php
+++ b/includes/routes/attendee/remove.php
@@ -47,7 +47,7 @@ class Remove_Attendee_Route extends Route {
 			$this->die_with_error( esc_html__( 'You do not have permission to edit this event.', 'gp-translation-events' ), 403 );
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user_id );
+		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
 		if ( $attendee instanceof Attendee ) {
 			if ( ! current_user_can( 'edit_translation_event_attendees', $event->id() ) ) {
 				$this->die_with_error( esc_html__( 'You do not have permission to remove this attendee.', 'gp-translation-events' ), 400 );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -46,7 +46,7 @@ class Attend_Event_Route extends Route {
 			$this->die_with_error( esc_html__( 'Cannot attend or un-attend a past event', 'gp-translation-events' ), 403 );
 		}
 
-		$attendee = $this->attendee_repository->get_attendee( $event->id(), $user_id );
+		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
 		if ( $attendee instanceof Attendee ) {
 			if ( $attendee->is_contributor() ) {
 				$this->die_with_error( esc_html__( 'Contributors cannot un-attend the event', 'gp-translation-events' ), 403 );

--- a/includes/routes/user/host-event.php
+++ b/includes/routes/user/host-event.php
@@ -49,7 +49,7 @@ class Host_Event_Route extends Route {
 			$this->die_with_404();
 		}
 
-		$affected_attendee = $this->attendee_repository->get_attendee( $event_id, $user_id );
+		$affected_attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event_id, $user_id );
 		// The user is attending to the event, so if I don't find the attendee, I won't create it.
 		if ( $affected_attendee instanceof Attendee ) {
 			if ( $affected_attendee->is_host() ) {

--- a/includes/stats/stats-listener.php
+++ b/includes/stats/stats-listener.php
@@ -78,7 +78,7 @@ class Stats_Listener {
 	private function handle_action( GP_Translation $translation, int $user_id, string $action, DateTimeImmutable $happened_at ): void {
 		try {
 			// Get events that are active when the action happened, for which the user is registered for.
-			$active_events = $this->event_repository->get_current_events();
+			$active_events = $this->event_repository->get_current_events_for_user( $user_id );
 			$events        = $this->select_events_user_is_registered_for( $active_events->events, $user_id );
 
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort

--- a/includes/stats/stats-listener.php
+++ b/includes/stats/stats-listener.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Exception;
 use GP_Translation;
 use GP_Translation_Set;
+use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
@@ -124,7 +125,20 @@ class Stats_Listener {
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
 	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$attending_event_ids = $this->attendee_repository->get_events_for_user( $user_id );
+		$event_ids = array_map(
+			function ( $event ) {
+				return $event->id();
+			},
+			$events,
+		);
+
+		$attending_event_ids = array_map(
+			function ( Attendee $attendee ) {
+				return $attendee->event_id();
+			},
+			$this->attendee_repository->get_attendees_for_events_for_user( $event_ids, $user_id )
+		);
+
 		return array_filter(
 			$events,
 			function ( Event $event ) use ( $attending_event_ids ) {

--- a/includes/stats/stats-listener.php
+++ b/includes/stats/stats-listener.php
@@ -7,9 +7,6 @@ use DateTimeZone;
 use Exception;
 use GP_Translation;
 use GP_Translation_Set;
-use Wporg\TranslationEvents\Attendee\Attendee;
-use Wporg\TranslationEvents\Attendee\Attendee_Repository;
-use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 
 class Stats_Listener {
@@ -18,15 +15,10 @@ class Stats_Listener {
 	const ACTION_REJECT          = 'reject';
 	const ACTION_REQUEST_CHANGES = 'request_changes';
 
-	private Attendee_Repository $attendee_repository;
 	private Event_Repository_Interface $event_repository;
 
-	public function __construct(
-		Event_Repository_Interface $event_repository,
-		Attendee_Repository $attendee_repository
-	) {
-		$this->event_repository    = $event_repository;
-		$this->attendee_repository = $attendee_repository;
+	public function __construct( Event_Repository_Interface $event_repository ) {
+		$this->event_repository = $event_repository;
 	}
 
 	public function start(): void {

--- a/includes/stats/stats-listener.php
+++ b/includes/stats/stats-listener.php
@@ -77,9 +77,8 @@ class Stats_Listener {
 
 	private function handle_action( GP_Translation $translation, int $user_id, string $action, DateTimeImmutable $happened_at ): void {
 		try {
-			// Get events that are active when the action happened, for which the user is registered for.
-			$active_events = $this->event_repository->get_current_events_for_user( $user_id );
-			$events        = $this->select_events_user_is_registered_for( $active_events->events, $user_id );
+			// Get events that are active now, for which the user is registered for.
+			$events = $this->event_repository->get_current_events_for_user( $user_id )->events;
 
 			// phpcs:ignore Generic.Commenting.DocComment.MissingShort
 			/** @var GP_Translation_Set $translation_set Translation set */
@@ -114,37 +113,4 @@ class Stats_Listener {
 			error_log( $exception );
 		}
 	}
-
-	/**
-	 * Filter an array of events so that it only includes events the given user is attending.
-	 *
-	 * @param Event[] $events Events.
-	 *
-	 * @return Event[]
-	 */
-	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-	// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.Found
-	private function select_events_user_is_registered_for( array $events, int $user_id ): array {
-		$event_ids = array_map(
-			function ( $event ) {
-				return $event->id();
-			},
-			$events,
-		);
-
-		$attending_event_ids = array_map(
-			function ( Attendee $attendee ) {
-				return $attendee->event_id();
-			},
-			$this->attendee_repository->get_attendees_for_events_for_user( $event_ids, $user_id )
-		);
-
-		return array_filter(
-			$events,
-			function ( Event $event ) use ( $attending_event_ids ) {
-				return in_array( $event->id(), $attending_event_ids, true );
-			}
-		);
-	}
-	// phpcs:enable
 }

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -131,27 +131,27 @@ class Attendee_Repository_Test extends GP_UnitTestCase {
 
 		$retrieved_attendees_1 = $this->repository->get_attendees_for_events_for_user( array( $event1_id, $event2_id ), $user1_id );
 		$this->assertCount( 2, $retrieved_attendees_1 );
-		$this->assertEquals( $attendee11, $retrieved_attendees_1[0] );
-		$this->assertTrue( $retrieved_attendees_1[0]->is_host() );
-		$this->assertTrue( $retrieved_attendees_1[0]->is_new_contributor() );
-		$this->assertTrue( $retrieved_attendees_1[0]->is_contributor() );
+		$this->assertEquals( $attendee11, $retrieved_attendees_1[ $event1_id ] );
+		$this->assertTrue( $retrieved_attendees_1[ $event1_id ]->is_host() );
+		$this->assertTrue( $retrieved_attendees_1[ $event1_id ]->is_new_contributor() );
+		$this->assertTrue( $retrieved_attendees_1[ $event1_id ]->is_contributor() );
 
-		$this->assertEquals( $attendee21, $retrieved_attendees_1[1] );
-		$this->assertTrue( $retrieved_attendees_1[1]->is_host() );
-		$this->assertFalse( $retrieved_attendees_1[1]->is_new_contributor() );
-		$this->assertFalse( $retrieved_attendees_1[1]->is_contributor() );
+		$this->assertEquals( $attendee21, $retrieved_attendees_1[ $event2_id ] );
+		$this->assertTrue( $retrieved_attendees_1[ $event2_id ]->is_host() );
+		$this->assertFalse( $retrieved_attendees_1[ $event2_id ]->is_new_contributor() );
+		$this->assertFalse( $retrieved_attendees_1[ $event2_id ]->is_contributor() );
 
 		$retrieved_attendees_2 = $this->repository->get_attendees_for_events_for_user( array( $event1_id, $event2_id ), $user2_id );
 		$this->assertCount( 2, $retrieved_attendees_2 );
-		$this->assertEquals( $attendee12, $retrieved_attendees_2[0] );
-		$this->assertFalse( $retrieved_attendees_2[0]->is_host() );
-		$this->assertFalse( $retrieved_attendees_2[0]->is_new_contributor() );
-		$this->assertFalse( $retrieved_attendees_2[0]->is_contributor() );
+		$this->assertEquals( $attendee12, $retrieved_attendees_2[ $event1_id ] );
+		$this->assertFalse( $retrieved_attendees_2[ $event1_id ]->is_host() );
+		$this->assertFalse( $retrieved_attendees_2[ $event1_id ]->is_new_contributor() );
+		$this->assertFalse( $retrieved_attendees_2[ $event1_id ]->is_contributor() );
 
-		$this->assertEquals( $attendee22, $retrieved_attendees_2[1] );
-		$this->assertFalse( $retrieved_attendees_2[1]->is_host() );
-		$this->assertFalse( $retrieved_attendees_2[1]->is_new_contributor() );
-		$this->assertTrue( $retrieved_attendees_2[1]->is_contributor() );
+		$this->assertEquals( $attendee22, $retrieved_attendees_2[ $event2_id ] );
+		$this->assertFalse( $retrieved_attendees_2[ $event2_id ]->is_host() );
+		$this->assertFalse( $retrieved_attendees_2[ $event2_id ]->is_new_contributor() );
+		$this->assertTrue( $retrieved_attendees_2[ $event2_id ]->is_contributor() );
 
 		$this->assertEmpty( $this->repository->get_attendees_for_events_for_user( array( $event3_id ), $user2_id ) );
 	}

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -64,7 +64,7 @@ class Attendee_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $event2_id, $rows[0]->event_id );
 	}
 
-	public function test_get_attendee() {
+	public function test_get_attendee_for_event_for_user() {
 		$event1_id = 1;
 		$event2_id = 2;
 		$user1_id  = 42;
@@ -84,19 +84,19 @@ class Attendee_Repository_Test extends GP_UnitTestCase {
 		$this->repository->insert_attendee( new Attendee( $event2_id, 84 ) );
 		$this->repository->insert_attendee( new Attendee( $event2_id, $user1_id ) );
 
-		$retrieved_attendee_11 = $this->repository->get_attendee( $event1_id, $user1_id );
+		$retrieved_attendee_11 = $this->repository->get_attendee_for_event_for_user( $event1_id, $user1_id );
 		$this->assertEquals( $attendee11, $retrieved_attendee_11 );
 		$this->assertTrue( $retrieved_attendee_11->is_host() );
 		$this->assertTrue( $retrieved_attendee_11->is_new_contributor() );
 		$this->assertTrue( $retrieved_attendee_11->is_contributor() );
 
-		$retrieved_attendee_12 = $this->repository->get_attendee( $event1_id, $user2_id );
+		$retrieved_attendee_12 = $this->repository->get_attendee_for_event_for_user( $event1_id, $user2_id );
 		$this->assertEquals( $attendee12, $retrieved_attendee_12 );
 		$this->assertFalse( $retrieved_attendee_12->is_host() );
 		$this->assertFalse( $retrieved_attendee_12->is_new_contributor() );
 		$this->assertFalse( $retrieved_attendee_12->is_contributor() );
 
-		$this->assertNull( $this->repository->get_attendee( $event2_id, $user2_id ) );
+		$this->assertNull( $this->repository->get_attendee_for_event_for_user( $event2_id, $user2_id ) );
 	}
 
 	public function test_get_hosts() {

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -261,22 +261,6 @@ class Attendee_Repository_Test extends GP_UnitTestCase {
 		$this->assertFalse( $attendees[ $user3_id ]->is_host() );
 	}
 
-	public function test_get_events_for_user() {
-		$event1_id    = 1;
-		$event2_id    = 2;
-		$event3_id    = 3;
-		$user_id      = 42;
-		$another_user = $user_id + 1;
-
-		$this->repository->insert_attendee( new Attendee( $event1_id, $user_id ) );
-		$this->repository->insert_attendee( new Attendee( $event2_id, $user_id ) );
-		$this->repository->insert_attendee( new Attendee( $event3_id, $another_user ) );
-
-		$this->assertEquals( array( $event1_id, $event2_id ), $this->repository->get_events_for_user( $user_id ) );
-		$this->assertEquals( array( $event3_id ), $this->repository->get_events_for_user( $another_user ) );
-		$this->assertEmpty( $this->repository->get_events_for_user( $another_user + 1 ) );
-	}
-
 	private function all_table_rows(): array {
 		global $wpdb, $gp_table_prefix;
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -291,7 +291,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$this->event_factory->create_active( array( $user_id ), $now );
-		$this->event_factory->create_active( array( $user_id ), $now );
+		$this->event_factory->create_active( array( $user_id ), $now->modify( '+1 minute' ) );
 
 		$events = $this->repository->get_past_events_for_user( $user_id )->events;
 		$this->assertCount( 2, $events );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -230,7 +230,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	public function test_get_events_for_user() {
 		$user_id   = $this->set_normal_user_as_current();
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event1_id = $this->event_factory->create_inactive_past( array( $user_id ) );
+		$event1_id = $this->event_factory->create_inactive_past();
 		$event2_id = $this->event_factory->create_active( array( $user_id ), $now );
 		$event3_id = $this->event_factory->create_inactive_future( array( $user_id ) );
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -227,6 +227,32 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$this->assertEquals( $event2_id, $events[0]->id() );
 	}
 
+	public function test_get_events_for_user() {
+		$user_id   = $this->set_normal_user_as_current();
+		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event1_id = $this->event_factory->create_inactive_past( array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( array( $user_id ), $now );
+		$event3_id = $this->event_factory->create_inactive_future( array( $user_id ) );
+
+		$events = $this->repository->get_events_for_user( $user_id )->events;
+		$this->assertCount( 3, $events );
+		$this->assertEquals( $event3_id, $events[0]->id() );
+		$this->assertEquals( $event2_id, $events[1]->id() );
+		$this->assertEquals( $event1_id, $events[2]->id() );
+
+		$result = $this->repository->get_events_for_user( $user_id, 1, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 3, $result->page_count );
+		$this->assertEquals( $event3_id, $events[0]->id() );
+
+		$result = $this->repository->get_events_for_user( $user_id, 2, 1 );
+		$events = $result->events;
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 3, $result->page_count );
+		$this->assertEquals( $event2_id, $events[0]->id() );
+	}
+
 	public function test_get_current_events_for_user() {
 		$user_id   = $this->set_normal_user_as_current();
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -258,8 +258,8 @@ class Event_Repository_Test extends GP_UnitTestCase {
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event1_id = $this->event_factory->create_active( array( $user_id ), $now );
 		$event2_id = $this->event_factory->create_active( array( $user_id ), $now );
-		$this->event_factory->create_active( array( $user_id ), $now->modify( '+2 hours' ) );
-		$this->event_factory->create_active( array( $user_id ), $now->modify( '+2 months' ) );
+		$this->event_factory->create_inactive_future( array( $user_id ) );
+		$this->event_factory->create_inactive_future( array( $user_id ) );
 		$this->event_factory->create_active( array(), $now );
 		$this->event_factory->create_inactive_past( array( $user_id ) );
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -294,7 +294,7 @@ class Translation_Events {
 
 			$user_id             = $post->post_author;
 			$attendee_repository = self::get_attendee_repository();
-			$attendee            = $attendee_repository->get_attendee( $event->id(), $user_id );
+			$attendee            = $attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
 
 			if ( null === $attendee ) {
 				$attendee = new Attendee( $event->id(), $user_id, true );

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -120,10 +120,7 @@ class Translation_Events {
 		GP::$router->add( "/events/$slug/attendees", array( 'Wporg\TranslationEvents\Routes\Attendee\List_Route', 'handle' ) );
 		GP::$router->add( "/events/$id/attendees/remove/$id", array( 'Wporg\TranslationEvents\Routes\Attendee\Remove_Attendee_Route', 'handle' ) );
 
-		$stats_listener = new Stats_Listener(
-			self::get_event_repository(),
-			self::get_attendee_repository(),
-		);
+		$stats_listener = new Stats_Listener( self::get_event_repository() );
 		$stats_listener->start();
 	}
 


### PR DESCRIPTION
In #282, I will need to query all events for a given user, but there was no method in the event repository to do so, so I'm doing that in this PR. Additionally, prior to this PR, whenever we needed to retrieve a list of events for a given user, we were doing the following:

1. Query for all the events a user is an attendee of
2. Pass the event ids returned in 1. as the `posts_in` condition for the `get_posts()`

This means that performance will degrade as time passes and more events are created, as 1. above returns all events the user is an attendee of.

This PR changes this, by making it possible to modify the where condition of the `get_posts()` to something like:

```php
$where and exists( select * from $attendees_table where user_id = $user_id and event_id = $posts_table.ID )
```

This makes it possible to query for events that the user is attending, so we no longer need step 1. above.

## Summary of changes

- `Event_Repository`:
    - Add `get_events_for_user()`
    - Change the internals so that we're more efficiently querying for the events of a user (as per description above)
- `Attendee_Repository`:
    - Rename some methods for clarity
    -  Add `get_attendees_for_events_for_user()`

## Testing instructions
There's no need for manual testing as the repositories are covered by tests.