### PR TITLE
Add the RSS feed in the header

### DIFF
--- a/templates/parts/header.php
+++ b/templates/parts/header.php
@@ -21,7 +21,7 @@ $image_url        = $image_url ?? Urls::event_default_image();
 add_action(
 	'gp_head',
 	function () use ( $html_title, $url, $html_description, $image_url ) {
-		echo '<link rel="alternate" type="application/rss+xml" title="Translating Events &raquo; WordPress Feed" href="' . esc_url( home_url( gp_url( '/events/feed' ) ) ) . '" />' . "\n";
+		echo '<link rel="alternate" type="application/rss+xml" title="' . esc_html__( 'Translating Events &raquo; WordPress Feed', 'gp-translation-events' ) . '" href="' . esc_url( home_url( gp_url( '/events/feed' ) ) ) . '" />' . "\n";
 		echo '<meta name="twitter:card" content="summary" />' . "\n";
 		echo '<meta name="twitter:site" content="@WordPress" />' . "\n";
 		echo '<meta name="twitter:title" content="' . esc_attr( $html_title ) . '" />' . "\n";

--- a/templates/parts/header.php
+++ b/templates/parts/header.php
@@ -21,6 +21,7 @@ $image_url        = $image_url ?? Urls::event_default_image();
 add_action(
 	'gp_head',
 	function () use ( $html_title, $url, $html_description, $image_url ) {
+		echo '<link rel="alternate" type="application/rss+xml" title="Translating Events &raquo; WordPress Feed" href="' . esc_url( home_url( gp_url( '/events/feed' ) ) ) . '" />' . "\n";
 		echo '<meta name="twitter:card" content="summary" />' . "\n";
 		echo '<meta name="twitter:site" content="@WordPress" />' . "\n";
 		echo '<meta name="twitter:title" content="' . esc_attr( $html_title ) . '" />' . "\n";

--- a/wporg-gp-translation-events.php
+++ b/wporg-gp-translation-events.php
@@ -92,6 +92,7 @@ class Translation_Events {
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_translation_event_js' ) );
 		add_action( 'init', array( $this, 'register_event_post_type' ) );
 		add_action( 'init', array( $this, 'send_notifications' ) );
+		add_action( 'init', array( $this, 'remove_incorrect_rss_feed' ) );
 		add_action( 'add_meta_boxes', array( $this, 'event_meta_boxes' ) );
 		add_action( 'save_post', array( $this, 'save_event_meta_boxes' ) );
 		add_action( 'transition_post_status', array( $this, 'event_status_transition' ), 10, 3 );
@@ -432,6 +433,13 @@ class Translation_Events {
 	 */
 	public function send_notifications() {
 		new Notifications_Send( self::now(), self::get_event_repository(), self::get_attendee_repository() );
+	}
+
+	/**
+	 * Remove the incorrect RSS feed.
+	 */
+	public function remove_incorrect_rss_feed() {
+		remove_action( 'wp_head', 'feed_links', 2 );
 	}
 
 	/**


### PR DESCRIPTION
This PR:
- Adds the rel="alternate" link for the events' RSS feed.
- Removes two invalid RSS feeds:
    - https://translate.wordpress.org/feed/
    - https://translate.wordpress.org/comments/feed/

To test it, you need to:
- Inspect the source code before switching to this branch, so you can see the 2 incorrect RSS feeds.
- Switch to this branch.
- Inspect the source code. Now you have a new RSS feed, linking to https://translate.wordpress.org/events/feed/, and you don't have the 2 incorrect RSS feeds.