### PR TITLE
Don't use the HTTP 500 status code when permission is denied

### DIFF
--- a/includes/routes/attendee/remove.php
+++ b/includes/routes/attendee/remove.php
@@ -50,7 +50,7 @@ class Remove_Attendee_Route extends Route {
 		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
 		if ( $attendee instanceof Attendee ) {
 			if ( ! current_user_can( 'edit_translation_event_attendees', $event->id() ) ) {
-				$this->die_with_error( esc_html__( 'You do not have permission to remove this attendee.', 'gp-translation-events' ), 400 );
+				$this->die_with_error( esc_html__( 'You do not have permission to remove this attendee.', 'gp-translation-events' ), 403 );
 			}
 			$this->attendee_repository->remove_attendee( $event->id(), $user_id );
 		}

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -21,7 +21,7 @@ class Create_Route extends Route {
 		}
 
 		if ( ! current_user_can( 'create_translation_event' ) ) {
-			$this->die_with_error( 'You do not have permission to create events.' );
+			$this->die_with_error( 'You do not have permission to create events.', 403 );
 		}
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );

--- a/includes/routes/event/list-trashed.php
+++ b/includes/routes/event/list-trashed.php
@@ -25,7 +25,7 @@ class List_Trashed_Route extends Route {
 		}
 
 		if ( ! current_user_can( 'manage_translation_events' ) ) {
-			$this->die_with_error( 'You do not have permission to manage events.' );
+			$this->die_with_error( 'You do not have permission to manage events.', 403 );
 		}
 
 		$current_page = 1;

--- a/tests/event/event-image.php
+++ b/tests/event/event-image.php
@@ -2,6 +2,8 @@
 
 namespace Wporg\Tests\Event;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use GP_UnitTestCase;
 use Wporg\TranslationEvents\Routes\Event\Image_Route;
 use Wporg\TranslationEvents\Templates;
@@ -9,6 +11,14 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Urls;
 
 class Event_Image_Test extends GP_UnitTestCase {
+
+	private DateTimeImmutable $now;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+	}
+
 	/**
 	 * Test that when the header template is fired, it generates the social metadata.
 	 *
@@ -62,7 +72,7 @@ class Event_Image_Test extends GP_UnitTestCase {
 		// phpcs:enable
 		ob_start();
 		$this->event_factory = new Event_Factory();
-		$event_id            = $this->event_factory->create_active();
+		$event_id            = $this->event_factory->create_active( $this->now );
 
 		$image_route = new Image_Route();
 		$image_route->handle( $event_id );

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -120,7 +120,7 @@ class Urls_Test extends GP_UnitTestCase {
 	}
 
 	public function test_event_image() {
-		$event_id = $this->event_factory->create_active();
+		$event_id = $this->event_factory->create_active( $this->now );
 		$expected = trailingslashit( gp_url_public_root() ) . "events/image/$event_id";
 		$this->assertEquals( $expected, Urls::event_image( $event_id ) );
 	}


### PR DESCRIPTION
Right now, we use the default HTTP status of `die_with_error` which is 500. This should be 403.

![Screenshot 2024-05-24 at 08 24 14](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/c8687ee4-d334-4f5a-9e04-b6d651c258a1)
