### PR TITLE
Fix flaky tests due to value of now changing

### DIFF
--- a/includes/event/event-capabilities.php
+++ b/includes/event/event-capabilities.php
@@ -43,15 +43,18 @@ class Event_Capabilities {
 		self::EDIT_TIMEZONE,
 	);
 
+	private DateTimeImmutable $now;
 	private Event_Repository_Interface $event_repository;
 	private Attendee_Repository $attendee_repository;
 	private Stats_Calculator $stats_calculator;
 
 	public function __construct(
+		DateTimeImmutable $now,
 		Event_Repository_Interface $event_repository,
 		Attendee_Repository $attendee_repository,
 		Stats_Calculator $stats_calculator
 	) {
+		$this->now                 = $now;
 		$this->event_repository    = $event_repository;
 		$this->attendee_repository = $attendee_repository;
 		$this->stats_calculator    = $stats_calculator;
@@ -260,14 +263,13 @@ class Event_Capabilities {
 	 * @return bool
 	 */
 	private function has_edit_field( WP_User $user, Event $event, $cap ): bool {
-		$now                 = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_end_plus_1_hr = $event->end()->modify( '+1 hour' );
 
 		if ( self::EDIT_DESCRIPTION === $cap ) {
 			return true;
 		}
 
-		if ( $event->start() > $now ) {
+		if ( $event->start() > $this->now ) {
 			return true;
 		}
 
@@ -279,10 +281,10 @@ class Event_Capabilities {
 			return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
 		}
 
-		if ( $event->end()->is_in_the_past() && $now < $event_end_plus_1_hr ) {
+		if ( $event->end()->is_in_the_past() && $this->now < $event_end_plus_1_hr ) {
 			return ( self::EDIT_TITLE === $cap || self::EDIT_END === $cap );
 		}
-		if ( $event->end()->is_in_the_past() && $now > $event_end_plus_1_hr ) {
+		if ( $event->end()->is_in_the_past() && $this->now > $event_end_plus_1_hr ) {
 			return ( self::EDIT_DESCRIPTION === $cap );
 		}
 

--- a/includes/event/event-date.php
+++ b/includes/event/event-date.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
+use Wporg\TranslationEvents\Translation_Events;
 
 /**
  * Event_Date
@@ -21,11 +22,15 @@ abstract class Event_Date extends DateTimeImmutable {
 			$timezone = new DateTimeZone( 'UTC' );
 		}
 
-		try {
-			$utc_date = new DateTime( $date, new DateTimeZone( 'UTC' ) );
-			$utc_date->setTimezone( $timezone );
-		} catch ( Exception $e ) {
-			$utc_date = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		if ( 'now' === $date ) {
+			$utc_date = Translation_Events::now();
+		} else {
+			try {
+				$utc_date = new DateTime( $date, new DateTimeZone( 'UTC' ) );
+				$utc_date->setTimezone( $timezone );
+			} catch ( Exception $e ) {
+				$utc_date = Translation_Events::now();
+			}
 		}
 
 		parent::__construct( $utc_date->format( 'Y-m-d H:i:s' ), $timezone );
@@ -54,8 +59,7 @@ abstract class Event_Date extends DateTimeImmutable {
 	}
 
 	public function is_in_the_past() {
-		$current_date_time = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		return $this->utc() < $current_date_time;
+		return $this->utc() < Translation_Events::now();
 	}
 
 	public function print_relative_time_html( $format = false ) {
@@ -98,7 +102,7 @@ abstract class Event_Date extends DateTimeImmutable {
 
 class Event_Start_Date extends Event_Date {
 	public function get_variable_text(): string {
-		$interval       = $this->diff( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) );
+		$interval       = $this->diff( Translation_Events::now() );
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
 		$hours_in_a_day = 24;
 
@@ -146,7 +150,7 @@ class Event_End_Date extends Event_Date {
 			return sprintf( 'ended %s', $this->format( 'l, F j, Y' ) );
 		}
 
-		$interval       = $this->diff( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) );
+		$interval       = $this->diff( Translation_Events::now() );
 		$hours_left     = ( $interval->d * 24 ) + $interval->h;
 		$hours_in_a_day = 24;
 

--- a/includes/event/event-repository-cached.php
+++ b/includes/event/event-repository-cached.php
@@ -45,9 +45,8 @@ class Event_Repository_Cached extends Event_Repository {
 		$this->assert_pagination_arguments( $page, $page_size );
 
 		$cache_duration = self::CACHE_DURATION;
-		$now            = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-		$boundary_start = $now;
-		$boundary_end   = $now->modify( "+$cache_duration seconds" );
+		$boundary_start = $this->now;
+		$boundary_end   = $this->now->modify( "+$cache_duration seconds" );
 
 		$events = wp_cache_get( self::ACTIVE_EVENTS_KEY, '', false, $found );
 		if ( ! $found ) {
@@ -61,8 +60,8 @@ class Event_Repository_Cached extends Event_Repository {
 		$events = array_values(
 			array_filter(
 				$events,
-				function ( $event ) use ( $now ) {
-					return $event->start() <= $now && $now <= $event->end();
+				function ( $event ) {
+					return $event->start() <= $this->now && $this->now <= $event->end();
 				}
 			)
 		);

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -14,7 +14,7 @@ use Wporg\TranslationEvents\Translation_Events;
 class Event_Repository implements Event_Repository_Interface {
 	private const POST_TYPE = Translation_Events::CPT;
 
-	private DateTimeImmutable $now;
+	protected DateTimeImmutable $now;
 	private Attendee_Repository $attendee_repository;
 
 	public function __construct( DateTimeImmutable $now, Attendee_Repository $attendee_repository ) {

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -229,14 +229,16 @@ class Event_Repository implements Event_Repository_Interface {
 
 	public function get_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
 			array(
 				'post_status' => array( 'publish', 'draft' ),
 				'meta_key'    => '_event_start',
-				'orderby'     => 'meta_value',
-				'order'       => 'DESC',
+				'orderby'     => array(
+					'meta_value' => 'DESC',
+				),
 			),
 			array(),
 			$user_id,
@@ -248,6 +250,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -267,8 +270,9 @@ class Event_Repository implements Event_Repository_Interface {
 					),
 				),
 				'meta_key'   => '_event_start',
-				'orderby'    => 'meta_value',
-				'order'      => 'ASC',
+				'orderby'    => array(
+					'meta_value' => 'ASC',
+				),
 			),
 			array(),
 			$user_id,
@@ -279,6 +283,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_current_and_upcoming_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -292,8 +297,9 @@ class Event_Repository implements Event_Repository_Interface {
 					),
 				),
 				'meta_key'   => '_event_start',
-				'orderby'    => 'meta_value',
-				'order'      => 'ASC',
+				'orderby'    => array(
+					'meta_value' => 'ASC',
+				),
 			),
 			array(),
 			$user_id,
@@ -304,6 +310,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -318,8 +325,9 @@ class Event_Repository implements Event_Repository_Interface {
 				),
 				'meta_key'   => '_event_start',
 				'meta_type'  => 'DATETIME',
-				'orderby'    => 'meta_value',
-				'order'      => 'DESC',
+				'orderby'    => array(
+					'meta_value' => 'DESC',
+				),
 			),
 			array(),
 			$user_id,
@@ -330,6 +338,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_events_created_by_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -337,8 +346,9 @@ class Event_Repository implements Event_Repository_Interface {
 				'post_status' => array( 'publish', 'draft' ),
 				'author'      => $user_id,
 				'meta_key'    => '_event_start',
-				'orderby'     => 'meta_value',
-				'order'       => 'DESC',
+				'orderby'     => array(
+					'meta_value' => 'DESC',
+				),
 			)
 		);
 		// phpcs:enable
@@ -370,14 +380,16 @@ class Event_Repository implements Event_Repository_Interface {
 
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
 			array(
 				'post_status' => array( 'publish', 'draft' ),
 				'meta_key'    => '_event_start',
-				'orderby'     => 'meta_value',
-				'order'       => 'DESC',
+				'orderby'     => array(
+					'meta_value' => 'DESC',
+				),
 			),
 			$events_user_is_hosting_ids
 		);

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -168,6 +168,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_upcoming_events( int $page = - 1, int $page_size = - 1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -180,8 +181,10 @@ class Event_Repository implements Event_Repository_Interface {
 						'type'    => 'DATETIME',
 					),
 				),
-				'orderby'    => array( 'meta_value', 'ID' ),
-				'order'      => 'ASC',
+				'orderby'    => array(
+					'meta_value' => 'ASC',
+					'ID'         => 'ASC',
+				),
 			)
 		);
 		// phpcs:enable
@@ -190,6 +193,7 @@ class Event_Repository implements Event_Repository_Interface {
 	public function get_past_events( int $page = - 1, int $page_size = - 1 ): Events_Query_Result {
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		return $this->execute_events_query(
 			$page,
 			$page_size,
@@ -202,8 +206,10 @@ class Event_Repository implements Event_Repository_Interface {
 						'type'    => 'DATETIME',
 					),
 				),
-				'orderby'    => array( 'meta_value', 'ID' ),
-				'order'      => 'DESC',
+				'orderby'    => array(
+					'meta_value' => 'DESC',
+					'ID'         => 'DESC',
+				),
 			)
 		);
 		// phpcs:enable
@@ -392,6 +398,7 @@ class Event_Repository implements Event_Repository_Interface {
 
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 		$query_args = array(
 			'meta_query' => array(
 				array(
@@ -409,7 +416,10 @@ class Event_Repository implements Event_Repository_Interface {
 			),
 			'meta_key'   => '_event_start',
 			'meta_type'  => 'DATETIME',
-			'orderby'    => array( 'meta_value', 'ID' ),
+			'orderby'    => array(
+				'meta_value' => 'ASC',
+				'ID'         => 'ASC',
+			),
 		);
 		// phpcs:enable
 

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -156,11 +156,9 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_current_events( int $page = -1, int $page_size = -1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		return $this->get_events_active_between(
-			$now,
-			$now,
+			$this->now,
+			$this->now,
 			array(),
 			$page,
 			$page_size
@@ -168,8 +166,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_upcoming_events( int $page = - 1, int $page_size = - 1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
@@ -179,7 +175,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_query' => array(
 					array(
 						'key'     => '_event_start',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '>=',
 						'type'    => 'DATETIME',
 					),
@@ -192,8 +188,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_past_events( int $page = - 1, int $page_size = - 1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
@@ -203,7 +197,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_query' => array(
 					array(
 						'key'     => '_event_end',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '<',
 						'type'    => 'DATETIME',
 					),
@@ -244,8 +238,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_current_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
@@ -255,13 +247,13 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_query' => array(
 					array(
 						'key'     => '_event_start',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '<=',
 						'type'    => 'DATETIME',
 					),
 					array(
 						'key'     => '_event_end',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '>=',
 						'type'    => 'DATETIME',
 					),
@@ -277,8 +269,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_current_and_upcoming_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
@@ -288,7 +278,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_query' => array(
 					array(
 						'key'     => '_event_end',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '>',
 						'type'    => 'DATETIME',
 					),
@@ -304,8 +294,6 @@ class Event_Repository implements Event_Repository_Interface {
 	}
 
 	public function get_past_events_for_user( int $user_id, int $page = -1, int $page_size = -1 ): Events_Query_Result {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
-
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		return $this->execute_events_query(
@@ -315,7 +303,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_query' => array(
 					array(
 						'key'     => '_event_end',
-						'value'   => $now->format( 'Y-m-d H:i:s' ),
+						'value'   => $this->now->format( 'Y-m-d H:i:s' ),
 						'compare' => '<',
 						'type'    => 'DATETIME',
 					),

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -238,6 +238,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_key'    => '_event_start',
 				'orderby'     => array(
 					'meta_value' => 'DESC',
+					'ID'         => 'DESC',
 				),
 			),
 			array(),
@@ -272,6 +273,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_key'   => '_event_start',
 				'orderby'    => array(
 					'meta_value' => 'ASC',
+					'ID'         => 'ASC',
 				),
 			),
 			array(),
@@ -299,6 +301,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_key'   => '_event_start',
 				'orderby'    => array(
 					'meta_value' => 'ASC',
+					'ID'         => 'ASC',
 				),
 			),
 			array(),
@@ -327,6 +330,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_type'  => 'DATETIME',
 				'orderby'    => array(
 					'meta_value' => 'DESC',
+					'ID'         => 'DESC',
 				),
 			),
 			array(),
@@ -348,6 +352,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_key'    => '_event_start',
 				'orderby'     => array(
 					'meta_value' => 'DESC',
+					'ID'         => 'DESC',
 				),
 			)
 		);
@@ -389,6 +394,7 @@ class Event_Repository implements Event_Repository_Interface {
 				'meta_key'    => '_event_start',
 				'orderby'     => array(
 					'meta_value' => 'DESC',
+					'ID'         => 'DESC',
 				),
 			),
 			$events_user_is_hosting_ids

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -181,6 +181,7 @@ class Event_Repository implements Event_Repository_Interface {
 						'type'    => 'DATETIME',
 					),
 				),
+				'meta_key'   => '_event_start',
 				'orderby'    => array(
 					'meta_value' => 'ASC',
 					'ID'         => 'ASC',
@@ -206,6 +207,7 @@ class Event_Repository implements Event_Repository_Interface {
 						'type'    => 'DATETIME',
 					),
 				),
+				'meta_key'   => '_event_end',
 				'orderby'    => array(
 					'meta_value' => 'DESC',
 					'ID'         => 'DESC',

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -397,7 +397,7 @@ class Event_Repository implements Event_Repository_Interface {
 				array(
 					'key'     => '_event_start',
 					'value'   => $boundary_end->format( 'Y-m-d H:i:s' ),
-					'compare' => '<',
+					'compare' => '<=',
 					'type'    => 'DATETIME',
 				),
 				array(

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -14,9 +14,11 @@ use Wporg\TranslationEvents\Translation_Events;
 class Event_Repository implements Event_Repository_Interface {
 	private const POST_TYPE = Translation_Events::CPT;
 
+	private DateTimeImmutable $now;
 	private Attendee_Repository $attendee_repository;
 
-	public function __construct( Attendee_Repository $attendee_repository ) {
+	public function __construct( DateTimeImmutable $now, Attendee_Repository $attendee_repository ) {
+		$this->now                 = $now;
 		$this->attendee_repository = $attendee_repository;
 	}
 

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use Throwable;
+use Wporg\TranslationEvents\Translation_Events;
 
 class InvalidTimeZone extends Exception {
 	public function __construct( Throwable $previous = null ) {
@@ -95,7 +96,7 @@ class Event {
 	}
 
 	public function is_active(): bool {
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$now = Translation_Events::now();
 		return $now >= $this->start->utc() && $now < $this->end->utc();
 	}
 

--- a/includes/notifications/notifications-schedule.php
+++ b/includes/notifications/notifications-schedule.php
@@ -2,17 +2,21 @@
 
 namespace Wporg\TranslationEvents\Notifications;
 
+use DateTimeImmutable;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 
 class Notifications_Schedule {
+	private DateTimeImmutable $now;
 	private Event_Repository_Interface $event_repository;
 
 	/**
 	 * Notifications_Schedule constructor.
 	 *
-	 * @param Event_Repository_Interface $event_repository    Event repository.
+	 * @param DateTimeImmutable          $now              The value of "now".
+	 * @param Event_Repository_Interface $event_repository Event repository.
 	 */
-	public function __construct( Event_Repository_Interface $event_repository ) {
+	public function __construct( DateTimeImmutable $now, Event_Repository_Interface $event_repository ) {
+		$this->now              = $now;
 		$this->event_repository = $event_repository;
 	}
 
@@ -34,13 +38,12 @@ class Notifications_Schedule {
 			$args                  = array(
 				'post_id' => $post_id,
 			);
-			$now                   = time();
 			$new_next_1h_schedule  = $event->start()->getTimestamp() - HOUR_IN_SECONDS;
 			$new_next_24h_schedule = $event->start()->getTimestamp() - 24 * HOUR_IN_SECONDS;
-			if ( $new_next_1h_schedule > $now ) {
+			if ( $new_next_1h_schedule > $this->now->getTimestamp() ) {
 				wp_schedule_single_event( $new_next_1h_schedule, 'wporg_gp_translation_events_email_notifications_1h', $args );
 			}
-			if ( $new_next_24h_schedule > $now ) {
+			if ( $new_next_24h_schedule > $this->now->getTimestamp() ) {
 				wp_schedule_single_event( $new_next_24h_schedule, 'wporg_gp_translation_events_email_notifications_24h', $args );
 			}
 		}

--- a/includes/notifications/notifications-send.php
+++ b/includes/notifications/notifications-send.php
@@ -3,7 +3,9 @@
 namespace Wporg\TranslationEvents\Notifications;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
+use Exception;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
@@ -15,17 +17,21 @@ class Notifications_Send {
 
 	private Attendee_Repository $attendee_repository;
 	private Event_Repository_Interface $event_repository;
+	private DateTimeImmutable $now;
 
 	/**
 	 * Notifications_Send constructor.
 	 *
+	 * @param DateTimeImmutable          $now                 The value of "now".
 	 * @param Event_Repository_Interface $event_repository    Event repository.
 	 * @param Attendee_Repository        $attendee_repository Attendee repository.
 	 */
 	public function __construct(
+		DateTimeImmutable $now,
 		Event_Repository_Interface $event_repository,
 		Attendee_Repository $attendee_repository
 	) {
+		$this->now                 = $now;
 		$this->event_repository    = $event_repository;
 		$this->attendee_repository = $attendee_repository;
 		add_action( 'wporg_gp_translation_events_email_notifications_1h', array( $this, 'send_notifications' ), 10, 1 );
@@ -38,7 +44,7 @@ class Notifications_Send {
 	 * @param int $post_id Post ID.
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function send_notifications( int $post_id ) {
 		$event = $this->event_repository->get_event( $post_id );
@@ -152,8 +158,7 @@ class Notifications_Send {
 	 * @return string
 	 */
 	private function calculate_time_until_event( Event_Start_Date $start_date ): string {
-		$now              = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-		$diff             = $start_date->diff( $now );
+		$diff             = $start_date->diff( $this->now );
 		$days_to_start    = $diff->days;
 		$hours_to_start   = $diff->h;
 		$minutes_to_start = $diff->i;

--- a/includes/routes/event/create.php
+++ b/includes/routes/event/create.php
@@ -8,6 +8,7 @@ use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Routes\Route;
+use Wporg\TranslationEvents\Translation_Events;
 
 /**
  * Displays the event create page.
@@ -24,7 +25,7 @@ class Create_Route extends Route {
 			$this->die_with_error( 'You do not have permission to create events.', 403 );
 		}
 
-		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$now = Translation_Events::now();
 
 		$event = new Event(
 			get_current_user_id(),

--- a/includes/routes/event/list.php
+++ b/includes/routes/event/list.php
@@ -2,10 +2,6 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
-use DateTime;
-use DateTimeZone;
-use Exception;
-use WP_Query;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
 use Wporg\TranslationEvents\Routes\Route;
 use Wporg\TranslationEvents\Translation_Events;
@@ -22,15 +18,6 @@ class List_Route extends Route {
 	}
 
 	public function handle(): void {
-		$current_datetime_utc = null;
-		try {
-			$current_datetime_utc = ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d H:i:s' );
-		} catch ( Exception $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $e );
-			$this->die_with_error( esc_html__( 'Something is wrong.', 'gp-translation-events' ) );
-		}
-
 		$_current_events_paged        = 1;
 		$_upcoming_events_paged       = 1;
 		$_past_events_paged           = 1;

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -2,10 +2,9 @@
 namespace Wporg\Tests\Attendee;
 
 use DateTimeImmutable;
-use DateTimeZone;
 use GP_Translation;
-use GP_UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Adder;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
@@ -15,7 +14,7 @@ use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Attendee_Adder_Test extends GP_UnitTestCase {
+class Attendee_Adder_Test extends Base_Test {
 	/**
 	 * @var MockObject|Attendee_Repository
 	 */

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -13,6 +13,7 @@ use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Attendee_Adder_Test extends GP_UnitTestCase {
 	/**
@@ -20,23 +21,23 @@ class Attendee_Adder_Test extends GP_UnitTestCase {
 	 */
 	private $attendee_repository;
 
+	private DateTimeImmutable $now;
 	private Attendee_Adder $adder;
 	private Event_Repository $event_repository;
 	private Event_Factory $event_factory;
 	private Translation_Factory $translation_factory;
 	private Stats_Factory $stats_factory;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->now                 = Translation_Events::now();
 		$this->attendee_repository = $this->createMock( Attendee_Repository::class );
 		$this->adder               = new Attendee_Adder( $this->attendee_repository );
-		$this->event_repository    = new Event_Repository( new Attendee_Repository() );
+		$this->event_repository    = new Event_Repository( $this->now, $this->attendee_repository );
 		$this->event_factory       = new Event_Factory();
 		$this->translation_factory = new Translation_Factory( $this->factory );
 		$this->stats_factory       = new Stats_Factory();
 
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$this->set_normal_user_as_current();
 	}
 

--- a/tests/attendee/attendee-adder.php
+++ b/tests/attendee/attendee-adder.php
@@ -1,7 +1,6 @@
 <?php
 namespace Wporg\Tests\Attendee;
 
-use DateTimeImmutable;
 use GP_Translation;
 use PHPUnit\Framework\MockObject\MockObject;
 use Wporg\Tests\Base_Test;
@@ -12,7 +11,6 @@ use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Attendee_Adder_Test extends Base_Test {
 	/**
@@ -20,7 +18,6 @@ class Attendee_Adder_Test extends Base_Test {
 	 */
 	private $attendee_repository;
 
-	private DateTimeImmutable $now;
 	private Attendee_Adder $adder;
 	private Event_Repository $event_repository;
 	private Event_Factory $event_factory;
@@ -29,7 +26,6 @@ class Attendee_Adder_Test extends Base_Test {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now                 = Translation_Events::now();
 		$this->attendee_repository = $this->createMock( Attendee_Repository::class );
 		$this->adder               = new Attendee_Adder( $this->attendee_repository );
 		$this->event_repository    = new Event_Repository( $this->now, $this->attendee_repository );

--- a/tests/attendee/attendee-repository.php
+++ b/tests/attendee/attendee-repository.php
@@ -2,12 +2,12 @@
 
 namespace Wporg\Tests\Attendee;
 
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 
-class Attendee_Repository_Test extends GP_UnitTestCase {
+class Attendee_Repository_Test extends Base_Test {
 	private Attendee_Repository $repository;
 	private Stats_Factory $stats_factory;
 

--- a/tests/base-test.php
+++ b/tests/base-test.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Wporg\Tests;
+
+use GP_UnitTestCase;
+
+abstract class Base_Test extends GP_UnitTestCase {
+}

--- a/tests/base-test.php
+++ b/tests/base-test.php
@@ -2,7 +2,15 @@
 
 namespace Wporg\Tests;
 
+use DateTimeImmutable;
 use GP_UnitTestCase;
+use Wporg\TranslationEvents\Translation_Events;
 
 abstract class Base_Test extends GP_UnitTestCase {
+	protected DateTimeImmutable $now;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->now = Translation_Events::now();
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -50,3 +50,6 @@ require "$_tests_dir/includes/bootstrap.php";
 require_once _glotpress_path( '/tests/phpunit/lib/testcase.php' );
 require_once _glotpress_path( '/tests/phpunit/lib/testcase-route.php' );
 require_once _glotpress_path( '/tests/phpunit/lib/testcase-request.php' );
+
+// Require our own test code.
+require_once __DIR__ . '/base-test.php';

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -10,23 +10,24 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Capabilities_Test extends GP_UnitTestCase {
+	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Attendee_Repository $attendee_repository;
 	private Event_Repository $event_repository;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->now                 = Translation_Events::now();
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();
-		$this->event_repository    = new Event_Repository( $this->attendee_repository );
+		$this->event_repository    = new Event_Repository( $this->now, $this->attendee_repository );
 
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_cannot_manage_if_no_crud_permission() {

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\Tests\Event;
 
-use DateTimeImmutable;
 use DateTimeZone;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee;
@@ -10,10 +9,8 @@ use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Capabilities_Test extends Base_Test {
-	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Attendee_Repository $attendee_repository;
@@ -21,7 +18,6 @@ class Event_Capabilities_Test extends Base_Test {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now                 = Translation_Events::now();
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -4,7 +4,7 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -12,7 +12,7 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Event_Capabilities_Test extends GP_UnitTestCase {
+class Event_Capabilities_Test extends Base_Test {
 	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;

--- a/tests/event/event-capabilities.php
+++ b/tests/event/event-capabilities.php
@@ -280,10 +280,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_id = $this->event_factory->create_event(
-			$now->modify( '-2 hours' ),
-			$now->modify( '-59 minutes' ),
+			$this->now->modify( '-2 hours' ),
+			$this->now->modify( '-59 minutes' ),
 			$timezone,
 			array(),
 		);
@@ -299,10 +298,9 @@ class Event_Capabilities_Test extends GP_UnitTestCase {
 		$this->set_normal_user_as_current();
 
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
-		$now      = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$event_id = $this->event_factory->create_event(
-			$now->modify( '-3 hours' ),
-			$now->modify( '-1 hours  -1 minutes' ),
+			$this->now->modify( '-3 hours' ),
+			$this->now->modify( '-1 hours  -1 minutes' ),
 			$timezone,
 			array(),
 		);

--- a/tests/event/event-date.php
+++ b/tests/event/event-date.php
@@ -2,10 +2,10 @@
 
 namespace Wporg\Tests\Event;
 
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 
-class Event_Date_Test extends GP_UnitTestCase {
+class Event_Date_Test extends Base_Test {
 	public function test_timezone() {
 		$start = new Event_Start_Date( '2024-03-07 12:00:00', new \DateTimeZone( 'UTC' ) );
 		$this->assertEquals( 'UTC', $start->timezone()->getName() );

--- a/tests/event/event-image.php
+++ b/tests/event/event-image.php
@@ -2,23 +2,13 @@
 
 namespace Wporg\Tests\Event;
 
-use DateTimeImmutable;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Routes\Event\Image_Route;
 use Wporg\TranslationEvents\Templates;
 use Wporg\TranslationEvents\Tests\Event_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
 class Event_Image_Test extends Base_Test {
-
-	private DateTimeImmutable $now;
-
-	public function setUp(): void {
-		parent::setUp();
-		$this->now = Translation_Events::now();
-	}
-
 	/**
 	 * Test that when the header template is fired, it generates the social metadata.
 	 *

--- a/tests/event/event-image.php
+++ b/tests/event/event-image.php
@@ -8,6 +8,7 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Routes\Event\Image_Route;
 use Wporg\TranslationEvents\Templates;
 use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
 class Event_Image_Test extends GP_UnitTestCase {
@@ -16,7 +17,7 @@ class Event_Image_Test extends GP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$this->now = Translation_Events::now();
 	}
 
 	/**

--- a/tests/event/event-image.php
+++ b/tests/event/event-image.php
@@ -3,15 +3,14 @@
 namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Routes\Event\Image_Route;
 use Wporg\TranslationEvents\Templates;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
-class Event_Image_Test extends GP_UnitTestCase {
+class Event_Image_Test extends Base_Test {
 
 	private DateTimeImmutable $now;
 

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -11,20 +11,21 @@ use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository_Cached_Test extends GP_UnitTestCase {
+	private DateTimeImmutable $now;
 	private Event_Repository_Cached $repository;
 	private Event_Factory $event_factory;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->now           = Translation_Events::now();
 		$this->event_factory = new Event_Factory();
-		$this->repository    = new Event_Repository_Cached( new Attendee_Repository() );
+		$this->repository    = new Event_Repository_Cached( $this->now, new Attendee_Repository() );
 
 		wp_cache_delete( 'translation-events-active-events' );
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_get_current_events_when_no_current_events_exist() {

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\Tests\Event;
 
-use DateTimeImmutable;
 use DateTimeZone;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
@@ -11,16 +10,13 @@ use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository_Cached_Test extends Base_Test {
-	private DateTimeImmutable $now;
 	private Event_Repository_Cached $repository;
 	private Event_Factory $event_factory;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now           = Translation_Events::now();
 		$this->event_factory = new Event_Factory();
 		$this->repository    = new Event_Repository_Cached( $this->now, new Attendee_Repository() );
 

--- a/tests/event/event-repository-cached.php
+++ b/tests/event/event-repository-cached.php
@@ -4,7 +4,7 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository_Cached;
 use Wporg\TranslationEvents\Event\Event;
@@ -13,7 +13,7 @@ use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Event_Repository_Cached_Test extends GP_UnitTestCase {
+class Event_Repository_Cached_Test extends Base_Test {
 	private DateTimeImmutable $now;
 	private Event_Repository_Cached $repository;
 	private Event_Factory $event_factory;

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -305,7 +305,7 @@ class Event_Repository_Test extends Base_Test {
 	public function test_get_past_events_for_user() {
 		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
-		$event2_id = $this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
+		$event2_id = $this->event_factory->create_inactive_past( $this->now->modify( '-1 minute' ), array( $user_id ) );
 
 		$this->event_factory->create_active( $this->now, array( $user_id ) );
 		$this->event_factory->create_active( $this->now->modify( '+1 minute' ), array( $user_id ) );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -208,7 +208,7 @@ class Event_Repository_Test extends Base_Test {
 	public function test_get_trashed_events() {
 		$event1_id = $this->event_factory->create_active( $this->now );
 		$event2_id = $this->event_factory->create_inactive_past( $this->now );
-		$this->event_factory->create_active( $this->now );
+		$this->event_factory->create_active( $this->now->modify( '+1 minute' ) );
 		$this->event_factory->create_inactive_future( $this->now );
 
 		$event1 = $this->repository->get_event( $event1_id );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -277,9 +277,9 @@ class Event_Repository_Test extends Base_Test {
 
 	public function test_get_current_and_upcoming_events_for_user() {
 		$user_id   = get_current_user_id();
-		$event1_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event1_id = $this->event_factory->create_active( $this->now->modify( '-1 minute' ), array( $user_id ) );
 		$event2_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
-		$event3_id = $this->event_factory->create_active( $this->now, array( $user_id ) );
+		$event3_id = $this->event_factory->create_active( $this->now->modify( '+1 minute' ), array( $user_id ) );
 		$this->event_factory->create_active( $this->now );
 		$this->event_factory->create_inactive_past( $this->now, array( $user_id ) );
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -201,8 +201,8 @@ class Event_Repository_Test extends Base_Test {
 
 		$events = $this->repository->get_past_events()->events;
 		$this->assertCount( 2, $events );
-		$this->assertEquals( $event1_id, $events[0]->id() );
-		$this->assertEquals( $event2_id, $events[1]->id() );
+		$this->assertEquals( $event2_id, $events[0]->id() );
+		$this->assertEquals( $event1_id, $events[1]->id() );
 	}
 
 	public function test_get_trashed_events() {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -4,7 +4,7 @@ namespace Wporg\Tests\Event;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository;
@@ -14,7 +14,7 @@ use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Event_Repository_Test extends GP_UnitTestCase {
+class Event_Repository_Test extends Base_Test {
 	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -12,23 +12,24 @@ use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository_Test extends GP_UnitTestCase {
+	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Attendee_Repository $attendee_repository;
 	private Event_Repository $repository;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->now                 = Translation_Events::now();
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();
-		$this->repository          = new Event_Repository( new Attendee_Repository() );
+		$this->repository          = new Event_Repository( $this->now, $this->attendee_repository );
 
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_get_event_returns_null_when_post_does_not_not_have_correct_type() {

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -182,8 +182,8 @@ class Event_Repository_Test extends Base_Test {
 	}
 
 	public function test_get_upcoming_events() {
-		$event1_id = $this->event_factory->create_active( $this->now->modify( '+1 month' ) );
-		$event2_id = $this->event_factory->create_active( $this->now->modify( '+2 months' ) );
+		$event1_id = $this->event_factory->create_inactive_future( $this->now );
+		$event2_id = $this->event_factory->create_inactive_future( $this->now->modify( '+1 minute' ) );
 		$this->event_factory->create_active( $this->now->modify( '-2 hours' ) );
 		$this->event_factory->create_inactive_past( $this->now );
 

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -194,7 +194,7 @@ class Event_Repository_Test extends Base_Test {
 	}
 
 	public function test_get_past_events() {
-		$event1_id = $this->event_factory->create_inactive_past( $this->now );
+		$event1_id = $this->event_factory->create_inactive_past( $this->now->modify( '-1 minute' ) );
 		$event2_id = $this->event_factory->create_inactive_past( $this->now );
 		$this->event_factory->create_active( $this->now->modify( '+2 hours' ) );
 		$this->event_factory->create_inactive_future( $this->now );

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -2,7 +2,6 @@
 
 namespace Wporg\Tests\Event;
 
-use DateTimeImmutable;
 use DateTimeZone;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
@@ -12,10 +11,8 @@ use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Event_Repository_Test extends Base_Test {
-	private DateTimeImmutable $now;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Attendee_Repository $attendee_repository;
@@ -23,7 +20,6 @@ class Event_Repository_Test extends Base_Test {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now                 = Translation_Events::now();
 		$this->event_factory       = new Event_Factory();
 		$this->stats_factory       = new Stats_Factory();
 		$this->attendee_repository = new Attendee_Repository();

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -332,7 +332,7 @@ class Event_Repository_Test extends Base_Test {
 		$user_id   = get_current_user_id();
 		$event1_id = $this->event_factory->create_inactive_past( $this->now );
 		$event2_id = $this->event_factory->create_active( $this->now );
-		$event3_id = $this->event_factory->create_active( $this->now->modify( '+5 seconds' ) );
+		$event3_id = $this->event_factory->create_active( $this->now->modify( '+1 minute' ) );
 		$event4_id = $this->event_factory->create_inactive_future( $this->now );
 
 		$this->set_admin_user_as_current();

--- a/tests/event/event-repository.php
+++ b/tests/event/event-repository.php
@@ -157,7 +157,7 @@ class Event_Repository_Test extends Base_Test {
 	}
 
 	public function test_get_active_events() {
-		$event1_id = $this->event_factory->create_active( $this->now );
+		$event1_id = $this->event_factory->create_active( $this->now->modify( '-1 minute' ) );
 		$event2_id = $this->event_factory->create_active( $this->now );
 		$this->event_factory->create_active( $this->now->modify( '+2 hours' ) );
 		$this->event_factory->create_inactive_future( $this->now );

--- a/tests/event/event.php
+++ b/tests/event/event.php
@@ -3,7 +3,7 @@
 namespace Wporg\Tests\Event;
 
 use DateTimeZone;
-use WP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\InvalidStart;
 use Wporg\TranslationEvents\Event\InvalidEnd;
@@ -11,7 +11,7 @@ use Wporg\TranslationEvents\Event\InvalidStatus;
 use Wporg\TranslationEvents\Event\Event_End_Date;
 use Wporg\TranslationEvents\Event\Event_Start_Date;
 
-class Event_Test extends WP_UnitTestCase {
+class Event_Test extends Base_Test {
 	public function test_validates_start_and_end() {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 

--- a/tests/lib/event-factory.php
+++ b/tests/lib/event-factory.php
@@ -43,8 +43,8 @@ class Event_Factory extends WP_UnitTest_Factory_For_Post {
 		$timezone = new DateTimeZone( 'Europe/Lisbon' );
 
 		return $this->create_event(
-			$now->modify( '-1 second' ),
-			$now->modify( '+1 hours' ),
+			$now,
+			$now->modify( '+1 hour' ),
 			$timezone,
 			$attendee_ids,
 		);

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -8,6 +8,7 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Stats_Calculator_Test extends GP_UnitTestCase {
 	private Event_Factory $event_factory;
@@ -22,7 +23,7 @@ class Stats_Calculator_Test extends GP_UnitTestCase {
 		$this->calculator    = new Stats_Calculator();
 
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$this->now = Translation_Events::now();
 	}
 
 	public function test_tells_that_event_has_no_stats() {

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -2,18 +2,15 @@
 
 namespace Wporg\Tests\Stats;
 
-use DateTimeImmutable;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Stats_Calculator_Test extends Base_Test {
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Stats_Calculator $calculator;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -22,7 +19,6 @@ class Stats_Calculator_Test extends Base_Test {
 		$this->calculator    = new Stats_Calculator();
 
 		$this->set_normal_user_as_current();
-		$this->now = Translation_Events::now();
 	}
 
 	public function test_tells_that_event_has_no_stats() {

--- a/tests/stats/stats-calculator.php
+++ b/tests/stats/stats-calculator.php
@@ -3,14 +3,13 @@
 namespace Wporg\Tests\Stats;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Stats\Stats_Calculator;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Stats_Calculator_Test extends GP_UnitTestCase {
+class Stats_Calculator_Test extends Base_Test {
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
 	private Stats_Calculator $calculator;

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -2,19 +2,16 @@
 
 namespace Wporg\Tests\Stats;
 
-use DateTimeImmutable;
 use GP_Translation;
 use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 
 class Stats_Listener_Test extends Base_Test {
 	private Translation_Factory $translation_factory;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -23,7 +20,6 @@ class Stats_Listener_Test extends Base_Test {
 		$this->stats_factory       = new Stats_Factory();
 
 		$this->set_normal_user_as_current();
-		$this->now = Translation_Events::now();
 	}
 
 	public function test_does_not_store_action_for_draft_events() {

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -9,6 +9,7 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 
 class Stats_Listener_Test extends GP_UnitTestCase {
 	private Translation_Factory $translation_factory;
@@ -23,7 +24,7 @@ class Stats_Listener_Test extends GP_UnitTestCase {
 		$this->stats_factory       = new Stats_Factory();
 
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$this->now = Translation_Events::now();
 	}
 
 	public function test_does_not_store_action_for_draft_events() {

--- a/tests/stats/stats-listener.php
+++ b/tests/stats/stats-listener.php
@@ -3,15 +3,14 @@
 namespace Wporg\Tests\Stats;
 
 use DateTimeImmutable;
-use DateTimeZone;
 use GP_Translation;
-use GP_UnitTestCase;
+use Wporg\Tests\Base_Test;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Tests\Stats_Factory;
 use Wporg\TranslationEvents\Tests\Translation_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 
-class Stats_Listener_Test extends GP_UnitTestCase {
+class Stats_Listener_Test extends Base_Test {
 	private Translation_Factory $translation_factory;
 	private Event_Factory $event_factory;
 	private Stats_Factory $stats_factory;

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -8,6 +8,7 @@ use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
+use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
 class Urls_Test extends GP_UnitTestCase {
@@ -17,11 +18,11 @@ class Urls_Test extends GP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->now              = Translation_Events::now();
 		$this->event_factory    = new Event_Factory();
-		$this->event_repository = new Event_Repository( new Attendee_Repository() );
+		$this->event_repository = new Event_Repository( $this->now, new Attendee_Repository() );
 
 		$this->set_normal_user_as_current();
-		$this->now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 	}
 
 	public function test_events_home() {

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -3,15 +3,13 @@
 namespace Wporg\Tests;
 
 use DateTimeImmutable;
-use DateTimeZone;
-use GP_UnitTestCase;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
 use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
-class Urls_Test extends GP_UnitTestCase {
+class Urls_Test extends Base_Test {
 	private Event_Factory $event_factory;
 	private Event_Repository $event_repository;
 	private DateTimeImmutable $now;

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -2,21 +2,17 @@
 
 namespace Wporg\Tests;
 
-use DateTimeImmutable;
 use Wporg\TranslationEvents\Attendee\Attendee_Repository;
 use Wporg\TranslationEvents\Event\Event_Repository;
 use Wporg\TranslationEvents\Tests\Event_Factory;
-use Wporg\TranslationEvents\Translation_Events;
 use Wporg\TranslationEvents\Urls;
 
 class Urls_Test extends Base_Test {
 	private Event_Factory $event_factory;
 	private Event_Repository $event_repository;
-	private DateTimeImmutable $now;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->now              = Translation_Events::now();
 		$this->event_factory    = new Event_Factory();
 		$this->event_repository = new Event_Repository( $this->now, new Attendee_Repository() );
 

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -102,6 +102,7 @@ class Translation_Events {
 		}
 
 		$this->event_capabilities = new Event_Capabilities(
+			self::now(),
 			self::get_event_repository(),
 			self::get_attendee_repository(),
 			new Stats_Calculator()

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -18,6 +18,8 @@
 
 namespace Wporg\TranslationEvents;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Exception;
 use GP;
 use GP_Locales;
@@ -45,6 +47,14 @@ class Translation_Events {
 			$instance = new self();
 		}
 		return $instance;
+	}
+
+	public static function now(): DateTimeImmutable {
+		static $now = null;
+		if ( null === $now ) {
+			$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		}
+		return $now;
 	}
 
 	public static function get_event_repository(): Event_Repository_Interface {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -415,7 +415,7 @@ class Translation_Events {
 	 * Send notifications for the events.
 	 */
 	public function send_notifications() {
-		new Notifications_Send( self::get_event_repository(), self::get_attendee_repository() );
+		new Notifications_Send( self::now(), self::get_event_repository(), self::get_attendee_repository() );
 	}
 
 	/**

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -60,7 +60,7 @@ class Translation_Events {
 	public static function get_event_repository(): Event_Repository_Interface {
 		static $event_repository = null;
 		if ( null === $event_repository ) {
-			$event_repository = new Event_Repository_Cached( self::get_attendee_repository() );
+			$event_repository = new Event_Repository_Cached( self::now(), self::get_attendee_repository() );
 		}
 		return $event_repository;
 	}


### PR DESCRIPTION
Fixes #308 

This PR (hopefully) fixes the issues with flaky tests, which we assume have to do with the value of _now_ not staying the same throughout the request. To fix the issue, the value of _now_ must be the same through the codebase, so we introduce a `Translation_Events::now()` function from which the value of _now_ must come from.

This means that we should never directly create an instance of `DateTimeImmutable` that represents _now_, we should always use `Translation_Events::now()` by injecting it into whoever needs it, or by calling it directly if injection is not an option.

This PR also adds a `Base_Test` that all tests should extend. The base test defines _now_, so all tests have `$this->now` available.

There were also issues with ordering not being guaranteed in tests, because of events that are created with the exact same start and end, which would result in randomness in the ordering, for example:

```php
$event1_id = $this->event_factory->create_active( $this->now );
$event2_id = $this->event_factory->create_active( $this->now );

$events = $this->repository->get_events_created_by_user( $user_id )->events;
```

In the code above, it will be random which event ends up as `$events[0]`. So instead we need to do:

```php
$event1_id = $this->event_factory->create_active( $this->now );
$event2_id = $this->event_factory->create_active( $this->now->modify( '+1 minute' ) );

$events = $this->repository->get_events_created_by_user( $user_id )->events;
```

which will result in `event_2` always being at `$events[0]`, because `get_events_created_by_user()` orders by `event_start` descending.