### PR TITLE
Fix event flag error

### DIFF
--- a/themes/wporg-translate-events-2024/blocks/event-flag/index.php
+++ b/themes/wporg-translate-events-2024/blocks/event-flag/index.php
@@ -16,12 +16,15 @@ register_block_type(
 				return '';
 			}
 			$current_user_attendee = Translation_Events::get_attendee_repository()->is_user_attending( $event_id, get_current_user_id() );
-			$event_flag = false;
-			if ( $current_user_attendee ) {
-				$event_flag = 'Attending';
-				if ( $current_user_attendee->is_host() ) {
-					$event_flag = 'Host';
-				}
+			$event_flag = '';
+
+			if ( ! $current_user_attendee ) {
+				return '';
+			}
+			if ( $event->is_past() ) {
+				$event_flag = $current_user_attendee->is_host() ? __( 'Hosted', 'wporg-translate-events-2024' ) : __( 'Attended', 'wporg-translate-events-2024' );
+			} else {
+				$event_flag = $current_user_attendee->is_host() ? __( 'Hosting', 'wporg-translate-events-2024' ) : __( 'Attending', 'wporg-translate-events-2024' );
 			}
 
 			if ( ! $event_flag ) {


### PR DESCRIPTION
Fixes #359 
The event flag that tells if a user is attending or hosting on the my events page and it had a bug which this PR fixes. In this PR we ensure that for an event that has ended;
if user is a host, we display `Hosted`
if user is only an attendee, we display `Attended`

If the event has not ended;
if user is a host, we display `Hosting`
if user is only an attendee, we display `Attending`

**Before**
![Screenshot 2024-09-24 at 23 51 14](https://github.com/user-attachments/assets/55cee0b8-ec75-42a1-9b42-4ce6779beab5)

**After**
![Screenshot 2024-09-24 at 23 47 13](https://github.com/user-attachments/assets/cd26b101-afd4-49ac-893e-1c2dc9b9b8bb)