### PR TITLE
Temporarily remove the waiting column from the stats table, to fix stats issues

### DIFF
--- a/templates/event.php
+++ b/templates/event.php
@@ -134,7 +134,6 @@ Templates::header(
 					<tr>
 						<th scope="col"><?php esc_html_e( 'Translations', 'gp-translation-events' ); ?></th>
 						<th scope="col"><?php esc_html_e( 'Created', 'gp-translation-events' ); ?></th>
-						<th scope="col"><?php esc_html_e( 'Waiting', 'gp-translation-events' ); ?></th>
 						<th scope="col"><?php esc_html_e( 'Reviewed', 'gp-translation-events' ); ?></th>
 						<th scope="col"><?php esc_html_e( 'Contributors', 'gp-translation-events' ); ?></th>
 					</tr>
@@ -145,7 +144,6 @@ Templates::header(
 					<tr>
 						<td title="<?php echo esc_html( $_locale ); ?> "><a href="<?php echo esc_url( gp_url_join( gp_url( '/languages' ), $row->language->slug ) ); ?>"><?php echo esc_html( $row->language->english_name ); ?></a></td>
 						<td><a href="<?php echo esc_url( Urls::event_translations( $event->id(), $row->language->slug ) ); ?>"><?php echo esc_html( $row->created ); ?></a></td>
-						<td><a href="<?php echo esc_url( Urls::event_translations( $event->id(), $row->language->slug, 'waiting' ) ); ?>"><?php echo esc_html( $row->waiting ); ?></a></td>
 						<td><?php echo esc_html( $row->reviewed ); ?></td>
 						<td><?php echo esc_html( $row->users ); ?></td>
 					</tr>
@@ -153,7 +151,6 @@ Templates::header(
 					<tr class="event-details-stats-totals">
 						<td>Total</td>
 						<td><?php echo esc_html( $event_stats->totals()->created ); ?></td>
-						<td><?php echo esc_html( $event_stats->totals()->waiting ); ?></td>
 						<td><?php echo esc_html( $event_stats->totals()->reviewed ); ?></td>
 						<td><?php echo esc_html( $event_stats->totals()->users ); ?></td>
 					</tr>


### PR DESCRIPTION
Fixes #285

I wasn't able to figure out yet what exactly causes the issue, but the issues with stats started once we introduced the waiting column. So in this PR, we're removing that column from the table. This is the quickest way to get a fix deployed, so that stats in production are correct. Then we can look into what it would take to bring back the waiting column.

The problem that the waiting column introduces is that we're now relying on joining with the translations table when computing stats. However, the model we had defined initially was based on the principle that stats would be calculated from the `actions` table.

Joining with the translations table means that, when calculating stats, we need to deal with the complexities of the lifecycle of translations. I think we should keep the principle that we defined initially that stats are calculated from the translations table alone.

So I think that when we bring back the waiting column after this PR is merged, we should look into how we can do so while only relying on the `actions` table for stats.