### PR TITLE
Remove the underline from the edit and delete buttons

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -174,7 +174,9 @@ span.event-list-date {
 }
 
 /* Event list: Event buttons. */
-.event-list-item-button {
+a.event-list-item-button,
+a.event-list-item-button:visited,
+a.event-list-item-button:hover {
 	text-decoration: none;
 	vertical-align: bottom;
 }

--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -174,9 +174,7 @@ span.event-list-date {
 }
 
 /* Event list: Event buttons. */
-a.event-list-item-button,
-a.event-list-item-button:visited,
-a.event-list-item-button:hover {
+a.event-list-item-button:any-link {
 	text-decoration: none;
 	vertical-align: bottom;
 }


### PR DESCRIPTION
In the event lists, the Edit and Delete buttons has an unusual underline.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/0eed9630-cd66-4347-b33f-0c8fae002864)

This PR removes it.

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/1667814/e9fbf2aa-e03c-46be-877c-98931f26d56c)
