### PR TITLE
Do not change negative symbol in the diff

### DIFF
--- a/assets/js/translation-events.js
+++ b/assets/js/translation-events.js
@@ -279,10 +279,9 @@
 							}
 							in_text  = '';
 							ago_text = ' ago';
-							diff     = - diff;
 						}
 
-						const seconds    = Math.floor( diff / 1000 );
+						const seconds    = Math.floor( Math.abs( diff ) / 1000 );
 						const minutes    = Math.floor( seconds / 60 );
 						const hours      = Math.floor( minutes / 60 );
 						let days         = Math.floor( hours / 24 );


### PR DESCRIPTION
Currently, the human diff in the `WordCamp Rio` event is incorrect. 

![image](https://github.com/user-attachments/assets/b55e93a7-ca3b-4019-be2e-b5ba257fc9ab)

This PR solves it.

![image](https://github.com/user-attachments/assets/c948ff7c-2a45-4f58-a32b-768c8550be8e)

