### PR TITLE
Fix issue in event form handler due to missing argument

### DIFF
--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -3,6 +3,7 @@
 namespace Wporg\TranslationEvents\Event;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use WP_Error;
@@ -14,9 +15,9 @@ class Event_Form_Handler {
 	private Event_Repository_Interface $event_repository;
 	private Notifications_Schedule $notifications_schedule;
 
-	public function __construct( Event_Repository_Interface $event_repository ) {
+	public function __construct( DateTimeImmutable $now, Event_Repository_Interface $event_repository ) {
 		$this->event_repository       = $event_repository;
-		$this->notifications_schedule = new Notifications_Schedule( $this->event_repository );
+		$this->notifications_schedule = new Notifications_Schedule( $now, $this->event_repository );
 	}
 
 	public function handle( array $form_data ): void {

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -259,7 +259,7 @@ class Translation_Events {
 	 * Handle the event form submission for the creation, editing, and deletion of events. This function is called via AJAX.
 	 */
 	public function submit_event_ajax() {
-		$form_handler = new Event_Form_Handler( self::get_event_repository(), self::get_attendee_repository() );
+		$form_handler = new Event_Form_Handler( self::now(), self::get_event_repository() );
 		// Nonce verification is done by the form handler.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$form_handler->handle( $_POST );


### PR DESCRIPTION
Since https://github.com/WordPress/wporg-gp-translation-events/pull/319, `Notifications_Schedule` constructor requires a `DateTimeImmutable` as first argument.

Thanks @trymebytes for finding this issue. I guess this means the form is currently broken.