### PR TITLE
Add new contributor emoji to manage attendee list

### DIFF
--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -42,7 +42,7 @@ Templates::header(
 						<a class="attendee-avatar" href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="avatar"><?php echo get_avatar( $attendee->user_id(), 48 ); ?></a>
 						<a href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $attendee->user_id() ) ); ?></a>
 						<?php if ( $attendee->is_new_contributor() ) : ?>
-							<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
+							<span class="first-time-contributor-tada" title="<?php esc_attr_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 						<?php endif; ?>
 					</td>
 					<td>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -41,6 +41,9 @@ Templates::header(
 					<td>
 						<a class="attendee-avatar" href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="avatar"><?php echo get_avatar( $attendee->user_id(), 48 ); ?></a>
 						<a href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $attendee->user_id() ) ); ?></a>
+						<?php if ( $attendee->is_new_contributor() ) : ?>
+								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
+							<?php endif; ?>
 					</td>
 					<td>
 						<?php if ( $attendee->is_host() ) : ?>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -42,8 +42,8 @@ Templates::header(
 						<a class="attendee-avatar" href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="avatar"><?php echo get_avatar( $attendee->user_id(), 48 ); ?></a>
 						<a href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $attendee->user_id() ) ); ?></a>
 						<?php if ( $attendee->is_new_contributor() ) : ?>
-								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
-							<?php endif; ?>
+							<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
+						<?php endif; ?>
 					</td>
 					<td>
 						<?php if ( $attendee->is_host() ) : ?>

--- a/templates/event-details.php
+++ b/templates/event-details.php
@@ -101,7 +101,7 @@ Templates::header(
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->user_id() ) ); ?>" class="avatar"><?php echo get_avatar( $contributor->user_id(), 48 ); ?></a>
 							<a href="<?php echo esc_url( get_author_posts_url( $contributor->user_id() ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $contributor->user_id() ) ); ?></a>
 							<?php if ( $contributor->is_new_contributor() ) : ?>
-								<span class="first-time-contributor-tada" title="<?php esc_html_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
+								<span class="first-time-contributor-tada" title="<?php esc_attr_e( 'New Translation Contributor', 'gp-translation-events' ); ?>"></span>
 							<?php endif; ?>
 						</li>
 					<?php endforeach; ?>


### PR DESCRIPTION
In this PR, we add the new contributor emoji (🎉) to the names of the new contributors on the list of attendees on the manage attendees page.

How it is displayed on the event details page for context.
<img width="771" alt="Screenshot 2024-06-25 at 14 36 27" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/8a16d47d-ac31-4d11-a1b2-8d6a8b577a79">


**Before**
<img width="1289" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/226b05ba-5999-42d7-8f20-7b4fbd567eef">


**After** 

<img width="1256" alt="image" src="https://github.com/WordPress/wporg-gp-translation-events/assets/2834132/2c67e9d4-4013-4749-b43f-906bd9c4a2a1">
