### PR TITLE
Define $editor_options which is used but not set.

### DIFF
--- a/includes/routes/event/translations.php
+++ b/includes/routes/event/translations.php
@@ -61,6 +61,8 @@ class Translations_Route extends Route {
 		}
 		Templates::render( 'translations/header', get_defined_vars() );
 
+		$editor_options = array();
+
 		foreach ( $translation_sets as $ts ) {
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(


### PR DESCRIPTION
Fixes a PHP warning when an event doesn't have any translation sets.

```
E_WARNING: Invalid argument supplied for foreach() in wporg-gp-translation-events/templates/translations/footer.php:14
```