### PR TITLE
Fix page layout

### DIFF
--- a/themes/wporg-translate-events-2024/blocks/footer/index.php
+++ b/themes/wporg-translate-events-2024/blocks/footer/index.php
@@ -3,13 +3,10 @@
 register_block_type(
 	'wporg-translate-events-2024/footer',
 	array(
-		// The $attributes argument cannot be removed despite not being used in this function,
-		// because otherwise it won't be available in render.php.
-		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
-		'render_callback' => function ( array $attributes ) {
+		'render_callback' => function () {
 			ob_start();
-			include_once __DIR__ . '/render.php';
-			return do_blocks( ob_get_clean() );
+			require __DIR__ . '/render.php';
+			return ob_get_clean();
 		},
 	)
 );

--- a/themes/wporg-translate-events-2024/blocks/footer/render.php
+++ b/themes/wporg-translate-events-2024/blocks/footer/render.php
@@ -1,6 +1,5 @@
 <?php namespace Wporg\TranslationEvents\Theme_2024; ?>
 
-			</div><?php // Close the main wp-block-group div, opened by the header block. ?>
 			<!-- wp:wporg/global-footer /-->
 			<?php wp_footer(); ?>
 		</div><?php // Close the wp-site-blocks div, opened by the header block. ?>

--- a/themes/wporg-translate-events-2024/blocks/footer/render.php
+++ b/themes/wporg-translate-events-2024/blocks/footer/render.php
@@ -1,6 +1,6 @@
 <?php namespace Wporg\TranslationEvents\Theme_2024; ?>
 
-			<!-- wp:wporg/global-footer /-->
+			<?php echo do_blocks( '<!-- wp:wporg/global-footer /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<?php wp_footer(); ?>
 		</div><?php // Close the wp-site-blocks div, opened by the header block. ?>
 	</body>

--- a/themes/wporg-translate-events-2024/blocks/header/render.php
+++ b/themes/wporg-translate-events-2024/blocks/header/render.php
@@ -18,5 +18,3 @@ $html_title = implode( ' | ', array( $attributes['title'], __( 'Translation Even
 		<div class="wp-site-blocks">
 			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			<?php echo $site_header; ?>
-			<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
-				<h2 class="wp-block-heading"><?php echo esc_html( $attributes['title'] ); ?></h2>

--- a/themes/wporg-translate-events-2024/functions.php
+++ b/themes/wporg-translate-events-2024/functions.php
@@ -155,10 +155,25 @@ function render_page( string $template_path, string $title, array $attributes ):
 	echo do_blocks(
 		<<<BLOCKS
 		<!-- wp:wporg-translate-events-2024/header $header_json /-->
-		<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
-			<h2 class="wp-block-heading">$page_title</h2>
-			$page_content
-		</div>
+
+		<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
+		<main class="wp-block-group entry-content">
+			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+			<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+				<div class="wp-block-group page-upcoming-title-past-wrapper">
+					<!-- wp:heading --><h2 class="wp-block-heading">$page_title</h2><!-- /wp:heading -->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+				<div class="wp-block-group">$page_content</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		</main>
+		<!-- /wp:group -->
+
 		<!-- wp:wporg-translate-events-2024/footer /-->
 		BLOCKS
 	);

--- a/themes/wporg-translate-events-2024/functions.php
+++ b/themes/wporg-translate-events-2024/functions.php
@@ -149,12 +149,16 @@ function render_page( string $template_path, string $title, array $attributes ):
 	$page_content = do_blocks( ob_get_clean() );
 
 	$header_json = wp_json_encode( array( 'title' => $title ) );
+	$page_title  = esc_html( $title );
 
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo do_blocks(
 		<<<BLOCKS
 		<!-- wp:wporg-translate-events-2024/header $header_json /-->
+		<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)">
+			<h2 class="wp-block-heading">$page_title</h2>
 			$page_content
+		</div>
 		<!-- wp:wporg-translate-events-2024/footer /-->
 		BLOCKS
 	);

--- a/themes/wporg-translate-events-2024/functions.php
+++ b/themes/wporg-translate-events-2024/functions.php
@@ -146,16 +146,10 @@ function render_page( string $template_path, string $title, array $attributes ):
 	// are registered.
 	ob_start();
 	require $template_path;
-	$page_content = do_blocks( ob_get_clean() );
-
-	$header_json = wp_json_encode( array( 'title' => $title ) );
-	$page_title  = esc_html( $title );
-
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo do_blocks(
+	$rendered_template = ob_get_clean();
+	$page_title        = esc_html( $title );
+	$page_content      = do_blocks(
 		<<<BLOCKS
-		<!-- wp:wporg-translate-events-2024/header $header_json /-->
-
 		<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 		<main class="wp-block-group entry-content">
 			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
@@ -167,13 +161,20 @@ function render_page( string $template_path, string $title, array $attributes ):
 				<!-- /wp:group -->
 
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-				<div class="wp-block-group">$page_content</div>
+				<div class="wp-block-group">$rendered_template</div>
 				<!-- /wp:group -->
 			</div>
 			<!-- /wp:group -->
 		</main>
 		<!-- /wp:group -->
+		BLOCKS
+	);
 
+	$header_json = wp_json_encode( array( 'title' => $title ) );
+	echo do_blocks( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		<<<BLOCKS
+		<!-- wp:wporg-translate-events-2024/header $header_json /-->
+		$page_content
 		<!-- wp:wporg-translate-events-2024/footer /-->
 		BLOCKS
 	);

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -9,3 +9,17 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: wporg-translate-events-2024
 Template: wporg-parent-2021
+*/
+
+/*
+ * Layout
+ */
+body {
+	--wp--custom--layout--wide-size: 1600px;
+}
+.wp-site-blocks .is-layout-constrained,
+.wp-block-post-content-is-layout-constrained {
+	& .alignwide {
+		max-width: var(--wp--custom--layout--wide-size) !important;
+	}
+}


### PR DESCRIPTION
There was an issue where the content of the page was not center-aligned on wide viewports. This PR fixes that so that on narrow viewports the content is left-aligned, and on wide ones it's center-aligned. It now behaves the same as [events.wordpress.org](https://events.wordpress.org/upcoming-events/).

This fix also has the nice side effect of also fixing the footer, so it stays anchored to the bottom of the window.

Additionally, this PR also fixes a bug that caused the styles of blocks referenced by the footer not to be registered. The bug is visible in the screenshots below (they were taken before the fix), where there are dots before each social link in the footer, and the social images are not coloured.

## Screen captures
The red border shows the size of the container.

### Before
<img width="1791" alt="Screenshot 2024-07-12 at 16 19 26" src="https://github.com/user-attachments/assets/d08791d0-4186-4935-92bd-5dca608c4a52">

### After
<img width="1819" alt="Screenshot 2024-07-15 at 15 42 23" src="https://github.com/user-attachments/assets/c788a497-9a1d-4088-bfe6-3c1d5679e0b6">

---
<img width="1224" alt="Screenshot 2024-07-15 at 15 42 38" src="https://github.com/user-attachments/assets/7059be98-9609-4e23-8135-214b28d58698">

---
<img width="493" alt="Screenshot 2024-07-15 at 15 43 16" src="https://github.com/user-attachments/assets/fad4d08c-6bfe-4b8a-b570-369f9f8d6f99">
