### PR TITLE
Change title to trash

### DIFF
--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -89,7 +89,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 				<?php else : ?>
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
 						class="event-list-item-button is-destructive"
-						title="<?php echo esc_attr__( 'Trash', 'gp-translation-events' ); ?>">
+						title="<?php echo esc_attr__( 'Move to trash', 'gp-translation-events' ); ?>">
 						<span class="dashicons dashicons-trash"></span>
 					</a>
 				<?php endif; ?>

--- a/templates/partials/event-list.php
+++ b/templates/partials/event-list.php
@@ -89,7 +89,7 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 				<?php else : ?>
 					<a href="<?php echo esc_url( Urls::event_trash( $event->id() ) ); ?>"
 						class="event-list-item-button is-destructive"
-						title="<?php echo esc_attr__( 'Delete', 'gp-translation-events' ); ?>">
+						title="<?php echo esc_attr__( 'Trash', 'gp-translation-events' ); ?>">
 						<span class="dashicons dashicons-trash"></span>
 					</a>
 				<?php endif; ?>


### PR DESCRIPTION
The icon title is different from the purpose of the icon.

**Before**

<img width="1003" alt="Screenshot 2024-05-29 at 11 35 50" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/a325231d-d334-4219-8ca7-c86fd38a7956">


**After**

<img width="966" alt="Screenshot 2024-05-29 at 14 16 15" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/9cefa5e9-446f-49f6-8a06-e8c2f6ef1097">
