### PR TITLE
Fix missing nonce verification on state-changing GET routes

### DIFF
--- a/includes/routes/attendee/remove.php
+++ b/includes/routes/attendee/remove.php
@@ -39,6 +39,11 @@ class Remove_Attendee_Route extends Route {
 			exit;
 		}
 
+		$nonce_action = "remove_translation_event_attendee_{$event_id}_{$user_id}";
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), $nonce_action ) ) {
+			$this->die_with_error( esc_html__( 'Your link has expired or is invalid. Please go back and try again.', 'gp-translation-events' ), 403 );
+		}
+
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();

--- a/includes/routes/event/delete.php
+++ b/includes/routes/event/delete.php
@@ -25,6 +25,11 @@ class Delete_Route extends Route {
 			exit;
 		}
 
+		$nonce_action = 'delete_translation_event_' . $event_id;
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), $nonce_action ) ) {
+			$this->die_with_error( esc_html__( 'Your link has expired or is invalid. Please go back and try again.', 'gp-translation-events' ), 403 );
+		}
+
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();

--- a/includes/routes/event/trash.php
+++ b/includes/routes/event/trash.php
@@ -27,6 +27,11 @@ class Trash_Route extends Route {
 			exit;
 		}
 
+		$nonce_action = 'trash_translation_event_' . $event_id;
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), $nonce_action ) ) {
+			$this->die_with_error( esc_html__( 'Your link has expired or is invalid. Please go back and try again.', 'gp-translation-events' ), 403 );
+		}
+
 		$event = $this->event_repository->get_event( $event_id );
 		if ( ! $event ) {
 			$this->die_with_404();

--- a/includes/routes/user/attendance-mode.php
+++ b/includes/routes/user/attendance-mode.php
@@ -41,6 +41,11 @@ class Attendance_Mode_Route extends Route {
 			$this->die_with_error( esc_html__( 'Only logged-in users can manage the attendance mode of an attendee', 'gp-translation-events' ), 403 );
 		}
 
+		$nonce_action = "toggle_translation_event_attendance_mode_{$event_id}_{$user_id}";
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), $nonce_action ) ) {
+			$this->die_with_error( esc_html__( 'Your link has expired or is invalid. Please go back and try again.', 'gp-translation-events' ), 403 );
+		}
+
 		if ( ! current_user_can( 'edit_translation_event', $event_id ) ) {
 			$this->die_with_error( esc_html__( 'You do not have permissions to manage the attendance mode of an attendee', 'gp-translation-events' ), 403 );
 		}

--- a/includes/urls.php
+++ b/includes/urls.php
@@ -38,11 +38,11 @@ class Urls {
 	}
 
 	public static function event_trash( int $event_id ): string {
-		return gp_url( '/events/trash/' . $event_id );
+		return wp_nonce_url( gp_url( '/events/trash/' . $event_id ), 'trash_translation_event_' . $event_id );
 	}
 
 	public static function event_delete( int $event_id ): string {
-		return gp_url( '/events/delete/' . $event_id );
+		return wp_nonce_url( gp_url( '/events/delete/' . $event_id ), 'delete_translation_event_' . $event_id );
 	}
 
 	public static function event_create(): string {
@@ -86,10 +86,10 @@ class Urls {
 	}
 
 	public static function event_remove_attendee( int $event_id, int $user_id ): string {
-		return gp_url( "/events/$event_id/attendees/remove/$user_id" );
+		return wp_nonce_url( gp_url( "/events/$event_id/attendees/remove/$user_id" ), "remove_translation_event_attendee_{$event_id}_{$user_id}" );
 	}
 
 	public static function event_toggle_attendance_mode( int $event_id, int $user_id ): string {
-		return gp_url( "/events/attendance-mode/$event_id/$user_id" );
+		return wp_nonce_url( gp_url( "/events/attendance-mode/$event_id/$user_id" ), "toggle_translation_event_attendance_mode_{$event_id}_{$user_id}" );
 	}
 }

--- a/tests/urls.php
+++ b/tests/urls.php
@@ -71,14 +71,20 @@ class Urls_Test extends Base_Test {
 
 	public function test_event_trash() {
 		$event_id = 42;
-		$expected = "/glotpress/events/trash/$event_id";
-		$this->assertEquals( $expected, Urls::event_trash( $event_id ) );
+		$url      = Urls::event_trash( $event_id );
+		$this->assertStringStartsWith( "/glotpress/events/trash/$event_id?_wpnonce=", $url );
+		$nonce = wp_parse_url( $url, PHP_URL_QUERY );
+		parse_str( $nonce, $query );
+		$this->assertNotFalse( wp_verify_nonce( $query['_wpnonce'], 'trash_translation_event_' . $event_id ) );
 	}
 
 	public function test_event_delete() {
 		$event_id = 42;
-		$expected = "/glotpress/events/delete/$event_id";
-		$this->assertEquals( $expected, Urls::event_delete( $event_id ) );
+		$url      = Urls::event_delete( $event_id );
+		$this->assertStringStartsWith( "/glotpress/events/delete/$event_id?_wpnonce=", $url );
+		$nonce = wp_parse_url( $url, PHP_URL_QUERY );
+		parse_str( $nonce, $query );
+		$this->assertNotFalse( wp_verify_nonce( $query['_wpnonce'], 'delete_translation_event_' . $event_id ) );
 	}
 
 	public function test_event_toggle_attendee() {


### PR DESCRIPTION
## Summary

- Four state-changing GET routes performed their action with only `is_user_logged_in()` and capability checks, so a logged-in event host/author could be tricked into running them by a top-level cross-origin navigation (SameSite=Lax sends the auth cookie on top-level GETs):
  - `/events/trash/{id}` → `Trash_Route::handle`
  - `/events/delete/{id}` → `Delete_Route::handle`
  - `/events/{id}/attendees/remove/{user}` → `Remove_Attendee_Route::handle`
  - `/events/attendance-mode/{id}/{user}` → `Attendance_Mode_Route::handle`
- Wrapped the corresponding URL helpers (`Urls::event_trash`, `event_delete`, `event_remove_attendee`, `event_toggle_attendance_mode`) with `wp_nonce_url()` using per-action, per-id nonces. Every existing caller (legacy templates + 2024 theme blocks) is auto-protected — no template changes needed.
- Each handler now verifies `_wpnonce` against its action key immediately after the login check, before any DB lookup or state change.
- Updated `tests/urls.php` so `test_event_trash` / `test_event_delete` assert the URL prefix and a valid nonce on the returned link.

## Test plan

- [ ] As a logged-in user with `trash_translation_event`, clicking the trash button on the event list still trashes the event and redirects to the events home.
- [ ] As a logged-in user with `manage_translation_events` + `delete_translation_event`, clicking the delete button still permanently deletes the event.
- [ ] As a logged-in user with `edit_translation_event_attendees`, clicking "Remove" on an attendee still removes them.
- [ ] As a logged-in user with `edit_translation_event`, clicking "Set as remote" / "Set as on-site" on the attendees table still toggles the attendance mode.
- [ ] Manually requesting any of those URLs without `?_wpnonce=...` returns a 403 with "Your link has expired or is invalid".
- [ ] Manually requesting any of those URLs with a forged/stale `_wpnonce` returns the same 403.
- [ ] `composer test` passes (incl. updated `tests/urls.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)