### PR TITLE
Update to PHP 8.4 and use wp-env for CI tests

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: 'none'
           tools: composer, cs2pr
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,28 +9,19 @@ jobs:
     name: PHPUnit ${{ matrix.php }}
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:5.7
-        ports:
-          - 3306/tcp
-        env:
-          MYSQL_ROOT_PASSWORD: password
-        # Set health checks to wait until mysql has started
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
-
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.3' ]
+        php: [ '8.4', '8.5' ]
 
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,18 +30,19 @@ jobs:
           coverage: 'none'
           tools: composer
 
-      - name: Install dependencies
+      - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 
-      - name: Install WordPress test setup
-        run: bash bin/install-wp-tests.sh wordpress_test root password 127.0.0.1:${{ job.services.mysql.ports[3306] }} latest
+      - name: Install wp-env
+        run: npm -g install @wordpress/env
 
-      - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Override PHP version
+        run: echo '{ "phpVersion":"${{ matrix.php }}" }' > .wp-env.override.json
+
+      - name: Start wp-env
+        run: wp-env start
 
       - name: Run tests
-        env:
-          WP_TESTS_DIR: /tmp/wordpress-tests-lib/
-        run: vendor/bin/phpunit
+        run: wp-env run tests-cli --env-cwd=wp-content/plugins/wporg-gp-translation-events ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction"
 
       - name: Install wp-env
-        run: npm -g install @wordpress/env
+        run: npm -g install @wordpress/env --force
 
       - name: Override PHP version
         run: echo '{ "phpVersion":"${{ matrix.php }}" }' > .wp-env.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "core": null,
-  "phpVersion": "8.3",
+  "phpVersion": "8.4",
   "plugins": [
     "GlotPress/GlotPress",
     "https://downloads.wordpress.org/plugin/sqlite-object-cache.1.3.7.zip",

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "",
     "license": "GPL-2.0-only",
     "require-dev": {
-        "phpunit/phpunit": "^9.6.16",
-        "yoast/phpunit-polyfills": "^2.0.0",
+        "phpunit/phpunit": "^9.6.16 || ^10.0 || ^11.0",
+        "yoast/phpunit-polyfills": "^2.0.0 || ^3.0",
         "wp-coding-standards/wpcs": "^3.0"
     },
     "scripts":{

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,6 @@
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="tests">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,12 +8,17 @@ if ( ! $_tests_dir ) {
 }
 
 function _glotpress_path( string $path ): string {
-	$glotpress_path = dirname( __DIR__, 2 ) . '/glotpress/';
-	if ( getenv( 'GITHUB_ACTIONS' ) ) {
-		$glotpress_path = '/tmp/wordpress/wp-content/plugins/glotpress/';
+	$plugins_dir = dirname( __DIR__, 2 );
+
+	// GlotPress may be installed as 'glotpress' or 'GlotPress' depending on the environment.
+	foreach ( array( 'glotpress', 'GlotPress' ) as $dir_name ) {
+		if ( is_dir( $plugins_dir . '/' . $dir_name ) ) {
+			return $plugins_dir . '/' . $dir_name . '/' . $path;
+		}
 	}
 
-	return $glotpress_path . $path;
+	// Fallback to lowercase.
+	return $plugins_dir . '/glotpress/' . $path;
 }
 
 // Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.


### PR DESCRIPTION
## Summary

- Fix PHP 8.4 implicit nullable type deprecations across `event.php` and `event-date.php`
- Replace custom `install-wp-tests.sh` CI setup with wp-env (resolves `svn: command not found` failures)
- Test matrix updated from PHP 7.4/8.3 to PHP 8.4/8.5
- Update wp-env default PHP version to 8.4
- Widen PHPUnit constraint to `^9.6 || ^10.0 || ^11.0` and polyfills to `^2.0 || ^3.0`
- Remove PHPUnit 10-incompatible XML attributes (`convertErrorsToExceptions`, etc.)
- Update coding standards workflow to PHP 8.4

## Test plan

- [ ] PHPUnit passes on PHP 8.4
- [ ] PHPUnit passes on PHP 8.5
- [ ] PHPCS passes on PHP 8.4
- [ ] Local development with `composer dev:test` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)