### PR TITLE
Fix PHP 8.4 deprecations and attend-event fatal error

### DIFF
--- a/includes/event/event-date.php
+++ b/includes/event/event-date.php
@@ -17,7 +17,7 @@ use Wporg\TranslationEvents\Translation_Events;
  */
 abstract class Event_Date extends DateTimeImmutable {
 	protected $event_timezone;
-	public function __construct( string $date, DateTimeZone $timezone = null ) {
+	public function __construct( string $date, ?DateTimeZone $timezone = null ) {
 		if ( ! $timezone ) {
 			$timezone = new DateTimeZone( 'UTC' );
 		}

--- a/includes/event/event.php
+++ b/includes/event/event.php
@@ -9,25 +9,25 @@ use Throwable;
 use Wporg\TranslationEvents\Translation_Events;
 
 class InvalidTimeZone extends Exception {
-	public function __construct( Throwable $previous = null ) {
+	public function __construct( ?Throwable $previous = null ) {
 		parent::__construct( 'Event time zone is invalid', 0, $previous );
 	}
 }
 
 class InvalidStart extends Exception {
-	public function __construct( Throwable $previous = null ) {
+	public function __construct( ?Throwable $previous = null ) {
 		parent::__construct( 'Event start is invalid', 0, $previous );
 	}
 }
 
 class InvalidEnd extends Exception {
-	public function __construct( Throwable $previous = null ) {
+	public function __construct( ?Throwable $previous = null ) {
 		parent::__construct( 'Event end is invalid', 0, $previous );
 	}
 }
 
 class InvalidStatus extends Exception {
-	public function __construct( Throwable $previous = null ) {
+	public function __construct( ?Throwable $previous = null ) {
 		parent::__construct( 'Event status is invalid', 0, $previous );
 	}
 }
@@ -58,7 +58,7 @@ class Event {
 		string $status,
 		string $title,
 		string $description,
-		DateTimeImmutable $updated_at = null,
+		?DateTimeImmutable $updated_at = null,
 		string $attendance_mode = 'onsite'
 	) {
 		$this->author_id = $author_id;
@@ -184,7 +184,7 @@ class Event {
 		$this->description = $description;
 	}
 
-	public function set_updated_at( DateTimeImmutable $updated_at = null ): void {
+	public function set_updated_at( ?DateTimeImmutable $updated_at = null ): void {
 		$this->updated_at = $updated_at ?? Translation_Events::now();
 	}
 

--- a/includes/routes/user/attend-event.php
+++ b/includes/routes/user/attend-event.php
@@ -38,11 +38,10 @@ class Attend_Event_Route extends Route {
 				$this->die_with_error( esc_html__( 'You are not authorized to change the attendance mode of this attendee', 'gp-translation-events' ), 403 );
 			}
 		}
-		$user = wp_get_current_user();
-		if ( ! $user ) {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
 			$this->die_with_error( esc_html__( 'Only logged-in users can attend events', 'gp-translation-events' ), 403 );
 		}
-		$user_id = $user->ID;
 
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {


### PR DESCRIPTION
## Summary

- **Fix fatal error when non-logged-in users attend an event**: `wp_get_current_user()` always returns a `WP_User` object (with `ID=0` for guests), so the `! $user` guard never triggered. This allowed `user_id=0` to reach the `Attendee` constructor, throwing "invalid user id". Replaced with `get_current_user_id()` which properly returns `0` for guests and can be checked as falsy.

- **Fix PHP 8.4 implicit nullable type deprecations**: Updated 7 instances of `Type $param = null` to `?Type $param = null` across `event.php` and `event-date.php` to silence PHP 8.4 deprecation warnings.

## Test plan

- [ ] Verify that non-logged-in users attempting to attend an event get a 403 error instead of a fatal exception
- [ ] Verify that logged-in users can still attend/un-attend events normally
- [ ] Confirm no PHP 8.4 deprecation warnings for implicit nullable types

🤖 Generated with [Claude Code](https://claude.com/claude-code)