### PR TITLE
Event has ended notice

### DIFF
--- a/themes/wporg-translate-events-2024/blocks/event-attend-button/index.php
+++ b/themes/wporg-translate-events-2024/blocks/event-attend-button/index.php
@@ -26,7 +26,7 @@ register_block_type(
 		<div class="event-details-join">
 				<?php if ( $event->end()->is_in_the_past() ) : ?>
 					<?php if ( $user_is_attending ) : ?>
-					<button disabled="disabled" class="wp-block-button__link"><?php esc_html_e( 'You attended', 'gp-translation-events' ); ?></button>
+						<p class="has-charcoal-4-color has-text-color has-small-font-size" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'You attended this event.', 'wporg-translate-events-2024' ); ?></p>
 				<?php endif; ?>
 			<?php elseif ( $user_is_contributor ) : ?>
 				<?php // Contributors can't un-attend so don't show anything. ?>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -20,6 +20,20 @@ echo wp_json_encode(
 ?>
 
 /-->
+<?php
+if ( $event->is_past() ) :
+	?>
+<!-- wp:wporg/notice {"type":"alert", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--20)">
+	<div class="wp-block-wporg-notice__icon"></div>
+	<div class="wp-block-wporg-notice__content">
+		<p>
+		<?php echo esc_html__( 'This event has ended.', 'wporg-translate-events-2024' ); ?>
+		</p>
+	</div>
+</div>
+<!-- /wp:wporg/notice -->
+<?php endif; ?>
 
 <!-- wp:paragraph -->
 <p>


### PR DESCRIPTION
In this PR we display a notice if the event has ended to allow users easily see that the event has ended, also the button is replaced with a simple text `You attended this event.`

**Before**

![image](https://github.com/user-attachments/assets/d7a4276f-ec4a-4d66-be73-b6f055090d7e)



**After**

![Screenshot 2024-09-24 at 19 06 06](https://github.com/user-attachments/assets/581c6129-07d2-4881-be17-8c8648c32d9d)

