### PR TITLE
Fix randomly failing tests

### DIFF
--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -40,7 +40,8 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 
 	public function test_add() {
 		$user_id  = get_current_user_id();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$attendee = new Attendee( $event_id, $user_id );
 
@@ -69,7 +70,7 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 			$this->translation_factory->create( $user3_id );
 		}
 
-		$event1_id  = $this->event_factory->create_active( array(), $now->modify( '+1 day' ) );
+		$event1_id  = $this->event_factory->create_active( $now->modify( '+1 day' ) );
 		$event1     = $this->event_repository->get_event( $event1_id );
 		$attendee11 = new Attendee( $event1_id, $user1_id );
 		$attendee12 = new Attendee( $event1_id, $user2_id );
@@ -82,7 +83,7 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 		$this->assertTrue( $attendee12->is_new_contributor() );
 		$this->assertFalse( $attendee13->is_new_contributor() );
 
-		$event2_id  = $this->event_factory->create_active( array(), $now->modify( '-1 day' ) );
+		$event2_id  = $this->event_factory->create_active( $now->modify( '-1 day' ) );
 		$event2     = $this->event_repository->get_event( $event2_id );
 		$attendee21 = new Attendee( $event2_id, $user1_id );
 		$attendee22 = new Attendee( $event2_id, $user2_id );
@@ -98,11 +99,12 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 	public function test_import_stats_if_active_event() {
 		$this->set_normal_user_as_current();
 		$user_id = get_current_user_id();
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		// Create a translation before the event starts, which should not be imported.
 		$this->translation_factory->create( $user_id, new DateTimeImmutable( '1 day ago', new DateTimeZone( 'UTC' ) ) );
 
-		$event_id = $this->event_factory->create_active( array(), new DateTimeImmutable( '5 minutes ago', new DateTimeZone( 'UTC' ) ) );
+		$event_id = $this->event_factory->create_active( $now->modify( '-5 minutes' ) );
 		$event    = $this->event_repository->get_event( $event_id );
 		$attendee = new Attendee( $event_id, $user_id );
 
@@ -145,7 +147,8 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 
 	public function test_does_not_import_stats_if_inactive_event() {
 		$user_id  = get_current_user_id();
-		$event_id = $this->event_factory->create_inactive_future();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_inactive_future( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$attendee = new Attendee( $event_id, $user_id );
 

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -55,7 +55,6 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 	}
 
 	public function test_sets_is_new_contributor() {
-		$this->set_normal_user_as_current();
 		$user1_id = 52;
 		$user2_id = 53;
 		$user3_id = 54;
@@ -97,7 +96,6 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 	}
 
 	public function test_import_stats_if_active_event() {
-		$this->set_normal_user_as_current();
 		$user_id = get_current_user_id();
 
 		// Create a translation before the event starts, which should not be imported.

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -24,46 +24,32 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();
 		$this->event_repository    = new Event_Repository( $this->attendee_repository );
-		$this->now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		$this->set_normal_user_as_current();
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_cannot_manage_if_no_crud_permission() {
-		$this->set_normal_user_as_current();
-
 		add_filter( 'gp_translation_events_can_crud_event', '__return_false' );
-
 		$this->assertFalse( current_user_can( 'manage_translation_events' ) );
 	}
 
 	public function test_can_manage_if_crud_permission() {
-		$this->set_normal_user_as_current();
-		get_current_user_id();
-
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
-
 		$this->assertTrue( current_user_can( 'manage_translation_events' ) );
 	}
 
 	public function test_cannot_create_if_no_crud_permission() {
-		$this->set_normal_user_as_current();
-
 		add_filter( 'gp_translation_events_can_crud_event', '__return_false' );
-
 		$this->assertFalse( current_user_can( 'create_translation_event' ) );
 	}
 
 	public function test_can_create_if_crud_permission() {
-		$this->set_normal_user_as_current();
-		get_current_user_id();
-
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
-
 		$this->assertTrue( current_user_can( 'create_translation_event' ) );
 	}
 
 	public function test_cannot_view_non_published_events() {
-		$this->set_normal_user_as_current();
-
 		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$event->set_status( 'draft' );
@@ -73,40 +59,30 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_gp_admin_can_view_non_published_events() {
-		$this->set_normal_user_as_current();
-
 		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$event->set_status( 'draft' );
 		$this->event_repository->update_event( $event );
 
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
-
 		$this->assertTrue( current_user_can( 'view_translation_event', $event_id ) );
 	}
 
 	public function test_event_id_as_string() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
-
 		$this->assertTrue( current_user_can( 'edit_translation_event', (string) $event_id ) );
 	}
 
 	public function test_author_can_edit() {
-		$this->set_normal_user_as_current();
-
 		$event_id = $this->event_factory->create_active( $this->now );
-
 		$this->assertTrue( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 
 	public function test_non_author_cannot_edit() {
-		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
 
 		$event_id = $this->event_factory->create_active( $this->now );
-
 		$this->assertFalse( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
 	}
 
@@ -124,7 +100,6 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_gp_admin_can_edit() {
-		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
 
@@ -135,13 +110,11 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_cannot_edit_past_event() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_inactive_past( $this->now );
 		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
 	}
 
 	public function test_cannot_edit_event_with_stats() {
-		$this->set_normal_user_as_current();
 		$author_user_id  = get_current_user_id();
 		$event_id        = $this->event_factory->create_active( $this->now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
@@ -158,7 +131,6 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_cannot_trash_event_with_stats() {
-		$this->set_normal_user_as_current();
 		$author_user_id  = get_current_user_id();
 		$event_id        = $this->event_factory->create_active( $this->now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
@@ -192,13 +164,11 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_author_can_trash() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
 		$this->assertTrue( current_user_can( 'trash_translation_event', $event_id ) );
 	}
 
 	public function test_non_author_cannot_trash() {
-		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
 
@@ -207,7 +177,6 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_host_can_trash() {
-		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
 
@@ -220,14 +189,12 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_gp_admin_can_trash() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
 		$this->assertTrue( current_user_can( 'trash_translation_event', $event_id ) );
 	}
 
 	public function test_cannot_delete_if_not_trashed() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
 
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
@@ -235,7 +202,6 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_non_gp_admin_cannot_delete() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 
@@ -247,7 +213,6 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	}
 
 	public function test_gp_admin_can_delete() {
-		$this->set_normal_user_as_current();
 		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\Tests\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
@@ -59,8 +61,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_cannot_view_non_published_events() {
 		$this->set_normal_user_as_current();
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$event->set_status( 'draft' );
 		$this->event_repository->update_event( $event );
@@ -70,8 +73,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_gp_admin_can_view_non_published_events() {
 		$this->set_normal_user_as_current();
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 		$event->set_status( 'draft' );
 		$this->event_repository->update_event( $event );
@@ -83,16 +87,17 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_event_id_as_string() {
 		$this->set_normal_user_as_current();
-
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$this->assertTrue( current_user_can( 'edit_translation_event', (string) $event_id ) );
 	}
 
 	public function test_author_can_edit() {
 		$this->set_normal_user_as_current();
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 
 		$this->assertTrue( current_user_can( 'edit_translation_event', $event_id ) );
 	}
@@ -101,8 +106,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 
 		$this->assertFalse( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
 	}
@@ -111,8 +117,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 
 		$attendee = new Attendee( $event_id, $non_author_user_id, true );
 		$this->attendee_repository->insert_attendee( $attendee );
@@ -124,8 +131,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
 
 		$this->assertTrue( user_can( $non_author_user_id, 'edit_translation_event', $event_id ) );
@@ -133,8 +141,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_cannot_edit_past_event() {
 		$this->set_normal_user_as_current();
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_inactive_past();
+		$event_id = $this->event_factory->create_inactive_past( $now );
 
 		$this->assertFalse( current_user_can( 'edit_translation_event', $event_id ) );
 	}
@@ -142,8 +151,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_cannot_edit_event_with_stats() {
 		$this->set_normal_user_as_current();
 		$author_user_id = get_current_user_id();
+		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id        = $this->event_factory->create_active();
+		$event_id        = $this->event_factory->create_active( $now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(
@@ -160,8 +170,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_cannot_trash_event_with_stats() {
 		$this->set_normal_user_as_current();
 		$author_user_id = get_current_user_id();
+		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id        = $this->event_factory->create_active();
+		$event_id        = $this->event_factory->create_active( $now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(
@@ -178,8 +189,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 	public function test_admin_can_trash_event_with_stats() {
 		$this->set_admin_user_as_current();
 		$author_user_id = get_current_user_id();
+		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id        = $this->event_factory->create_active();
+		$event_id        = $this->event_factory->create_active( $now );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->factory->original->create( array( 'project_id' => $translation_set->project_id ) );
 		$this->factory->translation->create(
@@ -195,7 +207,8 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_author_can_trash() {
 		$this->set_normal_user_as_current();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$this->assertTrue( current_user_can( 'trash_translation_event', $event_id ) );
 	}
 
@@ -203,8 +216,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 		$this->assertFalse( user_can( $non_author_user_id, 'trash_translation_event', $event_id ) );
 	}
 
@@ -212,8 +226,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 		$non_author_user_id = get_current_user_id();
 		$this->set_normal_user_as_current(); // This user is the author.
+		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $now );
 
 		$attendee = new Attendee( $event_id, $non_author_user_id, true );
 		$this->attendee_repository->insert_attendee( $attendee );
@@ -223,14 +238,16 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_gp_admin_can_trash() {
 		$this->set_normal_user_as_current();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
 		$this->assertTrue( current_user_can( 'trash_translation_event', $event_id ) );
 	}
 
 	public function test_cannot_delete_if_not_trashed() {
 		$this->set_normal_user_as_current();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		add_filter( 'gp_translation_events_can_crud_event', '__return_true' );
 		$this->assertFalse( current_user_can( 'delete_translation_event', $event_id ) );
@@ -238,7 +255,8 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_non_gp_admin_cannot_delete() {
 		$this->set_normal_user_as_current();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$event->set_status( 'trash' );
@@ -250,7 +268,8 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 
 	public function test_gp_admin_can_delete() {
 		$this->set_normal_user_as_current();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$event->set_status( 'trash' );

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -15,6 +15,7 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	private Event_Repository_Cached $repository;
 	private Event_Factory $event_factory;
+	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -23,6 +24,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 
 		wp_cache_delete( 'translation-events-active-events' );
 		$this->set_normal_user_as_current();
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_get_current_events_when_no_current_events_exist() {
@@ -40,12 +42,11 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_current_events() {
-		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event1_id = $this->event_factory->create_active( $now );
-		$event2_id = $this->event_factory->create_active( $now );
-		$this->event_factory->create_active( $now->modify( '+2 hours' ) );
-		$this->event_factory->create_inactive_future( $now );
-		$this->event_factory->create_inactive_past( $now );
+		$event1_id = $this->event_factory->create_active( $this->now );
+		$event2_id = $this->event_factory->create_active( $this->now );
+		$this->event_factory->create_active( $this->now->modify( '+2 hours' ) );
+		$this->event_factory->create_inactive_future( $this->now );
+		$this->event_factory->create_inactive_past( $this->now );
 
 		$result = $this->repository->get_current_events();
 		$events = $result->events;
@@ -84,8 +85,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_updated() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );
@@ -94,8 +94,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_trashed() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );
@@ -104,8 +103,7 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_deleted() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -41,11 +41,11 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 
 	public function test_get_current_events() {
 		$now       = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event1_id = $this->event_factory->create_active( array(), $now );
-		$event2_id = $this->event_factory->create_active( array(), $now );
-		$this->event_factory->create_active( array(), $now->modify( '+2 hours' ) );
-		$this->event_factory->create_inactive_future();
-		$this->event_factory->create_inactive_past();
+		$event1_id = $this->event_factory->create_active( $now );
+		$event2_id = $this->event_factory->create_active( $now );
+		$this->event_factory->create_active( $now->modify( '+2 hours' ) );
+		$this->event_factory->create_inactive_future( $now );
+		$this->event_factory->create_inactive_past( $now );
 
 		$result = $this->repository->get_current_events();
 		$events = $result->events;
@@ -84,7 +84,8 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_updated() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );
@@ -93,7 +94,8 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_trashed() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );
@@ -102,7 +104,8 @@ class Event_Repository_Cached_Test extends GP_UnitTestCase {
 	}
 
 	public function test_invalidates_cache_when_events_are_deleted() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->repository->get_event( $event_id );
 
 		wp_cache_set( 'translation-events-active-events', 'foo' );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -226,7 +226,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_events_for_user() {
-		$user_id   = $this->set_normal_user_as_current();
+		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_inactive_past( $this->now );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event3_id = $this->event_factory->create_inactive_future( $this->now, array( $user_id ) );
@@ -251,7 +251,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_current_events_for_user() {
-		$user_id   = $this->set_normal_user_as_current();
+		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$this->event_factory->create_inactive_future( $this->now, array( $user_id ) );
@@ -278,7 +278,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_current_and_upcoming_events_for_user() {
-		$user_id   = $this->set_normal_user_as_current();
+		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event3_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
@@ -305,7 +305,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_past_events_for_user() {
-		$user_id   = $this->set_normal_user_as_current();
+		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
 
@@ -331,7 +331,7 @@ class Event_Repository_Test extends GP_UnitTestCase {
 	}
 
 	public function test_get_events_created_by_user() {
-		$user_id   = $this->set_normal_user_as_current();
+		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_inactive_past( $this->now );
 		$event2_id = $this->event_factory->create_active( $this->now );
 		$event3_id = $this->event_factory->create_active( $this->now->modify( '+5 seconds' ) );

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -22,9 +22,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		);
 	}
 
-	public function create_draft(): int {
+	public function create_draft( DateTimeImmutable $now ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		$event_id = $this->create_event(
 			$now->modify( '-1 hours' ),
@@ -40,11 +39,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		return $event_id;
 	}
 
-	public function create_active( array $attendee_ids = array(), $now = null ): int {
+	public function create_active( DateTimeImmutable $now, array $attendee_ids = array() ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		if ( null === $now ) {
-			$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		}
 
 		return $this->create_event(
 			$now->modify( '-1 second' ),
@@ -54,9 +50,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		);
 	}
 
-	public function create_inactive_past( array $attendee_ids = array() ): int {
+	public function create_inactive_past( DateTimeImmutable $now, array $attendee_ids = array() ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->create_event(
 			$now->modify( '-2 month' ),
@@ -66,9 +61,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		);
 	}
 
-	public function create_inactive_future( array $attendee_ids = array() ): int {
+	public function create_inactive_future( DateTimeImmutable $now, array $attendee_ids = array() ): int {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
 		return $this->create_event(
 			$now->modify( '+1 month' ),

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -13,29 +13,30 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Stats_Calculator $calculator;
+	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory = new Event_Factory();
 		$this->stats_factory = new Stats_Factory();
 		$this->calculator    = new Stats_Calculator();
+
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_tells_that_event_has_no_stats() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$this->assertFalse( $this->calculator->event_has_stats( $event_id ) );
 	}
 
 	public function test_tells_that_event_has_stats() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id        = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event_id        = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->create_original_and_translation( $translation_set );
 		$this->stats_factory->create( $event_id, $user_id, $original->id, 'create', $translation_set->locale );
@@ -45,13 +46,12 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 
 	public function test_calculates_stats_for_event() {
 		$this->set_normal_user_as_current();
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$user1_id = 42;
 		$user2_id = 43;
 		$user3_id = 44;
 
-		$event1_id = $this->event_factory->create_active( $now, array( $user1_id ) );
-		$event2_id = $this->event_factory->create_active( $now, array( $user1_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now, array( $user1_id ) );
+		$event2_id = $this->event_factory->create_active( $this->now, array( $user1_id ) );
 
 		// For event1, aa locale, multiple users.
 		$translation_set_1 = $this->factory->translation_set->create_with_project_and_locale();

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -21,20 +21,18 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 		$this->stats_factory = new Stats_Factory();
 		$this->calculator    = new Stats_Calculator();
 
+		$this->set_normal_user_as_current();
 		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_tells_that_event_has_no_stats() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
-
+		$user_id  = get_current_user_id();
 		$event_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$this->assertFalse( $this->calculator->event_has_stats( $event_id ) );
 	}
 
 	public function test_tells_that_event_has_stats() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$event_id        = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
@@ -45,7 +43,6 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 	}
 
 	public function test_calculates_stats_for_event() {
-		$this->set_normal_user_as_current();
 		$user1_id = 42;
 		$user2_id = 43;
 		$user3_id = 44;

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\Tests\Stats;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Tests\Event_Factory;
@@ -22,18 +24,18 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 	public function test_tells_that_event_has_no_stats() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id = $this->event_factory->create_active( array( $user_id ) );
-		$event    = get_post( $event_id );
-
+		$event_id = $this->event_factory->create_active( $now, array( $user_id ) );
 		$this->assertFalse( $this->calculator->event_has_stats( $event_id ) );
 	}
 
 	public function test_tells_that_event_has_stats() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event_id        = $this->event_factory->create_active( array( $user_id ) );
+		$event_id        = $this->event_factory->create_active( $now, array( $user_id ) );
 		$translation_set = $this->factory->translation_set->create_with_project_and_locale();
 		$original        = $this->create_original_and_translation( $translation_set );
 		$this->stats_factory->create( $event_id, $user_id, $original->id, 'create', $translation_set->locale );
@@ -43,12 +45,13 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 
 	public function test_calculates_stats_for_event() {
 		$this->set_normal_user_as_current();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$user1_id = 42;
 		$user2_id = 43;
 		$user3_id = 44;
 
-		$event1_id = $this->event_factory->create_active( array( $user1_id ) );
-		$event2_id = $this->event_factory->create_active( array( $user1_id ) );
+		$event1_id = $this->event_factory->create_active( $now, array( $user1_id ) );
+		$event2_id = $this->event_factory->create_active( $now, array( $user1_id ) );
 
 		// For event1, aa locale, multiple users.
 		$translation_set_1 = $this->factory->translation_set->create_with_project_and_locale();

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -14,21 +14,23 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	private Translation_Factory $translation_factory;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
+	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->translation_factory = new Translation_Factory( $this->factory );
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
+
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_does_not_store_action_for_draft_events() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_draft( $now );
-		$this->event_factory->create_draft( $now );
+		$this->event_factory->create_draft( $this->now );
+		$this->event_factory->create_draft( $this->now );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -40,10 +42,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_does_not_store_action_for_inactive_events() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_inactive_past( $now, array( $user_id ) );
-		$this->event_factory->create_inactive_future( $now, array( $user_id ) );
+		$this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
+		$this->event_factory->create_inactive_future( $this->now, array( $user_id ) );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -55,10 +56,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_does_not_store_action_if_user_not_attending() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_active( $now );
-		$this->event_factory->create_active( $now );
+		$this->event_factory->create_active( $this->now );
+		$this->event_factory->create_active( $this->now );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -78,10 +78,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_create() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 
 		$translation = $this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -107,10 +106,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_approve() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );
@@ -142,10 +140,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_reject() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );
@@ -177,10 +174,9 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_request_changes() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
-		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -22,13 +22,12 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
 
+		$this->set_normal_user_as_current();
 		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_does_not_store_action_for_draft_events() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
-
+		$user_id = get_current_user_id();
 		$this->event_factory->create_draft( $this->now );
 		$this->event_factory->create_draft( $this->now );
 
@@ -40,8 +39,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_does_not_store_action_for_inactive_events() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
 		$this->event_factory->create_inactive_future( $this->now, array( $user_id ) );
@@ -54,8 +52,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_does_not_store_action_if_user_not_attending() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$this->event_factory->create_active( $this->now );
 		$this->event_factory->create_active( $this->now );
@@ -76,8 +73,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_stores_action_create() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
@@ -104,8 +100,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_stores_action_approve() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
@@ -138,8 +133,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_stores_action_reject() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
@@ -172,8 +166,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	}
 
 	public function test_stores_action_request_changes() {
-		$this->set_normal_user_as_current();
-		$user_id = wp_get_current_user()->ID;
+		$user_id = get_current_user_id();
 
 		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\Tests\Stats;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_Translation;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Tests\Event_Factory;
@@ -23,9 +25,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_does_not_store_action_for_draft_events() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_draft();
-		$this->event_factory->create_draft();
+		$this->event_factory->create_draft( $now );
+		$this->event_factory->create_draft( $now );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -37,9 +40,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_does_not_store_action_for_inactive_events() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_inactive_past( array( $user_id ) );
-		$this->event_factory->create_inactive_future( array( $user_id ) );
+		$this->event_factory->create_inactive_past( $now, array( $user_id ) );
+		$this->event_factory->create_inactive_future( $now, array( $user_id ) );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -51,9 +55,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_does_not_store_action_if_user_not_attending() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$this->event_factory->create_active();
-		$this->event_factory->create_active();
+		$this->event_factory->create_active( $now );
+		$this->event_factory->create_active( $now );
 
 		$this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -73,9 +78,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_create() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
 
 		$translation = $this->translation_factory->create( $user_id );
 		// Stats_Listener will have been called.
@@ -101,9 +107,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_approve() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );
@@ -135,9 +142,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_reject() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );
@@ -169,9 +177,10 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 	public function test_stores_action_request_changes() {
 		$this->set_normal_user_as_current();
 		$user_id = wp_get_current_user()->ID;
+		$now     = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$event1_id = $this->event_factory->create_active( array( $user_id ) );
-		$event2_id = $this->event_factory->create_active( array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_active( $now, array( $user_id ) );
 
 		/** @var GP_Translation $translation */
 		$translation = $this->translation_factory->create( $user_id );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -2,6 +2,9 @@
 
 namespace Wporg\Tests;
 
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -25,7 +28,8 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = "/glotpress/events/{$event->slug()}";
@@ -33,7 +37,8 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details_draft() {
-		$event_id          = $this->event_factory->create_active();
+		$now               = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id          = $this->event_factory->create_active( $now );
 		$post              = get_post( $event_id );
 		$post->post_status = 'draft';
 		wp_update_post( $post );
@@ -45,7 +50,8 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details_absolute() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = site_url() . "/glotpress/events/{$event->slug()}";
@@ -53,7 +59,8 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_translations() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = "/glotpress/events/{$event->slug()}/translations/pt";
@@ -64,28 +71,32 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_edit() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$expected = "/glotpress/events/edit/$event_id";
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
 	public function test_event_trash() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$expected = "/glotpress/events/trash/$event_id";
 		$this->assertEquals( $expected, Urls::event_trash( $event_id ) );
 	}
 
 	public function test_event_delete() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$expected = "/glotpress/events/delete/$event_id";
 		$this->assertEquals( $expected, Urls::event_delete( $event_id ) );
 	}
 
 	public function test_event_toggle_attendee() {
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$expected = "/glotpress/events/attend/$event_id";
 		$this->assertEquals( $expected, Urls::event_toggle_attendee( $event_id ) );
@@ -93,7 +104,8 @@ class Urls_Test extends GP_UnitTestCase {
 
 	public function test_event_toggle_host() {
 		$user_id  = get_current_user_id();
-		$event_id = $this->event_factory->create_active();
+		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->event_factory->create_active( $now );
 
 		$expected = "/glotpress/events/host/$event_id/$user_id";
 		$this->assertEquals( $expected, Urls::event_toggle_host( $event_id, $user_id ) );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\Tests;
 
-use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use GP_UnitTestCase;
@@ -71,42 +70,32 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_edit() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
-
+		$event_id = 42;
 		$expected = "/glotpress/events/edit/$event_id";
 		$this->assertEquals( $expected, Urls::event_edit( $event_id ) );
 	}
 
 	public function test_event_trash() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
-
+		$event_id = 42;
 		$expected = "/glotpress/events/trash/$event_id";
 		$this->assertEquals( $expected, Urls::event_trash( $event_id ) );
 	}
 
 	public function test_event_delete() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
-
+		$event_id = 42;
 		$expected = "/glotpress/events/delete/$event_id";
 		$this->assertEquals( $expected, Urls::event_delete( $event_id ) );
 	}
 
 	public function test_event_toggle_attendee() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
-
+		$event_id = 42;
 		$expected = "/glotpress/events/attend/$event_id";
 		$this->assertEquals( $expected, Urls::event_toggle_attendee( $event_id ) );
 	}
 
 	public function test_event_toggle_host() {
 		$user_id  = get_current_user_id();
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
-
+		$event_id = 42;
 		$expected = "/glotpress/events/host/$event_id/$user_id";
 		$this->assertEquals( $expected, Urls::event_toggle_host( $event_id, $user_id ) );
 	}

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -13,12 +13,15 @@ use Wporg\TranslationEvents\Urls;
 class Urls_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
 	private Event_Repository $event_repository;
+	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->event_factory    = new Event_Factory();
 		$this->event_repository = new Event_Repository( new Attendee_Repository() );
+
 		$this->set_normal_user_as_current();
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_events_home() {
@@ -27,8 +30,7 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = "/glotpress/events/{$event->slug()}";
@@ -36,8 +38,7 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details_draft() {
-		$now               = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id          = $this->event_factory->create_active( $now );
+		$event_id          = $this->event_factory->create_active( $this->now );
 		$post              = get_post( $event_id );
 		$post->post_status = 'draft';
 		wp_update_post( $post );
@@ -49,8 +50,7 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_details_absolute() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = site_url() . "/glotpress/events/{$event->slug()}";
@@ -58,8 +58,7 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_translations() {
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$event_id = $this->event_factory->create_active( $now );
+		$event_id = $this->event_factory->create_active( $this->now );
 		$event    = $this->event_repository->get_event( $event_id );
 
 		$expected = "/glotpress/events/{$event->slug()}/translations/pt";


### PR DESCRIPTION
As you might have noticed, the tests randomly fail, with something like:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/550401/180535fe-d735-45d8-b799-f36e61d8f40c)

I think this is due to the value of 'now' not staying the same throughout the test, which results in the order of events returned from the repository to not be consistent. If the seconds portion of 'now' changes while the test was running, the issue will manifest itself.

The solution to this is to make the value of 'now' the same throughout the test. That's what this PR does, along with some other small cleanups I noticed while fixing the 'now' issue.
