### PR TITLE
Also show absolute time in the events list

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -234,11 +234,37 @@
 						return;
 					}
 					const eventDateObj = new Date( datetime );
+					timeEl = timeEl.closest( 'span' );
 					timeEl.title       = eventDateObj.toUTCString();
 
 					const userTimezoneOffset   = new Date().getTimezoneOffset();
 					const userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
 					const userLocalDateTime    = new Date( eventDateObj.getTime() - userTimezoneOffsetMs );
+
+					const options = {
+						weekday: 'short',
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+						hour: 'numeric',
+						minute: 'numeric',
+						timeZoneName: 'short'
+					};
+					if ( timeEl.classList.contains( 'absolute' ) ) {
+						if ( timeEl.dataset.format ) {
+							if ( timeEl.dataset.format.includes( 'l' ) ) {
+								options.weekday = 'long';
+							} else if ( ! timeEl.dataset.format.includes( 'D' ) ) {
+								delete options.weekday;
+							}
+							if ( timeEl.dataset.format.includes( 'F' ) ) {
+								options.month = 'long';
+							} else if ( timeEl.dataset.format.includes( 'm' ) || timeEl.dataset.format.includes( 'n' ) ) {
+								options.month = 'numeric';
+							}
+						}
+						timeEl.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
+					}
 
 					if ( timeEl.classList.contains( 'relative' ) ) {
 						// Display the relative time.
@@ -265,21 +291,17 @@
 						const years      = Math.floor( days / 365.25 );
 						let relativeTime = '';
 						if ( years > 1 ) {
-							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) ) {
-								relativeTime = years + ' year' + ( years > 1 ? 's' : '' );
-							} else {
-								in_text = '';
-							}
+							relativeTime = years + ' year' + ( years > 1 ? 's' : '' );
 						} else if ( months > 1 ) {
-							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) ) {
-								relativeTime = months + ' month' + ( months > 1 ? 's' : '' );
+							relativeTime = months + ' month' + ( months > 1 ? 's' : '' );
+						} else if ( weeks > 2 ) {
+							relativeTime = weeks + ' week' + ( weeks > 1 ? 's' : '' );
+						} else if ( weeks === 1 ) {
+							if ( diff < 0 ) {
+								relativeTime = 'last week';
+								ago_text = '';
 							} else {
-								in_text = '';
-							}
-						} else if ( weeks > 1 ) {
-							if ( ! timeEl.classList.contains( 'hide-if-too-far' ) || weeks < 3 ) {
-								relativeTime = weeks + ' week' + ( weeks > 1 ? 's' : '' );
-							} else {
+								relativeTime = 'next week';
 								in_text = '';
 							}
 						} else if ( days > 0 ) {
@@ -291,32 +313,13 @@
 						} else {
 							relativeTime = 'less than a minute';
 						}
-						timeEl.textContent = in_text + relativeTime + ago_text;
-						return;
+						if ( timeEl.classList.contains( 'absolute' ) ) {
+							timeEl.textContent += ' (' + in_text + relativeTime + ago_text + ')';
+						} else {
+							timeEl.textContent = in_text + relativeTime + ago_text;
+						}
 					}
 
-					const options = {
-						weekday: 'short',
-						year: 'numeric',
-						month: 'short',
-						day: 'numeric',
-						hour: 'numeric',
-						minute: 'numeric',
-						timeZoneName: 'short'
-					};
-					if ( timeEl.dataset.format ) {
-						if ( timeEl.dataset.format.includes( 'l' ) ) {
-							options.weekday = 'long';
-						} else if ( ! timeEl.dataset.format.includes( 'D' ) ) {
-							delete options.weekday;
-						}
-						if ( timeEl.dataset.format.includes( 'F' ) ) {
-							options.month = 'long';
-						} else if ( timeEl.dataset.format.includes( 'm' ) || timeEl.dataset.format.includes( 'n' ) ) {
-							options.month = 'numeric';
-						}
-					}
-					timeEl.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
 				}
 			);
 		}

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -285,7 +285,7 @@
 						const seconds    = Math.floor( diff / 1000 );
 						const minutes    = Math.floor( seconds / 60 );
 						const hours      = Math.floor( minutes / 60 );
-						let days       = Math.floor( hours / 24 );
+						let days         = Math.floor( hours / 24 );
 						const weeks      = Math.floor( days / 7 );
 						const months     = Math.floor( days / 30 );
 						const years      = Math.floor( days / 365.25 );

--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -234,8 +234,8 @@
 						return;
 					}
 					const eventDateObj = new Date( datetime );
-					timeEl = timeEl.closest( 'span' );
 					timeEl.title       = eventDateObj.toUTCString();
+					const timeContent  = timeEl.querySelector( 'span' ) ? timeEl.querySelector( 'span' ) : timeEl;
 
 					const userTimezoneOffset   = new Date().getTimezoneOffset();
 					const userTimezoneOffsetMs = userTimezoneOffset * 60 * 1000;
@@ -263,7 +263,7 @@
 								options.month = 'numeric';
 							}
 						}
-						timeEl.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
+						timeContent.textContent = userLocalDateTime.toLocaleTimeString( navigator.language, options );
 					}
 
 					if ( timeEl.classList.contains( 'relative' ) ) {
@@ -285,7 +285,7 @@
 						const seconds    = Math.floor( diff / 1000 );
 						const minutes    = Math.floor( seconds / 60 );
 						const hours      = Math.floor( minutes / 60 );
-						const days       = Math.floor( hours / 24 );
+						let days       = Math.floor( hours / 24 );
 						const weeks      = Math.floor( days / 7 );
 						const months     = Math.floor( days / 30 );
 						const years      = Math.floor( days / 365.25 );
@@ -299,12 +299,15 @@
 						} else if ( weeks === 1 ) {
 							if ( diff < 0 ) {
 								relativeTime = 'last week';
-								ago_text = '';
+								ago_text     = '';
 							} else {
 								relativeTime = 'next week';
-								in_text = '';
+								in_text      = '';
 							}
 						} else if ( days > 0 ) {
+							if ( hours > 12 ) {
+								days += 1;
+							}
 							relativeTime = days + ' day' + ( days > 1 ? 's' : '' );
 						} else if ( hours > 0 ) {
 							relativeTime = hours + ' hour' + ( hours > 1 ? 's' : '' );
@@ -314,14 +317,15 @@
 							relativeTime = 'less than a minute';
 						}
 						if ( timeEl.classList.contains( 'absolute' ) ) {
-							timeEl.textContent += ' (' + in_text + relativeTime + ago_text + ')';
+							timeContent.textContent += ' (' + in_text + relativeTime + ago_text + ')';
 						} else {
-							timeEl.textContent = in_text + relativeTime + ago_text;
+							timeContent.textContent = in_text + relativeTime + ago_text;
 						}
 					}
 
 				}
 			);
 		}
-	}( jQuery, $gp )
+	}( jQuery,
+	$gp )
 );

--- a/templates/parts/event-list.php
+++ b/templates/parts/event-list.php
@@ -25,7 +25,7 @@ $current_user_attendee_per_event = $current_user_attendee_per_event ?? array();
 /**
  * @param Event_Start_Date|Event_End_Date $time
  */
-$print_time = function ( $time ) : void {
+$print_time = function ( $time ): void {
 	$time->print_absolute_and_relative_time_html();
 };
 ?>

--- a/templates/parts/event-list.php
+++ b/templates/parts/event-list.php
@@ -12,16 +12,12 @@ use Wporg\TranslationEvents\Urls;
 /** @var ?bool $show_start */
 /** @var ?bool $show_end */
 /** @var ?bool $show_excerpt */
-/** @var ?string $date_format */
-/** @var ?bool $relative_time */
 /** @var ?string[] $extra_classes */
 /** @var ?Attendee[] $current_user_attendee_per_event Associative array with event id as key, and Attendee as value. */
 
 $show_start                      = $show_start ?? false;
 $show_end                        = $show_end ?? false;
 $show_excerpt                    = $show_excerpt ?? true;
-$date_format                     = $date_format ?? '';
-$relative_time                   = $relative_time ?? true;
 $show_permanent_delete           = $show_permanent_delete ?? false;
 $extra_classes                   = isset( $extra_classes ) ? implode( $extra_classes, ' ' ) : '';
 $current_user_attendee_per_event = $current_user_attendee_per_event ?? array();
@@ -29,12 +25,8 @@ $current_user_attendee_per_event = $current_user_attendee_per_event ?? array();
 /**
  * @param Event_Start_Date|Event_End_Date $time
  */
-$print_time = function ( $time ) use ( $date_format, $relative_time ): void {
-	if ( $relative_time ) {
-		$time->print_relative_time_html( $date_format );
-	} else {
-		$time->print_time_html( $date_format );
-	}
+$print_time = function ( $time ) : void {
+	$time->print_absolute_and_relative_time_html();
 };
 ?>
 
@@ -105,16 +97,16 @@ $print_time = function ( $time ) use ( $date_format, $relative_time ): void {
 			<?php // Dates. ?>
 			<?php if ( $show_start ) : ?>
 				<?php if ( $event->start()->is_in_the_past() ) : ?>
-					<span class="event-list-date">started <?php $print_time( $event->start() ); ?></span>
+					<span class="event-list-date"><?php $print_time( $event->start() ); ?></span>
 				<?php else : ?>
-					<span class="event-list-date">starts <?php $print_time( $event->start() ); ?></span>
+					<span class="event-list-date"><?php $print_time( $event->start() ); ?></span>
 				<?php endif; ?>
 			<?php endif; ?>
 			<?php if ( $show_end ) : ?>
 				<?php if ( $event->end()->is_in_the_past() ) : ?>
-					<span class="event-list-date">ended <?php $print_time( $event->end() ); ?></span>
+					<span class="event-list-date"><?php $print_time( $event->end() ); ?></span>
 				<?php else : ?>
-					<span class="event-list-date">ends <?php $print_time( $event->end() ); ?></time></span>
+					<span class="event-list-date"><?php $print_time( $event->end() ); ?></time></span>
 				<?php endif; ?>
 			<?php endif; ?>
 


### PR DESCRIPTION
Fixes #288.

This now also shows the absolute date in list view and moves the relative day into parenthesis.

### Old
![rtcamp](https://github.com/WordPress/wporg-gp-translation-events/assets/92981225/dfa92600-3147-4bfb-b780-41a8139f2920)

### New
![Screenshot 2024-06-05 at 16 04 17](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/27a0c3c1-9965-4097-a1f5-cf81e1f1b4a9)
