### PR TITLE
Only show Permanently Delete Button on Deleted Events page

### DIFF
--- a/templates/events-list-trashed.php
+++ b/templates/events-list-trashed.php
@@ -28,7 +28,7 @@ Templates::header(
 					'show_start'             => true,
 					'show_end'               => true,
 					'relative_time'          => false,
-					'allow_permanent_delete' => true,
+					'show_permanent_delete'  => true,
 				),
 			);
 			?>

--- a/templates/events-list-trashed.php
+++ b/templates/events-list-trashed.php
@@ -28,6 +28,7 @@ Templates::header(
 					'show_start'             => true,
 					'show_end'               => true,
 					'relative_time'          => false,
+					'allow_permanent_delete' => true,
 				),
 			);
 			?>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -22,7 +22,7 @@ $show_end                        = $show_end ?? false;
 $show_excerpt                    = $show_excerpt ?? true;
 $date_format                     = $date_format ?? '';
 $relative_time                   = $relative_time ?? true;
-$allow_permanent_delete          = $allow_permanent_delete ?? false;
+$show_permanent_delete           = $show_permanent_delete ?? false;
 $extra_classes                   = isset( $extra_classes ) ? implode( $extra_classes, ' ' ) : '';
 $current_user_attendee_per_event = $current_user_attendee_per_event ?? array();
 
@@ -94,7 +94,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					</a>
 				<?php endif; ?>
 			<?php endif; ?>
-			<?php if ( $allow_permanent_delete && current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
+			<?php if ( $show_permanent_delete && current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>"
 					class="button is-small is-destructive"
 					title="<?php echo esc_attr__( 'Delete permanently', 'gp-translation-events' ); ?>">

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -22,6 +22,7 @@ $show_end                        = $show_end ?? false;
 $show_excerpt                    = $show_excerpt ?? true;
 $date_format                     = $date_format ?? '';
 $relative_time                   = $relative_time ?? true;
+$allow_permanent_delete          = $allow_permanent_delete ?? false;
 $extra_classes                   = isset( $extra_classes ) ? implode( $extra_classes, ' ' ) : '';
 $current_user_attendee_per_event = $current_user_attendee_per_event ?? array();
 
@@ -93,7 +94,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 					</a>
 				<?php endif; ?>
 			<?php endif; ?>
-			<?php if ( current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
+			<?php if ( $allow_permanent_delete && current_user_can( 'delete_translation_event', $event->id() ) ) : ?>
 				<a href="<?php echo esc_url( Urls::event_delete( $event->id() ) ); ?>"
 					class="button is-small is-destructive"
 					title="<?php echo esc_attr__( 'Delete permanently', 'gp-translation-events' ); ?>">


### PR DESCRIPTION
## Before
Currently an Admin will see a permanently delete button on all pages. 

![Screenshot 2024-05-28 at 13 40 51](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/5896bbb8-5a20-47a6-bc61-403eb786b978)

## After
I'd like to avoid accidentally deleting an event, so this button now only shows on the trashed events page:

![Screenshot 2024-05-28 at 13 42 08](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/af4bb1a5-23e3-42e8-b598-d7cad612d583)

![Screenshot 2024-05-28 at 13 42 16](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/bcbed9c0-f58a-4986-ae0b-2174a9244c4b)
