### PR TITLE
Add a date in the RSS header when we don't have current and future events

### DIFF
--- a/includes/event/event-repository.php
+++ b/includes/event/event-repository.php
@@ -551,6 +551,10 @@ class Event_Repository implements Event_Repository_Interface {
 		$events = array();
 		foreach ( $posts as $post ) {
 			$meta = $this->get_event_meta( $post->ID );
+			if ( empty( $meta['start'] ) || empty( $meta['end'] ) || empty( $meta['timezone'] ) ) {
+				// If the event is missing any of the required meta fields, we skip it.
+				continue;
+			}
 
 			$title = $post->post_title;
 			if ( empty( $title ) ) {

--- a/includes/routes/event/rss.php
+++ b/includes/routes/event/rss.php
@@ -2,6 +2,7 @@
 
 namespace Wporg\TranslationEvents\Routes\Event;
 
+use DateTimeImmutable;
 use DateTimeInterface;
 use Wporg\TranslationEvents\Event\Event;
 use Wporg\TranslationEvents\Event\Event_Repository_Interface;
@@ -97,7 +98,11 @@ class Rss_Route extends Route {
 	 */
 	private function document_pub_and_build_date( array $events ): ?string {
 		if ( empty( $events ) ) {
-			return null;
+			$events = $this->event_repository->get_past_events()->events;
+		}
+		if ( empty( $events ) ) {
+			$zero_date = new DateTimeImmutable( '@0' );
+			return $zero_date->format( DATE_RSS );
 		}
 
 		$pub_date = $events[0]->updated_at();

--- a/includes/routes/event/rss.php
+++ b/includes/routes/event/rss.php
@@ -120,10 +120,8 @@ class Rss_Route extends Route {
 		}
 		foreach ( $events_post as $event_post ) {
 			$event = $this->event_repository->get_event( $event_post['ID'] );
-			if ( $event ) {
-				if ( $event->updated_at() > $pub_date ) {
-					$pub_date = $event->updated_at();
-				}
+			if ( $event && ( $event->updated_at() > $pub_date ) ) {
+				$pub_date = $event->updated_at();
 			}
 		}
 

--- a/includes/routes/event/rss.php
+++ b/includes/routes/event/rss.php
@@ -32,10 +32,10 @@ class Rss_Route extends Route {
 	 */
 	public function handle(): void {
 		$args                = array(
-			'posts_per_page' => 20,
-			'post_type'      => Translation_Events::CPT,
-			'post_status'    => 'publish',
-			'post_parent'    => '>0',
+			'posts_per_page'      => 20,
+			'post_type'           => Translation_Events::CPT,
+			'post_status'         => 'publish',
+			'post_parent__not_in' => array( 0 ),
 		);
 		$last_20_events_post = wp_get_recent_posts( $args );
 		$rss_feed            = $this->get_rss_20_header( $last_20_events_post );

--- a/includes/routes/event/rss.php
+++ b/includes/routes/event/rss.php
@@ -108,10 +108,9 @@ class Rss_Route extends Route {
 	 * @return string|null
 	 */
 	private function document_pub_and_build_date( array $events_post ): ?string {
-		$pub_date = null;
+		$pub_date = new DateTimeImmutable( '@0' );
 		if ( empty( $events_post ) ) {
-			$zero_date = new DateTimeImmutable( '@0' );
-			return $zero_date->format( DATE_RSS );
+			return $pub_date->format( DATE_RSS );
 		}
 
 		$first_event = $this->event_repository->get_event( $events_post[0]['ID'] );


### PR DESCRIPTION
In the RSS feed, if we don't have current and future events, some fields in the header (pubDate and lastBuildDate) are empty, so the RSS feed is not valid:

### Empty header
![image](https://github.com/user-attachments/assets/641ac7ef-8401-4323-890c-dae711d6a133)

### Invalid check
![image](https://github.com/user-attachments/assets/fafb4189-1e65-4845-9849-3b938caad8a2)

This PR uses:
- The last updated event from the past events, if we don't have future events.
- The Unix epoch date if we don't have any event in the system.

### Last updated event from the past events
![image](https://github.com/user-attachments/assets/ae5ae735-7e3f-4f84-9137-6ed8ed45c3ba)

### Unix epoch date
![image](https://github.com/user-attachments/assets/e5e6a89f-067a-4164-8714-f09269dc13e2)

