### PR TITLE
Fix broken form

### DIFF
--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -238,7 +238,6 @@ class Event_Form_Handler {
 			$title,
 			$description,
 			null,
-			null,
 			$attendance_mode,
 		);
 		$event->set_id( intval( $event_id ) );

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -237,6 +237,8 @@ class Event_Form_Handler {
 			$event_status,
 			$title,
 			$description,
+			null,
+			null,
 			$attendance_mode,
 		);
 		$event->set_id( intval( $event_id ) );

--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -144,7 +144,6 @@ class Event_Repository implements Event_Repository_Interface {
 				$post->post_status,
 				$post->post_title,
 				$post->post_content,
-				$post->post_date_gmt ? new DateTimeImmutable( $post->post_date_gmt ) : null,
 				$post->post_modified_gmt ? new DateTimeImmutable( $post->post_modified_gmt ) : null,
 				$meta['attendance_mode'],
 			);
@@ -571,7 +570,6 @@ class Event_Repository implements Event_Repository_Interface {
 				$post->post_status,
 				$title,
 				$post->post_content,
-				$post->post_date_gmt ? new DateTimeImmutable( $post->post_date_gmt ) : null,
 				$post->post_modified_gmt ? new DateTimeImmutable( $post->post_modified_gmt ) : null,
 				$meta['attendance_mode'],
 			);

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -42,7 +42,6 @@ class Event {
 	private string $status;
 	private string $title;
 	private string $description;
-	private DateTimeImmutable $created_at;
 	private DateTimeImmutable $updated_at;
 	private string $attendance_mode;
 
@@ -59,7 +58,6 @@ class Event {
 		string $status,
 		string $title,
 		string $description,
-		DateTimeImmutable $created_at = null,
 		DateTimeImmutable $updated_at = null,
 		string $attendance_mode = 'onsite'
 	) {
@@ -71,7 +69,6 @@ class Event {
 		$this->set_status( $status );
 		$this->set_title( $title );
 		$this->set_description( $description );
-		$this->set_created_at( $created_at );
 		$this->set_updated_at( $updated_at );
 		$this->set_attendance_mode( $attendance_mode );
 	}
@@ -141,10 +138,6 @@ class Event {
 		return $this->description;
 	}
 
-	public function created_at(): DateTimeImmutable {
-		return $this->created_at;
-	}
-
 	public function updated_at(): DateTimeImmutable {
 		return $this->updated_at;
 	}
@@ -189,10 +182,6 @@ class Event {
 
 	public function set_description( string $description ): void {
 		$this->description = $description;
-	}
-
-	public function set_created_at( DateTimeImmutable $created_at = null ): void {
-		$this->created_at = $created_at ?? Translation_Events::now();
 	}
 
 	public function set_updated_at( DateTimeImmutable $updated_at = null ): void {

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -59,8 +59,8 @@ class Event {
 		string $status,
 		string $title,
 		string $description,
-		DatetimeImmutable $created_at = null,
-		DatetimeImmutable $updated_at = null,
+		DateTimeImmutable $created_at = null,
+		DateTimeImmutable $updated_at = null,
 		string $attendance_mode = 'onsite'
 	) {
 		$this->author_id = $author_id;


### PR DESCRIPTION
Found out that the event form is broken on form submission and returns the error below;

`Uncaught Error: Argument 8 passed to Wporg\TranslationEvents\Event\Event::__construct() must be an instance of DateTimeImmutable or null, string given, called in /Users/tosinoguntuyi/Sites/translate/wp-content/plugins/wporg-gp-translation-events/includes/event/event-form-handler.php on line 233`

In this PR, we add `null` values for the newly introduced `created_at` and `updated_at` function arguments.