### PR TITLE
Increase width for Contributors

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -88,7 +88,7 @@
 	list-style-type: none;
 	margin-right: 1em;
 	margin-bottom: .5em;
-	width: 15em;
+	width: 20em;
 }
 
 .event-contributors li .avatar,


### PR DESCRIPTION
I'd like to propose to increase the width for Contributors. [Before](https://translate.wordpress.org/events/2024/wordcamp-europe/):
![Screenshot 2024-06-12 at 10 33 18](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/4c69693c-8330-4bd1-b63b-52560a9d15b2)

After:
![Screenshot 2024-06-12 at 10 33 11](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/996e2eb9-3686-42a3-9f60-8f4c4f62a426)
