### PR TITLE
Track Onsite and Offsite attendees

### DIFF
--- a/assets/css/translation-events.css
+++ b/assets/css/translation-events.css
@@ -471,6 +471,9 @@ a.remove-attendee.button:hover {
 	color: var(--gp-color-btn-danger-hover-text);
 	border-color: var(----gp-color-btn-danger-hover-border);
 }
+form.add-remove-user-as-host .button {
+	margin-bottom: 4px;
+}
 
 /* show the event-details-right below instead of on the right on mobile */
 @media (max-width: 768px) {

--- a/autoload.php
+++ b/autoload.php
@@ -35,3 +35,4 @@ require_once __DIR__ . '/includes/project/project-repository.php';
 require_once __DIR__ . '/includes/event-text-snippet.php';
 require_once __DIR__ . '/includes/routes/attendee/list.php';
 require_once __DIR__ . '/includes/routes/attendee/remove.php';
+require_once __DIR__ . '/includes/routes/user/attendance-mode.php';

--- a/includes/attendee/attendee-adder.php
+++ b/includes/attendee/attendee-adder.php
@@ -93,6 +93,4 @@ class Attendee_Adder {
 
 		return intval( $translation_count ) <= 10;
 	}
-
-
 }

--- a/includes/attendee/attendee-adder.php
+++ b/includes/attendee/attendee-adder.php
@@ -21,13 +21,9 @@ class Attendee_Adder {
 	 *
 	 * @throws Exception
 	 */
-	public function add_to_event( Event $event, Attendee $attendee, $is_remote_attendee = false ): void {
+	public function add_to_event( Event $event, Attendee $attendee ): void {
 		if ( $this->check_is_new_contributor( $event, $attendee->user_id() ) ) {
 			$attendee->mark_as_new_contributor();
-		}
-
-		if ( $is_remote_attendee ) {
-			$attendee->mark_as_remote_attendee();
 		}
 
 		$this->attendee_repository->insert_attendee( $attendee );

--- a/includes/attendee/attendee-adder.php
+++ b/includes/attendee/attendee-adder.php
@@ -21,9 +21,13 @@ class Attendee_Adder {
 	 *
 	 * @throws Exception
 	 */
-	public function add_to_event( Event $event, Attendee $attendee ): void {
+	public function add_to_event( Event $event, Attendee $attendee, $is_remote_attendee = false ): void {
 		if ( $this->check_is_new_contributor( $event, $attendee->user_id() ) ) {
 			$attendee->mark_as_new_contributor();
+		}
+
+		if ( $is_remote_attendee ) {
+			$attendee->mark_as_remote_attendee();
 		}
 
 		$this->attendee_repository->insert_attendee( $attendee );
@@ -89,4 +93,6 @@ class Attendee_Adder {
 
 		return intval( $translation_count ) <= 10;
 	}
+
+
 }

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -43,7 +43,10 @@ class Attendee_Repository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->update(
 			"{$gp_table_prefix}event_attendees",
-			array( 'is_host' => $attendee->is_host() ? 1 : 0 ),
+			array(
+				'is_host'   => $attendee->is_host() ? 1 : 0,
+				'is_remote' => $attendee->is_remote() ? 1 : 0,
+			),
 			array(
 				'event_id' => $attendee->event_id(),
 				'user_id'  => $attendee->user_id(),
@@ -159,7 +162,7 @@ class Attendee_Repository {
 					$row->user_id,
 					'1' === $row->is_host,
 					'1' === $row->is_new_contributor,
-					'1' === $row->remote,
+					'1' === $row->is_remote,
 					null === $row->locales ? array() : explode( ',', $row->locales ),
 				);
 			},

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -15,12 +15,13 @@ class Attendee_Repository {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->query(
 			$wpdb->prepare(
-				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id, is_host, is_new_contributor) values (%d, %d, %d, %d)",
+				"insert ignore into {$gp_table_prefix}event_attendees (event_id, user_id, is_host, is_new_contributor, is_remote) values (%d, %d, %d, %d, %d)",
 				array(
 					'event_id'           => $attendee->event_id(),
 					'user_id'            => $attendee->user_id(),
 					'is_host'            => $attendee->is_host() ? 1 : 0,
 					'is_new_contributor' => $attendee->is_new_contributor() ? 1 : 0,
+					'is_remote'          => $attendee->is_remote() ? 1 : 0,
 				),
 			),
 		);
@@ -131,6 +132,7 @@ class Attendee_Repository {
 						user_id,
 						is_host,
 						is_new_contributor,
+						is_remote,
 						(
 							select group_concat( distinct locale )
 							from {$gp_table_prefix}event_actions
@@ -157,6 +159,7 @@ class Attendee_Repository {
 					$row->user_id,
 					'1' === $row->is_host,
 					'1' === $row->is_new_contributor,
+					'1' === $row->remote,
 					null === $row->locales ? array() : explode( ',', $row->locales ),
 				);
 			},
@@ -183,6 +186,7 @@ class Attendee_Repository {
 					user_id,
 					is_host,
 					is_new_contributor,
+					is_remote,
 					(
 						select group_concat( distinct locale )
 						from {$gp_table_prefix}event_actions

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -207,6 +207,7 @@ class Attendee_Repository {
 					$row->user_id,
 					'1' === $row->is_host,
 					'1' === $row->is_new_contributor,
+					'1' === $row->is_remote,
 					null === $row->locales ? array() : explode( ',', $row->locales ),
 				);
 			},

--- a/includes/attendee/attendee-repository.php
+++ b/includes/attendee/attendee-repository.php
@@ -162,8 +162,8 @@ class Attendee_Repository {
 					$row->user_id,
 					'1' === $row->is_host,
 					'1' === $row->is_new_contributor,
-					'1' === $row->is_remote,
 					null === $row->locales ? array() : explode( ',', $row->locales ),
+					'1' === $row->is_remote,
 				);
 			},
 			$rows,
@@ -214,8 +214,8 @@ class Attendee_Repository {
 					$row->user_id,
 					'1' === $row->is_host,
 					'1' === $row->is_new_contributor,
-					'1' === $row->is_remote,
 					null === $row->locales ? array() : explode( ',', $row->locales ),
+					'1' === $row->is_remote,
 				);
 			},
 			$rows,

--- a/includes/attendee/attendee.php
+++ b/includes/attendee/attendee.php
@@ -19,7 +19,7 @@ class Attendee {
 	/**
 	 * @throws Exception
 	 */
-	public function __construct( int $event_id, int $user_id, bool $is_host = false, $is_new_contributor = false, $is_remote = false, array $contributed_locales = array() ) {
+	public function __construct( int $event_id, int $user_id, bool $is_host = false, $is_new_contributor = false, array $contributed_locales = array(), $is_remote = false ) {
 		if ( $event_id < 1 ) {
 			throw new Exception( 'invalid event id' );
 		}

--- a/includes/attendee/attendee.php
+++ b/includes/attendee/attendee.php
@@ -9,6 +9,7 @@ class Attendee {
 	private int $user_id;
 	private bool $is_host;
 	private bool $is_new_contributor;
+	private bool $is_remote;
 
 	/**
 	 * @var string[]
@@ -18,7 +19,7 @@ class Attendee {
 	/**
 	 * @throws Exception
 	 */
-	public function __construct( int $event_id, int $user_id, bool $is_host = false, $is_new_contributor = false, array $contributed_locales = array() ) {
+	public function __construct( int $event_id, int $user_id, bool $is_host = false, $is_new_contributor = false, $is_remote = false, array $contributed_locales = array() ) {
 		if ( $event_id < 1 ) {
 			throw new Exception( 'invalid event id' );
 		}
@@ -30,6 +31,7 @@ class Attendee {
 		$this->user_id             = $user_id;
 		$this->is_host             = $is_host;
 		$this->is_new_contributor  = $is_new_contributor;
+		$this->is_remote           = $is_remote;
 		$this->contributed_locales = $contributed_locales;
 	}
 
@@ -53,6 +55,10 @@ class Attendee {
 		return ! empty( $this->contributed_locales );
 	}
 
+	public function is_remote(): bool {
+		return $this->is_remote;
+	}
+
 	public function mark_as_host(): void {
 		$this->is_host = true;
 	}
@@ -63,6 +69,14 @@ class Attendee {
 
 	public function mark_as_new_contributor(): void {
 		$this->is_new_contributor = true;
+	}
+
+	public function mark_as_remote_attendee(): void {
+		$this->is_remote = true;
+	}
+
+	public function mark_as_in_person_attendee(): void {
+		$this->is_remote = false;
 	}
 
 	/**

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -46,7 +46,9 @@ class Attend_Event_Route extends Route {
 			$this->die_with_error( esc_html__( 'Cannot attend or un-attend a past event', 'gp-translation-events' ), 403 );
 		}
 
-		$attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
+		$attendee           = $this->attendee_repository->get_attendee_for_event_for_user( $event->id(), $user_id );
+		$is_remote_attendee = isset( $_POST['attend_remotely'] );
+
 		if ( $attendee instanceof Attendee ) {
 			if ( $attendee->is_contributor() ) {
 				$this->die_with_error( esc_html__( 'Contributors cannot un-attend the event', 'gp-translation-events' ), 403 );
@@ -54,7 +56,7 @@ class Attend_Event_Route extends Route {
 			$this->attendee_repository->remove_attendee( $event->id(), $user_id );
 		} else {
 			$attendee = new Attendee( $event->id(), $user_id );
-			$this->attendee_adder->add_to_event( $event, $attendee );
+			$this->attendee_adder->add_to_event( $event, $attendee, $is_remote_attendee );
 		}
 
 		wp_safe_redirect( Urls::event_details( $event->id() ) );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -31,6 +31,13 @@ class Attend_Event_Route extends Route {
 	}
 
 	public function handle( int $event_id ): void {
+		$nonce_name = '_attendee_nonce';
+		if ( isset( $_POST['_attendee_nonce'] ) ) {
+			$nonce_value = sanitize_text_field( wp_unslash( $_POST['_attendee_nonce'] ) );
+			if ( ! wp_verify_nonce( $nonce_value, $nonce_name ) ) {
+				$this->die_with_error( esc_html__( 'You are not authorized to change the attendance mode of this attendee', 'gp-translation-events' ), 403 );
+			}
+		}
 		$user = wp_get_current_user();
 		if ( ! $user ) {
 			$this->die_with_error( esc_html__( 'Only logged-in users can attend events', 'gp-translation-events' ), 403 );

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -62,8 +62,8 @@ class Attend_Event_Route extends Route {
 			}
 			$this->attendee_repository->remove_attendee( $event->id(), $user_id );
 		} else {
-			$attendee = new Attendee( $event->id(), $user_id );
-			$this->attendee_adder->add_to_event( $event, $attendee, $is_remote_attendee );
+			$attendee = new Attendee( $event->id(), $user_id, false, false, array(), $is_remote_attendee );
+			$this->attendee_adder->add_to_event( $event, $attendee );
 		}
 
 		wp_safe_redirect( Urls::event_details( $event->id() ) );

--- a/includes/routes/user/attendance-mode.php
+++ b/includes/routes/user/attendance-mode.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Wporg\TranslationEvents\Routes\User;
+
+use Wporg\TranslationEvents\Attendee\Attendee;
+use Wporg\TranslationEvents\Attendee\Attendee_Repository;
+use Wporg\TranslationEvents\Event\Event_Repository_Interface;
+use Wporg\TranslationEvents\Routes\Route;
+use Wporg\TranslationEvents\Translation_Events;
+use Wporg\TranslationEvents\Urls;
+
+/**
+ * Toggle whether the current user is attending an event onsite or remotely.
+ * If the user is not currently marked as remote attendee, they will be marked as remote attendee.
+ * If the user is currently marked as as remote attendee, they will be marked as not remote attendee.
+ */
+class Attendance_Mode_Route extends Route {
+	private Event_Repository_Interface $event_repository;
+	private Attendee_Repository $attendee_repository;
+
+	/**
+	 * Attendance_Mode_Route constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->event_repository    = Translation_Events::get_event_repository();
+		$this->attendee_repository = Translation_Events::get_attendee_repository();
+	}
+
+	/**
+	 * Handle the request to toggle whether the current user is attending an event onsite or remotely.
+	 *
+	 * @param int $event_id The event ID.
+	 * @param int $user_id  The user ID.
+	 * @return void
+	 */
+	public function handle( int $event_id, int $user_id ): void {
+
+		$current_user = wp_get_current_user();
+		if ( ! $current_user->exists() ) {
+			$this->die_with_error( esc_html__( "Only logged-in users can manage the attendance mode of an attendee", 'gp-translation-events' ), 403 );
+		}
+
+		if ( ! current_user_can( 'edit_translation_event', $event_id ) ) {
+			$this->die_with_error( esc_html__( "You do not have permissions to manage the attendance mode of an attendee", 'gp-translation-events' ), 403 );
+		}
+		$event = $this->event_repository->get_event( $event_id );
+		if ( ! $event ) {
+			$this->die_with_404();
+		}
+
+		$affected_attendee = $this->attendee_repository->get_attendee_for_event_for_user( $event_id, $user_id );
+		if ( $affected_attendee instanceof Attendee ) {
+			if ( $affected_attendee->is_remote() ) {
+				$affected_attendee->mark_as_in_person_attendee();
+			} else {
+				$affected_attendee->mark_as_remote_attendee();
+			}
+			$this->attendee_repository->update_attendee( $affected_attendee );
+		}
+		wp_safe_redirect( Urls::event_attendees( $event->id() ) );
+		exit;
+	}
+}

--- a/includes/routes/user/attendance-mode.php
+++ b/includes/routes/user/attendance-mode.php
@@ -38,11 +38,11 @@ class Attendance_Mode_Route extends Route {
 
 		$current_user = wp_get_current_user();
 		if ( ! $current_user->exists() ) {
-			$this->die_with_error( esc_html__( "Only logged-in users can manage the attendance mode of an attendee", 'gp-translation-events' ), 403 );
+			$this->die_with_error( esc_html__( 'Only logged-in users can manage the attendance mode of an attendee', 'gp-translation-events' ), 403 );
 		}
 
 		if ( ! current_user_can( 'edit_translation_event', $event_id ) ) {
-			$this->die_with_error( esc_html__( "You do not have permissions to manage the attendance mode of an attendee", 'gp-translation-events' ), 403 );
+			$this->die_with_error( esc_html__( 'You do not have permissions to manage the attendance mode of an attendee', 'gp-translation-events' ), 403 );
 		}
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -6,7 +6,7 @@ use Exception;
 use WP_Query;
 
 class Upgrade {
-	private const VERSION        = 3;
+	private const VERSION        = 4;
 	private const VERSION_OPTION = 'wporg_gp_translations_events_version';
 
 	public static function upgrade_if_needed(): void {
@@ -62,6 +62,7 @@ class Upgrade {
 				`user_id` int(10) NOT NULL COMMENT 'ID of the user who is attending the event',
 				`is_host` tinyint(1) default 0 not null comment 'Whether the user is a host of the event',
 				`is_new_contributor` tinyint(1) default 0 not null comment 'Whether the user is a new translation contributor',
+				`is_remote` tinyint(1) default 0 not null comment 'Whether the user attends the event remotely',
 			PRIMARY KEY (`translate_event_attendees_id`),
 			UNIQUE KEY `event_per_user` (`event_id`,`user_id`),
 			INDEX `user` (`user_id`)

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -88,4 +88,8 @@ class Urls {
 	public static function event_remove_attendee( int $event_id, int $user_id ): string {
 		return gp_url( "/events/$event_id/attendees/remove/$user_id" );
 	}
+
+	public static function event_toggle_attendance_mode( int $event_id, int $user_id ): string {
+		return gp_url( "/events/attendance-mode/$event_id/$user_id" );
+	}
 }

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -54,6 +54,7 @@ Templates::header(
 							<?php else : ?>
 									<input type="submit" class="button is-secondary convert-to-host" value="<?php echo esc_attr__( 'Make co-host', 'gp-translation-events' ); ?>"/>
 							<?php endif; ?>
+							<a href="" class="button remove-attendee"><?php $attendee->is_remote() ? esc_html_e( 'Set as onsite', 'gp-translation-events' ) : esc_html_e( 'Set as remote', 'gp-translation-events' ); ?></a>
 							<?php if ( ! $attendee->is_host() ) : ?>
 								<a href="<?php echo esc_url( Urls::event_remove_attendee( $event->id(), $attendee->user_id() ) ); ?>" class="button remove-attendee"><?php esc_html_e( 'Remove', 'gp-translation-events' ); ?></a>
 							<?php endif; ?>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -31,6 +31,7 @@ Templates::header(
 		<thead>
 			<tr>
 				<th scope="col"><?php esc_html_e( 'Name', 'gp-translation-events' ); ?></th>
+				<th><?php esc_html_e( 'Remote', 'gp-translation-events' ); ?></th>
 				<th><?php esc_html_e( 'Host', 'gp-translation-events' ); ?></th>
 				<th><?php esc_html_e( 'Action', 'gp-translation-events' ); ?></th>
 			</tr>
@@ -41,6 +42,11 @@ Templates::header(
 					<td>
 						<a class="attendee-avatar" href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="avatar"><?php echo get_avatar( $attendee->user_id(), 48 ); ?></a>
 						<a href="<?php echo esc_url( get_author_posts_url( $attendee->user_id() ) ); ?>" class="name"><?php echo esc_html( get_the_author_meta( 'display_name', $attendee->user_id() ) ); ?></a>
+					</td>
+					<td>
+						<?php if ( $attendee->is_remote() ) : ?>
+							<span><?php esc_html_e( 'Yes', 'gp-translation-events' ); ?></span>
+							<?php endif; ?>
 					</td>
 					<td>
 						<?php if ( $attendee->is_host() ) : ?>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -49,6 +49,7 @@ Templates::header(
 					</td>
 					<td>
 					<form class="add-remove-user-as-host" method="post" action="<?php echo esc_url( Urls::event_toggle_host( $event->id(), $attendee->user_id() ) ); ?>">
+						<?php wp_nonce_field( '_attendee_nonce', '_attendee_nonce' ); ?>
 						<?php if ( $attendee->is_host() ) : ?>
 							<input type="submit" class="button is-primary remove-as-host" value="<?php echo esc_attr__( 'Remove as host', 'gp-translation-events' ); ?>"/>
 							<?php else : ?>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -49,7 +49,6 @@ Templates::header(
 					</td>
 					<td>
 					<form class="add-remove-user-as-host" method="post" action="<?php echo esc_url( Urls::event_toggle_host( $event->id(), $attendee->user_id() ) ); ?>">
-						<?php wp_nonce_field( '_attendee_nonce', '_attendee_nonce' ); ?>
 						<?php if ( $attendee->is_host() ) : ?>
 							<input type="submit" class="button is-primary remove-as-host" value="<?php echo esc_attr__( 'Remove as host', 'gp-translation-events' ); ?>"/>
 							<?php else : ?>

--- a/templates/event-attendees.php
+++ b/templates/event-attendees.php
@@ -54,7 +54,7 @@ Templates::header(
 							<?php else : ?>
 									<input type="submit" class="button is-secondary convert-to-host" value="<?php echo esc_attr__( 'Make co-host', 'gp-translation-events' ); ?>"/>
 							<?php endif; ?>
-							<a href="" class="button remove-attendee"><?php $attendee->is_remote() ? esc_html_e( 'Set as onsite', 'gp-translation-events' ) : esc_html_e( 'Set as remote', 'gp-translation-events' ); ?></a>
+							<a href="<?php echo esc_url( Urls::event_toggle_attendance_mode( $event->id(), $attendee->user_id() ) ); ?>" class="button set-attendance-mode"><?php $attendee->is_remote() ? esc_html_e( 'Set as onsite', 'gp-translation-events' ) : esc_html_e( 'Set as remote', 'gp-translation-events' ); ?></a>
 							<?php if ( ! $attendee->is_host() ) : ?>
 								<a href="<?php echo esc_url( Urls::event_remove_attendee( $event->id(), $attendee->user_id() ) ); ?>" class="button remove-attendee"><?php esc_html_e( 'Remove', 'gp-translation-events' ); ?></a>
 							<?php endif; ?>

--- a/templates/event-details.php
+++ b/templates/event-details.php
@@ -284,6 +284,7 @@ Templates::header(
 				<?php // Contributors can't un-attend so don't show anything. ?>
 			<?php else : ?>
 				<form class="event-details-attend" method="post" action="<?php echo esc_url( Urls::event_toggle_attendee( $event->id() ) ); ?>">
+					<?php wp_nonce_field( '_attendee_nonce', '_attendee_nonce' ); ?>
 					<?php if ( $user_is_attending ) : ?>
 						<input type="submit" class="button is-secondary attending-btn" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
 					<?php else : ?>

--- a/templates/event-details.php
+++ b/templates/event-details.php
@@ -287,7 +287,7 @@ Templates::header(
 					<?php if ( $user_is_attending ) : ?>
 						<input type="submit" class="button is-secondary attending-btn" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
 					<?php else : ?>
-						<input type="submit" class="button is-primary attend-btn" value="<?php esc_attr_e( 'Attend Event', 'gp-translation-events' ); ?>"/>
+						<input type="submit" class="button is-primary attend-btn" value="<?php esc_attr_e( 'Attend Event Onsite', 'gp-translation-events' ); ?>"/>
 						<input type="submit" name="attend_remotely" class="button is-primary attend-btn" value="<?php esc_attr_e( 'Attend Event Remotely', 'gp-translation-events' ); ?>"/>
 					<?php endif; ?>
 				</form>

--- a/templates/event-details.php
+++ b/templates/event-details.php
@@ -288,6 +288,7 @@ Templates::header(
 						<input type="submit" class="button is-secondary attending-btn" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
 					<?php else : ?>
 						<input type="submit" class="button is-primary attend-btn" value="<?php esc_attr_e( 'Attend Event', 'gp-translation-events' ); ?>"/>
+						<input type="submit" name="attend_remotely" class="button is-primary attend-btn" value="<?php esc_attr_e( 'Attend Event Remotely', 'gp-translation-events' ); ?>"/>
 					<?php endif; ?>
 				</form>
 			<?php endif; ?>

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -131,6 +131,7 @@ class Translation_Events {
 		GP::$router->add( "/events/$slug", array( 'Wporg\TranslationEvents\Routes\Event\Details_Route', 'handle' ) );
 		GP::$router->add( "/events/$slug/attendees", array( 'Wporg\TranslationEvents\Routes\Attendee\List_Route', 'handle' ) );
 		GP::$router->add( "/events/$id/attendees/remove/$id", array( 'Wporg\TranslationEvents\Routes\Attendee\Remove_Attendee_Route', 'handle' ) );
+		GP::$router->add( "/events/attendance-mode/$id/$id", array( 'Wporg\TranslationEvents\Routes\User\Attendance_Mode_Route', 'handle' ), 'get' );
 
 		$stats_listener = new Stats_Listener( self::get_event_repository() );
 		$stats_listener->start();


### PR DESCRIPTION
Fixes #328

In this PR we add a feature that allows attendees choose how they want to attend an event either as an onsite attendee or remote attendee. We added an extra button to the event page for this.
![Screenshot 2024-06-25 at 12 19 23](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/7f735904-0f3d-4890-9c32-b997f188f408)

We also updated the attendees table by adding a column for "Remote", we also added a button that allows the host update the attendance status of an attendee. 

![Screenshot 2024-06-25 at 12 23 48](https://github.com/WordPress/wporg-gp-translation-events/assets/203408/c1699d08-2b03-4a1e-ba6a-f462e3aa9f86)