### PR TITLE
Fix repeated footer

### DIFF
--- a/includes/routes/event/translations.php
+++ b/includes/routes/event/translations.php
@@ -9,6 +9,7 @@ use Translation_Entry;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
+use Wporg\TranslationEvents\Templates;
 
 /**
  * Displays the event details page.
@@ -58,7 +59,7 @@ class Translations_Route extends Route {
 			$projects[ $ts->translation_set_id ] = GP::$project->get( $ts->project_id );
 
 		}
-		gp_tmpl_load( 'event-translations-header', get_defined_vars(), $this->template_path );
+		Templates::render( 'event-translations-header', get_defined_vars() );
 
 		foreach ( $translation_sets as $ts ) {
 			$rows = $wpdb->get_results(
@@ -170,9 +171,9 @@ class Translations_Route extends Route {
 
 				$translations[ $row->row_id ] = new Translation_Entry( (array) $row );
 			}
-			gp_tmpl_load( 'translations', get_defined_vars(), $this->template_path );
+			Templates::render( 'translations', get_defined_vars() );
 		}
 
-		gp_tmpl_load( 'event-translations-footer', get_defined_vars(), $this->template_path );
+		Templates::render( 'event-translations-footer', get_defined_vars() );
 	}
 }

--- a/includes/routes/event/translations.php
+++ b/includes/routes/event/translations.php
@@ -174,6 +174,5 @@ class Translations_Route extends Route {
 		}
 
 		gp_tmpl_load( 'event-translations-footer', get_defined_vars(), $this->template_path );
-		gp_tmpl_footer();
 	}
 }

--- a/includes/routes/event/translations.php
+++ b/includes/routes/event/translations.php
@@ -174,5 +174,6 @@ class Translations_Route extends Route {
 		}
 
 		gp_tmpl_load( 'event-translations-footer', get_defined_vars(), $this->template_path );
+		gp_tmpl_footer();
 	}
 }

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -38,4 +38,4 @@ foreach ( $editor_options as $translation_set_id => $options ) {
 </script>
 <?php
 gp_enqueue_script( 'wporg-translate-editor' );
-gp_tmpl_footer(); ?>
+ ?>

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -40,4 +40,3 @@ foreach ( $editor_options as $translation_set_id => $options ) {
 <?php
 gp_enqueue_script( 'wporg-translate-editor' );
 Templates::footer();
-?>

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -38,5 +38,5 @@ foreach ( $editor_options as $translation_set_id => $options ) {
 </script>
 <?php
 gp_enqueue_script( 'wporg-translate-editor' );
-gp_tmpl_footer();
+Templates::footer();
 ?>

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -1,6 +1,7 @@
 <?php
 namespace Wporg\TranslationEvents\Templates;
 
+use Wporg\TranslationEvents\Templates;
 ?>
 
 </div>

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -38,4 +38,4 @@ foreach ( $editor_options as $translation_set_id => $options ) {
 </script>
 <?php
 gp_enqueue_script( 'wporg-translate-editor' );
- ?>
+?>

--- a/templates/event-translations-footer.php
+++ b/templates/event-translations-footer.php
@@ -38,4 +38,5 @@ foreach ( $editor_options as $translation_set_id => $options ) {
 </script>
 <?php
 gp_enqueue_script( 'wporg-translate-editor' );
+gp_tmpl_footer();
 ?>


### PR DESCRIPTION
A footer is displayed for every project translated on the [translations page](https://translate.wordpress.org/events/2024/wordcamp-porto-portugal-2024-contributor-day/translations/bn/), see below;

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/b8219017-554b-4c2b-a0da-3ca248e3a16f)

In this PR we fix that by loading the GlotPress footer at the end of the loop that renders the translated projects.