### PR TITLE
Fix event times stored in wrong timezone in the database

### DIFF
--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -220,7 +220,7 @@ class Event_Form_Handler {
 		try {
 			$start_utc = new DateTime( $event_start, $timezone );
 			$start_utc = $start_utc->setTimezone( new DateTimeZone( 'UTC' ) );
-			$start = new Event_Start_Date( $start_utc->format( 'Y-m-d H:i:s' ), $timezone );
+			$start     = new Event_Start_Date( $start_utc->format( 'Y-m-d H:i:s' ), $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidStart();
 		}
@@ -228,7 +228,7 @@ class Event_Form_Handler {
 		try {
 			$end_utc = new DateTime( $event_end, $timezone );
 			$end_utc = $end_utc->setTimezone( new DateTimeZone( 'UTC' ) );
-			$end = new Event_End_Date( $end_utc->format( 'Y-m-d H:i:s' ), $timezone );
+			$end     = new Event_End_Date( $end_utc->format( 'Y-m-d H:i:s' ), $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidEnd();
 		}

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -235,8 +235,8 @@ class Event_Form_Handler {
 
 		$event = new Event(
 			get_current_user_id(),
-			$start_utc,
-			$end_utc,
+			$start->setTimezone( new DateTimeZone( 'UTC' ) ),
+			$end->setTimezone( new DateTimeZone( 'UTC' ) ),
 			$timezone,
 			$event_status,
 			$title,

--- a/includes/event/event-form-handler.php
+++ b/includes/event/event-form-handler.php
@@ -218,21 +218,25 @@ class Event_Form_Handler {
 		}
 
 		try {
-			$start = new Event_Start_Date( $event_start, $timezone );
+			$start_utc = new DateTime( $event_start, $timezone );
+			$start_utc = $start_utc->setTimezone( new DateTimeZone( 'UTC' ) );
+			$start = new Event_Start_Date( $start_utc->format( 'Y-m-d H:i:s' ), $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidStart();
 		}
 
 		try {
-			$end = new Event_End_Date( $event_end, $timezone );
+			$end_utc = new DateTime( $event_end, $timezone );
+			$end_utc = $end_utc->setTimezone( new DateTimeZone( 'UTC' ) );
+			$end = new Event_End_Date( $end_utc->format( 'Y-m-d H:i:s' ), $timezone );
 		} catch ( Exception $e ) {
 			throw new InvalidEnd();
 		}
 
 		$event = new Event(
 			get_current_user_id(),
-			$start->setTimezone( new DateTimeZone( 'UTC' ) ),
-			$end->setTimezone( new DateTimeZone( 'UTC' ) ),
+			$start_utc,
+			$end_utc,
 			$timezone,
 			$event_status,
 			$title,

--- a/templates/parts/event-form.php
+++ b/templates/parts/event-form.php
@@ -48,11 +48,11 @@ use Wporg\TranslationEvents\Urls;
 		?>
 		<div>
 			<label for="event-start"><?php esc_html_e( 'Start Date', 'gp-translation-events' ); ?></label>
-			<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly' ); ?> >
+			<input type="datetime-local" id="event-start" name="event_start" value="<?php echo esc_attr( $event->start()->setTimezone( $event->timezone() )->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_start', $event->id() ) ?: 'readonly' ); ?> >
 		</div>
 		<div>
 			<label for="event-end"><?php esc_html_e( 'End Date', 'gp-translation-events' ); ?></label>
-			<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
+			<input type="datetime-local" id="event-end" name="event_end" value="<?php echo esc_attr( $event->end()->setTimezone( $event->timezone() )->format( 'Y-m-d H:i' ) ); ?>" required <?php echo esc_html( $is_create_form || current_user_can( 'edit_translation_event_end', $event->id() ) ?: 'readonly' ); ?>>
 		</div>
 		<div>
 			<label for="event-timezone"><?php esc_html_e( 'Event Timezone', 'gp-translation-events' ); ?></label>


### PR DESCRIPTION
Fixes #354 

When storing an event in another timezone we need to convert it to UTC before saving it to the db:
![Screenshot 2024-09-17 at 14 36 47](https://github.com/user-attachments/assets/766486d4-1ddc-4132-bdf9-3c0e7c8f8331)

9am in Los Angeles needs to be saved as 4pm UTC. 

When editing the event, we need to convert it back into the even timezone so that the local time is being edited.