### PR TITLE
Add edit link to event details page

### DIFF
--- a/themes/wporg-translate-events-2024/blocks/event-attend-button/index.php
+++ b/themes/wporg-translate-events-2024/blocks/event-attend-button/index.php
@@ -14,7 +14,6 @@ register_block_type(
 			}
 			$event_id = $attributes['id'];
 			$user_is_attending = $attributes['user_is_attending'];
-			$user_is_contributor = $attributes['user_is_contributor'];
 			$event = Translation_Events::get_event_repository()->get_event( $event_id );
 			if ( ! $event ) {
 				return '';
@@ -24,31 +23,20 @@ register_block_type(
 			if ( is_user_logged_in() ) :
 				?>
 		<div class="event-details-join">
-				<?php if ( $event->end()->is_in_the_past() ) : ?>
-					<?php if ( $user_is_attending ) : ?>
-						<p class="has-charcoal-4-color has-text-color has-small-font-size" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'You attended this event.', 'wporg-translate-events-2024' ); ?></p>
-				<?php endif; ?>
-			<?php elseif ( $user_is_contributor ) : ?>
-				<?php // Contributors can't un-attend so don't show anything. ?>
-			<?php else : ?>
-				<form class="event-details-attend" method="post" action="<?php echo esc_url( Urls::event_toggle_attendee( $event->id() ) ); ?>">
+				<?php if ( ! $event->end()->is_in_the_past() ) : ?>
+			<form class="event-details-attend" method="post" action="<?php echo esc_url( Urls::event_toggle_attendee( $event->id() ) ); ?>">
 					<?php wp_nonce_field( '_attendee_nonce', '_attendee_nonce' ); ?>
 					<?php if ( $user_is_attending ) : ?>
-						<input type="submit" class="wp-block-button__link" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
-					<?php else : ?>
-						<?php if ( ! $event->is_remote() ) : ?>
-							<input type="submit" class="wp-block-button__link" value="<?php esc_attr_e( 'Attend Event On-site', 'gp-translation-events' ); ?>"/>
-							<?php if ( ! $event->is_hybrid() ) : ?>
-								<p class="onsite-btn-note">
-									<?php echo wp_kses_post( __( '<strong>Note:</strong> This is an onsite-only event. Please only click attend if you are at the event. The host might otherwise remove you.', 'gp-translation-events' ) ); ?>
-								</p>	
-							<?php endif; ?>
-						<?php endif; ?>
-						<?php if ( $event->is_remote() || $event->is_hybrid() ) : ?>
-							<input type="submit" name="attend_remotely" class="wp-block-button__link" value="<?php esc_attr_e( 'Attend Event Remotely', 'gp-translation-events' ); ?>"/>
-						<?php endif; ?>
+					<input type="submit" class="wp-block-button__link" value="<?php esc_attr_e( "You're attending", 'gp-translation-events' ); ?>" />
+				<?php else : ?>
+					<?php if ( ! $event->is_remote() ) : ?>
+						<input type="submit" class="wp-block-button__link" value="<?php esc_attr_e( 'Attend Event On-site', 'gp-translation-events' ); ?>"/>
 					<?php endif; ?>
-				</form>
+					<?php if ( $event->is_remote() || $event->is_hybrid() ) : ?>
+						<input type="submit" name="attend_remotely" class="wp-block-button__link" value="<?php esc_attr_e( 'Attend Event Remotely', 'gp-translation-events' ); ?>"/>
+					<?php endif; ?>
+				<?php endif; ?>
+			</form>
 			<?php endif; ?>
 		</div>
 		<?php else : ?>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/index.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/index.php
@@ -28,10 +28,11 @@ register_block_type(
 				return '';
 			}
 			$attributes['event'] = $event;
+			$attributes['use_custom_page_title'] = true;
 
 			render_page(
 				__DIR__ . '/render.php',
-				'',
+				esc_html( $event->title() ),
 				$attributes
 			);
 		},

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/index.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/index.php
@@ -31,7 +31,7 @@ register_block_type(
 
 			render_page(
 				__DIR__ . '/render.php',
-				esc_html( $event->title() ),
+				'',
 				$attributes
 			);
 		},

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -2,6 +2,7 @@
 namespace Wporg\TranslationEvents\Theme_2024;
 
 use Wporg\TranslationEvents\Attendee\Attendee;
+use Wporg\TranslationEvents\Urls;
 
 $event               = $attributes['event'];
 $user_is_attending   = $attributes['user_is_attending'];
@@ -20,6 +21,13 @@ echo wp_json_encode(
 ?>
 
 /-->
+
+<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
+<a class="details-edit-event" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>">
+	<span class="dashicons dashicons-edit"></span><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?>
+</a>
+<?php endif; ?>
+
 <?php
 if ( is_user_logged_in() ) :
 	if ( $event->is_past() ) :

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -37,13 +37,29 @@ if ( is_user_logged_in() ) :
 		<?php
 		if ( $user_is_attending ) :
 			?>
-			<p class="has-charcoal-4-color has-text-color has-small-font-size" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'You attended this event.', 'wporg-translate-events-2024' ); ?></p>
+			<!-- wp:wporg/notice {"type":"info", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+			<div class="wp-block-wporg-notice is-info-notice" style="margin-top:var(--wp--preset--spacing--20)">
+				<div class="wp-block-wporg-notice__icon"></div>
+				<div class="wp-block-wporg-notice__content">
+					<p>
+						<?php esc_html_e( 'You attended this event.', 'wporg-translate-events-2024' ); ?>
+					</p>
+				</div>
+			</div>
+			<!-- /wp:wporg/notice -->
 		<?php endif; ?>
 	<?php else : ?>
 		<?php if ( ! $event->is_hybrid() && ! $event->is_remote() ) : ?>
-			<p class="onsite-btn-note">
-				<?php echo wp_kses_post( __( '<strong>Note:</strong> This is an onsite-only event. Please only click attend if you are at the event. The host might otherwise remove you.', 'wporg-translate-events-2024' ) ); ?>
-			</p>
+			<!-- wp:wporg/notice {"type":"tip","style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+			<div class="wp-block-wporg-notice is-tip-notice" style="margin-top:var(--wp--preset--spacing--20)">
+				<div class="wp-block-wporg-notice__icon"></div>
+				<div class="wp-block-wporg-notice__content">
+					<p>
+						<?php echo wp_kses_post( __( 'This is an onsite-only event. Please only click attend if you are at the event. The host might otherwise remove you.', 'wporg-translate-events-2024' ) ); ?>
+					</p>
+				</div>
+			</div>
+			<!-- /wp:wporg/notice -->
 		<?php endif; ?>	
 		<?php
 	endif;

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -1,7 +1,6 @@
 <?php
 namespace Wporg\TranslationEvents\Theme_2024;
 
-use Wporg\TranslationEvents\Attendee\Attendee;
 use Wporg\TranslationEvents\Urls;
 
 $event               = $attributes['event'];

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -21,19 +21,34 @@ echo wp_json_encode(
 
 /-->
 <?php
-if ( $event->is_past() ) :
-	?>
-<!-- wp:wporg/notice {"type":"alert", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--20)">
-	<div class="wp-block-wporg-notice__icon"></div>
-	<div class="wp-block-wporg-notice__content">
-		<p>
-		<?php echo esc_html__( 'This event has ended.', 'wporg-translate-events-2024' ); ?>
-		</p>
-	</div>
-</div>
-<!-- /wp:wporg/notice -->
-<?php endif; ?>
+if ( is_user_logged_in() ) :
+	if ( $event->is_past() ) :
+		?>
+		<!-- wp:wporg/notice {"type":"alert", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+		<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--20)">
+			<div class="wp-block-wporg-notice__icon"></div>
+			<div class="wp-block-wporg-notice__content">
+				<p>
+				<?php echo esc_html__( 'This event has ended.', 'wporg-translate-events-2024' ); ?>
+				</p>
+			</div>
+		</div>
+		<!-- /wp:wporg/notice -->
+		<?php
+		if ( $user_is_attending ) :
+			?>
+			<p class="has-charcoal-4-color has-text-color has-small-font-size" style="margin-top:var(--wp--preset--spacing--10);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_html_e( 'You attended this event.', 'wporg-translate-events-2024' ); ?></p>
+		<?php endif; ?>
+	<?php else : ?>
+		<?php if ( ! $event->is_hybrid() && ! $event->is_remote() ) : ?>
+			<p class="onsite-btn-note">
+				<?php echo wp_kses_post( __( '<strong>Note:</strong> This is an onsite-only event. Please only click attend if you are at the event. The host might otherwise remove you.', 'wporg-translate-events-2024' ) ); ?>
+			</p>
+		<?php endif; ?>	
+		<?php
+	endif;
+endif;
+?>
 
 <!-- wp:paragraph -->
 <p>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -26,7 +26,19 @@ $user_is_contributor = $attributes['user_is_contributor'];
 	<?php endif; ?>
 </div>
 
-<?php if ( ! $event->is_past() ) : ?>
+<?php if ( $event->is_past() ) : ?>
+	<!-- wp:wporg/notice {"type":"alert"} -->
+	<div class="wp-block-wporg-notice is-alert-notice">
+			<div class="wp-block-wporg-notice__icon"></div>
+			<div class="wp-block-wporg-notice__content">
+				<p>
+				<?php echo esc_html__( 'This event has ended.', 'wporg-translate-events-2024' ); ?>
+				</p>
+			</div>
+		</div>
+		<!-- /wp:wporg/notice -->
+
+<?php else : ?>
 <!-- wp:wporg-translate-events-2024/event-attend-button 
 	<?php
 	echo wp_json_encode(
@@ -38,24 +50,12 @@ $user_is_contributor = $attributes['user_is_contributor'];
 	);
 	?>
 
-/-->
+/-->	
 <?php endif; ?>
 
 <?php
 if ( is_user_logged_in() ) :
 	if ( $event->is_past() ) :
-		?>
-		<!-- wp:wporg/notice {"type":"alert"} -->
-		<div class="wp-block-wporg-notice is-alert-notice">
-			<div class="wp-block-wporg-notice__icon"></div>
-			<div class="wp-block-wporg-notice__content">
-				<p>
-				<?php echo esc_html__( 'This event has ended.', 'wporg-translate-events-2024' ); ?>
-				</p>
-			</div>
-		</div>
-		<!-- /wp:wporg/notice -->
-		<?php
 		if ( $user_is_attending ) :
 			?>
 			<!-- wp:wporg/notice {"type":"info", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -8,23 +8,36 @@ $user_is_attending   = $attributes['user_is_attending'];
 $user_is_contributor = $attributes['user_is_contributor'];
 
 ?>
+
+<div class="wp-block-columns is-layout-flex details-page-title">
+	<div class="wp-block-column" style="flex-basis:85%">
+		<h2 class="wp-block-heading"><?php echo esc_html( $event->title() ); ?></h2>
+	</div>
+	<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
+		<div class="wp-block-column" style="flex-basis:15%">
+			<div class="wp-block-button is-style-outline is-style-outline--13 details-edit-event">
+				<div class="wp-block-button">
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?></a>
+				</div>
+			</div>
+		</div>
+	<?php endif; ?>
+
+</div>
+
+<?php if ( ! $event->is_past() ) : ?>
 <!-- wp:wporg-translate-events-2024/event-attend-button 
-<?php
-echo wp_json_encode(
-	array(
-		'id'                  => $event->id(),
-		'user_is_attending'   => $user_is_attending,
-		'user_is_contributor' => $user_is_contributor,
-	)
-);
-?>
+	<?php
+	echo wp_json_encode(
+		array(
+			'id'                  => $event->id(),
+			'user_is_attending'   => $user_is_attending,
+			'user_is_contributor' => $user_is_contributor,
+		)
+	);
+	?>
 
 /-->
-
-<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-	<div class="wp-block-button is-style-outline is-style-outline--13 details-edit-event">
-		<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?></a>
-	</div>
 <?php endif; ?>
 
 <?php

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -44,8 +44,8 @@ $user_is_contributor = $attributes['user_is_contributor'];
 if ( is_user_logged_in() ) :
 	if ( $event->is_past() ) :
 		?>
-		<!-- wp:wporg/notice {"type":"alert", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--40)">
+		<!-- wp:wporg/notice {"type":"alert"} -->
+		<div class="wp-block-wporg-notice is-alert-notice">
 			<div class="wp-block-wporg-notice__icon"></div>
 			<div class="wp-block-wporg-notice__content">
 				<p>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -15,7 +15,7 @@ $user_is_contributor = $attributes['user_is_contributor'];
 	</div>
 	<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
 		<div>
-			<div class="wp-block-buttons is-content-justification-end">
+			<div class="wp-block-buttons details-edit-event-btn">
 				<div class="wp-block-button is-style-outline">
 					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>">
 						<?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -22,9 +22,9 @@ echo wp_json_encode(
 /-->
 
 <?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-<a class="details-edit-event" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>">
-	<span class="dashicons dashicons-edit"></span><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?>
-</a>
+	<div class="wp-block-button is-style-outline is-style-outline--13 details-edit-event">
+		<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?></a>
+	</div>
 <?php endif; ?>
 
 <?php
@@ -32,7 +32,7 @@ if ( is_user_logged_in() ) :
 	if ( $event->is_past() ) :
 		?>
 		<!-- wp:wporg/notice {"type":"alert", "style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
-		<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--20)">
+		<div class="wp-block-wporg-notice is-alert-notice" style="margin-top:var(--wp--preset--spacing--40)">
 			<div class="wp-block-wporg-notice__icon"></div>
 			<div class="wp-block-wporg-notice__content">
 				<p>

--- a/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
+++ b/themes/wporg-translate-events-2024/blocks/pages/events/event-details/render.php
@@ -9,20 +9,21 @@ $user_is_contributor = $attributes['user_is_contributor'];
 
 ?>
 
-<div class="wp-block-columns is-layout-flex details-page-title">
-	<div class="wp-block-column" style="flex-basis:85%">
+<div class="wp-block-grid is-layout-grid details-page-title">
+	<div>
 		<h2 class="wp-block-heading"><?php echo esc_html( $event->title() ); ?></h2>
 	</div>
 	<?php if ( current_user_can( 'edit_translation_event', $event->id() ) ) : ?>
-		<div class="wp-block-column" style="flex-basis:15%">
-			<div class="wp-block-button is-style-outline is-style-outline--13 details-edit-event">
-				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>"><?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?></a>
+		<div>
+			<div class="wp-block-buttons is-content-justification-end">
+				<div class="wp-block-button is-style-outline">
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( Urls::event_edit( $event->id() ) ); ?>">
+						<?php echo esc_html__( 'Edit Event', 'wporg-translate-events-2024' ); ?>
+					</a>
 				</div>
 			</div>
 		</div>
 	<?php endif; ?>
-
 </div>
 
 <?php if ( ! $event->is_past() ) : ?>

--- a/themes/wporg-translate-events-2024/functions.php
+++ b/themes/wporg-translate-events-2024/functions.php
@@ -178,7 +178,7 @@ function render_page( string $template_path, string $title, array $attributes ):
 	require $template_path;
 	$rendered_template = ob_get_clean();
 	$page_title        = esc_html( $title );
-	$page_title_block  = ! empty( $page_title ) ? do_blocks( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	$page_title_block  = ( empty( $attributes['use_custom_page_title'] ) ) ? do_blocks( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		<<<BLOCKS
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 					<div class="wp-block-group page-upcoming-title-past-wrapper">

--- a/themes/wporg-translate-events-2024/functions.php
+++ b/themes/wporg-translate-events-2024/functions.php
@@ -178,18 +178,23 @@ function render_page( string $template_path, string $title, array $attributes ):
 	require $template_path;
 	$rendered_template = ob_get_clean();
 	$page_title        = esc_html( $title );
-	$page_content      = do_blocks(
+	$page_title_block  = ! empty( $page_title ) ? do_blocks( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		<<<BLOCKS
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+					<div class="wp-block-group page-upcoming-title-past-wrapper">
+						<!-- wp:heading --><h2 class="wp-block-heading">$page_title </h2><!-- /wp:heading -->
+					</div>
+				<!-- /wp:group -->
+		BLOCKS
+	) : '';
+
+	$page_content = do_blocks(
 		<<<BLOCKS
 		<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 		<main class="wp-block-group entry-content">
 			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 			<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
-				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-				<div class="wp-block-group page-upcoming-title-past-wrapper">
-					<!-- wp:heading --><h2 class="wp-block-heading">$page_title</h2><!-- /wp:heading -->
-				</div>
-				<!-- /wp:group -->
-
+				$page_title_block
 				<!-- wp:group {"layout":{"type":"inherit","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 				<div class="wp-block-group">$rendered_template</div>
 				<!-- /wp:group -->

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -221,7 +221,9 @@ div.details-edit-event {
 	grid-template-columns: 85% 15%;
 	align-items: center;
 }
-
+.details-page-title h2.wp-block-heading {
+	margin-bottom: 10px;
+}
 @media (min-width: 960px) {
 
 .wporg-marker-list__container .wporg-marker-list-item {

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -207,7 +207,21 @@ span.user-remote-icon.dashicons-video-alt2 {
 .event-nav-link:hover {
 	text-decoration: underline;
 }
- @media (min-width: 960px) {
+
+.event-details-join {
+	display: inline-block;
+}
+
+a.details-edit-event span.dashicons-edit {
+	vertical-align: text-bottom;
+}
+
+a.details-edit-event {
+	float: right;
+	text-decoration: none;
+}
+
+@media (min-width: 960px) {
 
 .wporg-marker-list__container .wporg-marker-list-item {
 	display: grid;

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -212,11 +212,7 @@ span.user-remote-icon.dashicons-video-alt2 {
 	display: inline-block;
 }
 
-a.details-edit-event span.dashicons-edit {
-	vertical-align: text-bottom;
-}
-
-a.details-edit-event {
+div.details-edit-event {
 	float: right;
 	text-decoration: none;
 }

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -217,6 +217,11 @@ div.details-edit-event {
 	text-decoration: none;
 }
 
+.details-page-title {
+	grid-template-columns: 85% 15%;
+	align-items: center;
+}
+
 @media (min-width: 960px) {
 
 .wporg-marker-list__container .wporg-marker-list-item {

--- a/themes/wporg-translate-events-2024/style.css
+++ b/themes/wporg-translate-events-2024/style.css
@@ -212,14 +212,16 @@ span.user-remote-icon.dashicons-video-alt2 {
 	display: inline-block;
 }
 
-div.details-edit-event {
+div.details-edit-event-btn {
 	float: right;
 	text-decoration: none;
 }
 
 .details-page-title {
 	grid-template-columns: 85% 15%;
-	align-items: center;
+	gap: 0;
+	align-items: baseline;
+
 }
 .details-page-title h2.wp-block-heading {
 	margin-bottom: 10px;


### PR DESCRIPTION
Fixes #365 and also displayed the notices on event details page using the wporg-notice block.

**Before adding edit link**

![Screenshot 2024-10-09 at 09 59 45](https://github.com/user-attachments/assets/859ed1e3-6832-4398-9781-4f1eabe34500)

**After adding edit link**
![Screenshot 2024-10-09 at 09 59 28](https://github.com/user-attachments/assets/aff36e3c-3d46-42c0-ad15-562cbea59616)



**Before using the notice block**
![Screenshot 2024-10-08 at 16 15 35](https://github.com/user-attachments/assets/4b523f6f-9b7e-4916-b19c-f5fc1e2d970a)

![Screenshot 2024-10-08 at 16 02 21](https://github.com/user-attachments/assets/36d67595-6fd7-413f-864d-3a284fd10b8e)


**After (using the notice block)**
![Screenshot 2024-10-08 at 16 21 48](https://github.com/user-attachments/assets/b50a3115-02be-41d9-a3e3-f1f4552b37d2)



![Screenshot 2024-10-08 at 16 14 32](https://github.com/user-attachments/assets/57d59e4c-548c-41f5-87f6-a49619fc305c)


