### PR TITLE
When determining current events for the user, query attended events separately

### DIFF
--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -25,6 +25,8 @@ class Attendee_Repository {
 			),
 		);
 		// phpcs:enable
+
+		wp_cache_delete( 'events_for_user_' . $attendee->user_id() );
 	}
 
 	/**
@@ -81,6 +83,7 @@ class Attendee_Repository {
 		);
 
 		// phpcs:enable
+		wp_cache_delete( 'events_for_user_' . $user_id );
 	}
 
 	/**

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -591,7 +591,13 @@ function add_user_id_where_clause_to_events_query( string $where, WP_Query $quer
 		$posts_where[] = "$posts_table.post_author = $user_id";
 	}
 
-	$event_ids = $wpdb->get_col( $wpdb->prepare( "SELECT event_id FROM $attendees_table WHERE user_id = %d", $user_id ) );
+	$event_ids = wp_cache_get( 'events_for_user_' . $user_id );
+	if ( false === $event_ids ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$event_ids = $wpdb->get_col( $wpdb->prepare( "SELECT event_id FROM $attendees_table WHERE user_id = %d", $user_id ) );
+		wp_cache_set( 'events_for_user_' . $user_id, $event_ids );
+	}
 
 	if ( ! empty( $event_ids ) ) {
 		$posts_where[] = "$posts_table.ID IN ( " . implode( ', ', array_map( 'intval', $event_ids ) ) . ' )';

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -586,10 +586,20 @@ function add_user_id_where_clause_to_events_query( string $where, WP_Query $quer
 	$posts_table     = "{$wpdb->prefix}posts";
 	$attendees_table = "{$gp_table_prefix}event_attendees";
 
-	$where_creator = '1 = 0';
+	$posts_where = array();
 	if ( $include_created_by_user ) {
-		$where_creator = "$posts_table.post_author = $user_id";
+		$posts_where[] = "$posts_table.post_author = $user_id";
 	}
 
-	return $where . " and ( $where_creator or exists( select * from $attendees_table where event_id = $posts_table.ID and user_id = $user_id ) )";
+	$event_ids = $wpdb->get_col( $wpdb->prepare( "SELECT event_id FROM $attendees_table WHERE user_id = %d", $user_id ) );
+
+	if ( ! empty( $event_ids ) ) {
+		$posts_where[] = "$posts_table.ID IN ( " . implode( ', ', array_map( 'intval', $event_ids ) ) . ' )';
+	}
+	if ( empty( $posts_where ) ) {
+		// If there are no events for this user, we want to return an empty result set.
+		return $where . ' AND 0 = 1';
+	}
+
+	return $where . ' AND ( ' . implode( ' OR ', $posts_where ) . ' )';
 }

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -593,9 +593,10 @@ function add_user_id_where_clause_to_events_query( string $where, WP_Query $quer
 
 	$event_ids = wp_cache_get( 'events_for_user_' . $user_id );
 	if ( false === $event_ids ) {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$event_ids = $wpdb->get_col( $wpdb->prepare( "SELECT event_id FROM $attendees_table WHERE user_id = %d", $user_id ) );
+		// phpcs:enable
 		wp_cache_set( 'events_for_user_' . $user_id, $event_ids );
 	}
 

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -155,6 +155,7 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 		// Should not be counted as the user is not an attendee.
 		$this->assertEquals( 0, $this->stats_factory->get_count() );
 
+		// We need the adder to talk to a real Attendee_Repository, so not using the mock here.
 		$adder = new Attendee_Adder( new Attendee_Repository() );
 		$adder->add_to_event( $event, $attendee );
 		// import stats.

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -142,6 +142,29 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 		$this->assertEquals( $translation2->date_added, $stats1['happened_at'] );
 	}
 
+	public function test_stats_for_inactive_then_active_event() {
+		$user_id = get_current_user_id();
+
+		$event_id = $this->event_factory->create_active( $this->now->modify( '-5 minutes' ) );
+		$event    = $this->event_repository->get_event( $event_id );
+		$attendee = new Attendee( $event_id, $user_id );
+
+		$this->assertEquals( 0, $this->stats_factory->get_count() );
+
+		$this->translation_factory->create( $user_id );
+		// Should not be counted as the user is not an attendee.
+		$this->assertEquals( 0, $this->stats_factory->get_count() );
+
+		$adder = new Attendee_Adder( new Attendee_Repository() );
+		$adder->add_to_event( $event, $attendee );
+		// import stats.
+		$this->assertEquals( 1, $this->stats_factory->get_count() );
+
+		$this->translation_factory->create( $user_id );
+		// Now the next translation should be counted immediately.
+		$this->assertEquals( 2, $this->stats_factory->get_count() );
+	}
+
 	public function test_does_not_import_stats_if_inactive_event() {
 		$user_id  = get_current_user_id();
 		$event_id = $this->event_factory->create_inactive_future( $this->now );


### PR DESCRIPTION
Fixes #305 

On translate.wordpress.org, the posts table and the event_attendees tables are in different database shards so they cannot be used in the same SQL query.