### PR TITLE
Don't show active events in translation table if user is not logged in

### DIFF
--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -480,6 +480,11 @@ class Event_Repository implements Event_Repository_Interface {
 	): Events_Query_Result {
 		$this->assert_pagination_arguments( $page, $page_size );
 
+		// A user who is not logged-in, does not have any events.
+		if ( 0 === $user_id ) {
+			return new Events_Query_Result( array(), $page, 0 );
+		}
+
 		$args = array_replace_recursive(
 			$args,
 			array(

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -367,6 +367,10 @@ class Translation_Events {
 	 * @throws Exception
 	 */
 	public function add_active_events_current_user(): void {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
 		$event_repository            = self::get_event_repository();
 		$user_attending_events_query = $event_repository->get_current_events_for_user( get_current_user_id() );
 		$events                      = $user_attending_events_query->events;


### PR DESCRIPTION
The list of active events was shown above the translation table when user is not logged in:

![image](https://github.com/WordPress/wporg-gp-translation-events/assets/550401/d8326ab1-ef0a-4c72-baf9-920f49088fee)

This PR fixes that.
