### PR TITLE
Fix access to manage attendees page

### DIFF
--- a/includes/routes/attendee/list.php
+++ b/includes/routes/attendee/list.php
@@ -40,7 +40,7 @@ class List_Route extends Route {
 		if ( ! $event ) {
 			$this->die_with_404();
 		}
-		if ( ! current_user_can( 'edit_translation_event', $event->id() ) ) {
+		if ( ! current_user_can( 'edit_translation_event_attendees', $event->id() ) ) {
 			$this->die_with_error( esc_html__( 'You do not have permission to edit this event\'s attendees.', 'gp-translation-events' ), 403 );
 		}
 		if ( gp_get( 'filter' ) && 'hosts' === gp_get( 'filter' ) ) {

--- a/includes/routes/attendee/list.php
+++ b/includes/routes/attendee/list.php
@@ -40,7 +40,7 @@ class List_Route extends Route {
 		if ( ! $event ) {
 			$this->die_with_404();
 		}
-		if ( ! current_user_can( 'edit_translation_event_attendees', $event->id() ) ) {
+		if ( ! current_user_can( 'edit_translation_event', $event->id() ) ) {
 			$this->die_with_error( esc_html__( 'You do not have permission to edit this event\'s attendees.', 'gp-translation-events' ), 403 );
 		}
 		if ( gp_get( 'filter' ) && 'hosts' === gp_get( 'filter' ) ) {

--- a/templates/event-edit.php
+++ b/templates/event-edit.php
@@ -28,7 +28,9 @@ Templates::header(
 </div>
 
 <div class="event-edit-right">
-	<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event->id() ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
+	<?php if ( current_user_can( 'edit_translation_event_attendees', $event->id() ) ) : ?>
+		<a class="manage-attendees-btn button is-primary" href="<?php echo esc_url( Urls::event_attendees( $event->id() ) ); ?>"><?php esc_html_e( 'Manage Attendees', 'gp-translation-events' ); ?></a>
+	<?php endif; ?>
 </div>
 
 <?php Templates::footer(); ?>


### PR DESCRIPTION
Fixes #317 

**Testing Instructions**
- Checkout the `trunk` branch
- Try to go to the edit page of an event that you do not have permissions to edit attendees, the "Manage Events" button is displayed.
- And when clicked, you get an error  "You do not have the permission to edit this event's attendees" will be displayed.
- Checkout the `manage-attendee-access` branch 
- Try to go to the edit page of an event that you do not have permissions to edit attendees, the "Manage Events" button is not displayed. The button will only be displayed for users with permissions.
